### PR TITLE
Redis appender

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
@@ -114,7 +114,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
   
   protected void secondarySubAppend(ILoggingEvent event, Connection connection,
       long eventId) throws Throwable {
-    Map<String, String> mergedMap = mergePropertyMaps(event);
+    Map<String, String> mergedMap = DBHelper.mergePropertyMaps(event);
     insertProperties(mergedMap, connection, eventId);
 
     if (event.getThrowableProxy() != null) {
@@ -138,7 +138,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     int arrayLen = argArray != null ? argArray.length : 0;
     
     for(int i = 0; i < arrayLen && i < 4; i++) {
-      stmt.setString(ARG0_INDEX+i, truncateTo254(argArray[i].toString()));
+      stmt.setString(ARG0_INDEX+i, DBHelper.truncateTo254(argArray[i].toString()));
     }
     if(arrayLen < 4) {
       for(int i = arrayLen; i < 4; i++) {
@@ -147,17 +147,6 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     }
   }
 
-  String truncateTo254(String s) {
-    if(s == null) {
-      return null;
-    }
-    if(s.length() <= 254) {
-      return s;
-    } else {
-      return s.substring(0, 254);
-    }
-  }
-  
   void bindCallerDataWithPreparedStatement(PreparedStatement stmt,
       StackTraceElement[] callerDataArray) throws SQLException {
     StackTraceElement callerData = callerDataArray[0];
@@ -167,25 +156,6 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
       stmt.setString(CALLER_METHOD_INDEX, callerData.getMethodName());
       stmt.setString(CALLER_LINE_INDEX, Integer.toString(callerData.getLineNumber()));
     }
-  }
-
-  Map<String, String> mergePropertyMaps(ILoggingEvent event) {
-    Map<String, String> mergedMap = new HashMap<String, String>();
-    // we add the context properties first, then the event properties, since
-    // we consider that event-specific properties should have priority over
-    // context-wide
-    // properties.
-    Map<String, String> loggerContextMap = event.getLoggerContextVO()
-        .getPropertyMap();
-    Map<String, String> mdcMap = event.getMDCPropertyMap();
-    if (loggerContextMap != null) {
-      mergedMap.putAll(loggerContextMap);
-    }
-    if (mdcMap != null) {
-      mergedMap.putAll(mdcMap);
-    }
-
-    return mergedMap;
   }
 
   @Override

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBHelper.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBHelper.java
@@ -15,6 +15,9 @@ package ch.qos.logback.classic.db;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author Ceki G&uuml;lc&uuml;
  * 
@@ -43,5 +46,35 @@ public class DBHelper {
       mask |= EXCEPTION_EXISTS;
     }
     return mask;
+  }
+
+  public static String truncateTo254(final String s) {
+    if(s == null) {
+      return null;
+    }
+    if(s.length() <= 254) {
+      return s;
+    } else {
+      return s.substring(0, 254);
+    }
+  }
+
+  public static Map<String, String> mergePropertyMaps(ILoggingEvent event) {
+    Map<String, String> mergedMap = new HashMap<String, String>();
+    // we add the context properties first, then the event properties, since
+    // we consider that event-specific properties should have priority over
+    // context-wide
+    // properties.
+    Map<String, String> loggerContextMap = event.getLoggerContextVO()
+        .getPropertyMap();
+    Map<String, String> mdcMap = event.getMDCPropertyMap();
+    if (loggerContextMap != null) {
+      mergedMap.putAll(loggerContextMap);
+    }
+    if (mdcMap != null) {
+      mergedMap.putAll(mdcMap);
+    }
+
+    return mergedMap;
   }
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/nosql/RedisAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/nosql/RedisAppender.java
@@ -1,0 +1,96 @@
+package ch.qos.logback.classic.db.nosql;
+
+import ch.qos.logback.classic.db.DBHelper;
+import ch.qos.logback.classic.db.names.ColumnName;
+import ch.qos.logback.classic.spi.*;
+import ch.qos.logback.core.CoreConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implementation for {@link ch.qos.logback.classic.spi.LoggingEvent} event type.
+ *
+ * @author Juan Uys
+ */
+public class RedisAppender extends RedisAppenderBase<LoggingEvent> {
+
+  /**
+   * Saves each constituent of {@link ch.qos.logback.classic.spi.LoggingEvent} as a
+   * Redis key/value entry.
+   *
+   * @param event
+   * @param eventId
+   */
+  @Override
+  public void subAppend(final LoggingEvent event, final Integer eventId) {
+
+    final String eventIdStr = eventId + ":";
+
+    // for "logging_event" equivalent
+    set(eventIdStr + ColumnName.TIMESTMP.toString().toLowerCase(), event.getTimeStamp());
+    set(eventIdStr + ColumnName.FORMATTED_MESSAGE.toString().toLowerCase(), event.getFormattedMessage());
+    set(eventIdStr + ColumnName.LOGGER_NAME.toString().toLowerCase(), event.getLoggerName());
+    set(eventIdStr + ColumnName.LEVEL_STRING.toString().toLowerCase(), event.getLevel().toString());
+    set(eventIdStr + ColumnName.THREAD_NAME.toString().toLowerCase(), event.getThreadName());
+    set(eventIdStr + ColumnName.REFERENCE_FLAG.toString().toLowerCase(), DBHelper.computeReferenceMask(event));
+
+    event_arguments: {
+      int arrayLen = event.getArgumentArray() != null ? event.getArgumentArray().length : 0;
+
+      for(int i = 0; i < arrayLen; i++) {
+        set(eventIdStr + "arg" + i, DBHelper.truncateTo254(event.getArgumentArray()[i].toString()));
+      }
+    }
+
+    caller_data: {
+      StackTraceElement callerData = event.getCallerData()[0];
+      if (callerData != null) {
+        set(eventIdStr + ColumnName.CALLER_FILENAME.toString().toLowerCase(), callerData.getFileName());
+        set(eventIdStr + ColumnName.CALLER_CLASS.toString().toLowerCase(), callerData.getClassName());
+        set(eventIdStr + ColumnName.CALLER_METHOD.toString().toLowerCase(), callerData.getMethodName());
+        set(eventIdStr + ColumnName.CALLER_LINE.toString().toLowerCase(), Integer.toString(callerData.getLineNumber()));
+      }
+    }
+
+    // for "logging_event_property" equivalent
+    final Map<String, String> merged =  DBHelper.mergePropertyMaps(event);
+    for (Map.Entry<String, String> entry : merged.entrySet()) {
+      set(eventIdStr + "mdc:" + entry.getKey(), entry.getValue());
+    }
+
+    // for "logging_event_exception" equivalent
+    if (event.getThrowableProxy() != null) {
+      short baseIndex = 0;
+      IThrowableProxy tp = event.getThrowableProxy();
+      while (tp != null) {
+
+        exception_firstline: {
+          StringBuilder buf = new StringBuilder();
+          ThrowableProxyUtil.printFirstLine(buf, tp);
+          set(eventIdStr + "exception:" + baseIndex++, buf.toString());
+        }
+
+        // exception common frames
+        int commonFrames = tp.getCommonFrames();
+        StackTraceElementProxy[] stepArray = tp.getStackTraceElementProxyArray();
+        for (int i = 0; i < stepArray.length - commonFrames; i++) {
+          StringBuilder sb = new StringBuilder();
+          sb.append(CoreConstants.TAB);
+          ThrowableProxyUtil.printSTEP(sb, stepArray[i]);
+          set(eventIdStr + "exception:" + baseIndex++, sb.toString());
+        }
+
+        // exception ommitted frames
+        if (commonFrames > 0) {
+          StringBuilder sb = new StringBuilder();
+          sb.append(CoreConstants.TAB).append("... ").append(commonFrames).append(
+          " common frames omitted");
+          set(eventIdStr + "exception:" + baseIndex++, sb.toString());
+        }
+
+        tp = tp.getCause();
+      }
+    }
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderH2Test.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderH2Test.java
@@ -147,7 +147,7 @@ public class DBAppenderH2Test  {
     Statement stmt = connectionSource.getConnection().createStatement();
     ResultSet rs = null;
     rs = stmt.executeQuery("SELECT * FROM LOGGING_EVENT_PROPERTY WHERE EVENT_ID=1");
-    Map<String, String> map = appender.mergePropertyMaps(event);
+    Map<String, String> map = DBHelper.mergePropertyMaps(event);
     int i = 0;
     while (rs.next()) {
       String key = rs.getString(2);

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderHSQLTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderHSQLTest.java
@@ -145,7 +145,7 @@ public class DBAppenderHSQLTest  {
     Statement stmt = connectionSource.getConnection().createStatement();
     ResultSet rs = null;
     rs = stmt.executeQuery("SELECT * FROM LOGGING_EVENT_PROPERTY  WHERE EVENT_ID = 0");
-    Map<String, String> map = appender.mergePropertyMaps(event);
+    Map<String, String> map = DBHelper.mergePropertyMaps(event);
     System.out.println("ma.size="+map.size());
     int i = 0;
     while (rs.next()) {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/nosql/RedisAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/nosql/RedisAppenderTest.java
@@ -1,0 +1,64 @@
+package ch.qos.logback.classic.db.nosql;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.pattern.util.IEscapeUtil;
+import ch.qos.logback.core.testUtil.RandomUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+/**
+ * Tests for {@link RedisAppenderBase}
+ *
+ * TODO better tests pending Jedis interface for stubbing, and/or in-memory Redis server.
+ *
+ * @author Juan Uys
+ */
+public class RedisAppenderTest {
+
+  LoggerContext lc;
+  Logger logger;
+  RedisAppenderBase appender;
+
+  int diff = RandomUtil.getPositiveInt();
+
+  @Before
+  public void setUp() {
+    lc = new LoggerContext();
+    lc.setName("default");
+    logger = lc.getLogger("root");
+    appender = new RedisAppender();
+    appender.setName("Redis");
+    appender.setContext(lc);
+
+    appender.setHostName("localhost");
+    //appender.start();
+  }
+
+  @After
+  public void tearDown() {
+    //appender.stop();
+    logger = null;
+    lc = null;
+    appender = null;
+  }
+
+  @Test
+  public void testSave() {
+    ILoggingEvent event = createLoggingEvent();
+
+    //appender.append(event);
+    // TODO etc
+  }
+
+  private ILoggingEvent createLoggingEvent() {
+    ILoggingEvent le = new LoggingEvent(this.getClass().getName(), logger,
+        Level.DEBUG, "test message", new Exception("test Ex"), new Integer[]{diff});
+    return le;
+  }
+}

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -80,6 +80,11 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>com.googlecode.jedis</groupId>
+      <artifactId>jedis</artifactId>
+    </dependency>
   </dependencies>
 
 

--- a/logback-core/src/main/java/ch/qos/logback/classic/db/nosql/RedisAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/classic/db/nosql/RedisAppenderBase.java
@@ -1,0 +1,144 @@
+package ch.qos.logback.classic.db.nosql;
+
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import redis.clients.jedis.Jedis;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * <p>Redis appender common functionality.</p>
+ *
+ *
+ * @author Juan Uys
+ */
+public abstract class RedisAppenderBase<E> extends UnsynchronizedAppenderBase<E> {
+
+  // user-specified
+  private int port;
+  private String password;
+  private String hostName;
+  private int timeout;
+  private String uniqueKeyPrefix;
+
+  private Jedis client;
+
+  // forms the common part of all keys
+  private String keyBase;
+
+  protected void init() {
+    // initialise the Redis client
+    if (getPort() != 0 && getTimeout() != 0) {
+      client = new Jedis(getHostName(), getPort(), getTimeout());
+    } else if (getPort() != 0) {
+      client = new Jedis(getHostName(), getPort());
+    } else {
+      client = new Jedis(getHostName());
+    }
+    try {
+      client.connect();
+      if (getPassword() != null) {
+        client.auth(getPassword());
+      }
+    } catch (UnknownHostException e) {
+      addError("Could not get Redis Connection", e);
+    } catch (IOException e) {
+      addError("Could not get Redis Connection", e);
+    } catch (Throwable e) {
+      addError("Unexpected exception on creating Redis Client", e);
+    }
+
+    // set up the common key base
+    StringBuffer keyB = new StringBuffer();
+    if (uniqueKeyPrefix != null && !uniqueKeyPrefix.trim().equals("")) {
+        keyB = keyB.append(uniqueKeyPrefix).append(':');
+      } else {
+        keyB = keyB.append("logback:");
+      }
+
+    try {
+      keyB = keyB.append(InetAddress.getLocalHost().getHostName()).append(':');
+    } catch (UnknownHostException e) {
+      addError("Failed to get local hostname", e);
+    }
+    keyBase = keyB.toString();
+  }
+
+  @Override
+  public void start() {
+    init();
+    super.start();    //To change body of overridden methods use File | Settings | File Templates.
+  }
+
+  @Override
+  public void stop() {
+    try {
+      client.disconnect();
+    } catch (IOException e) {
+      addError("Could not close Redis Channel", e);
+    } catch (Throwable e) {
+      addError("Unexpected exception on closing Redis Client", e);
+    }
+    super.stop();
+  }
+
+  @Override
+  protected void append(E eventObject) {
+    subAppend(eventObject, getEventId());
+  }
+
+  abstract public void subAppend(E event, Integer eventId);
+
+  private int getPort() {
+    return port;
+  }
+
+  private String getPassword() {
+    return password;
+  }
+
+  private String getHostName() {
+    return hostName;
+  }
+
+  public String getKeyBase() {
+    return keyBase;
+  }
+
+  private int getTimeout() {
+    return timeout;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public void setHostName(String hostName) {
+    this.hostName = hostName;
+  }
+
+  public void setTimeout(int timeout) {
+    this.timeout = timeout;
+  }
+
+  public void setUniqueKeyPrefix(String uniqueKeyPrefix) {
+    this.uniqueKeyPrefix = uniqueKeyPrefix;
+  }
+
+  protected void setClient(Jedis client) {
+    this.client = client;
+  }
+
+  public void set(String key, Object value) {
+    client.set(getKeyBase() + key, String.valueOf(value));
+  }
+
+  public Integer getEventId() {
+    return client.incr(keyBase+"id");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
         <artifactId>mysql-connector-java</artifactId>
         <version>5.1.9</version>
       </dependency>
+      <dependency>
+        <groupId>com.googlecode.jedis</groupId>
+        <artifactId>jedis</artifactId>
+        <version>1.3.0</version>
+      </dependency>
 
 
       <dependency>


### PR DESCRIPTION
Hi Ceki,

I wrote an initial draft of the Redis Appender. Please have a look at the diff and please send me comments.
## Tests

Please note that there are no tests because: 
- the client (Jedis) does not have a stub-able interface
- the client does not have a mock implementation (due to lack of interface)
- there are no in-memory Redis servers currently available

...but I do have a simple client and example output here: http://gist.github.com/630471
## Configuration

Configuration is simple and uses sensible defaults:
    <appender name="REDIS" class="ch.qos.logback.classic.db.nosql.RedisAppender"/>

All configuration options include:

<table>
<thead>
<tr><td>Option</td><td>Default</td></tr>
</thead>
<tbody>
<tr><td>port</td><td>6379</td></tr>
<tr><td>password</td><td> </td></tr>
<tr><td>hostName</td><td>localhost</td></tr>
<tr><td>timeout</td><td>Jedis client default</td></tr>
<tr><td>uniqueKeyPrefix</td><td>logback</td></tr>
</tbody>
</table>

## TODO
- benchmarks (compare with MySQL?)
- stress/load testing (please advise)
- a separate client to ease tapping into Redis (runnable WAR file with Jetty)

Please let me know if there's anything else, and I will appreciate any input and comments on this commit.

Thanks,
Juan
