### PR TITLE
small fix to ensure compressed file path parents are created before compressing

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
@@ -50,6 +50,13 @@ public class Compressor extends ContextAwareBase {
   // }
 
   public void compress(String nameOfFile2Compress, String nameOfCompressedFile) {
+      
+    // ensure path structure exists for destination file
+    File compressedFile = new File(nameOfCompressedFile);
+    if (compressedFile.getParentFile() != null) {
+      compressedFile.getParentFile().getAbsoluteFile().mkdirs();
+    }
+
     switch (compressionMode) {
     case GZ:
       addInfo("GZ compressing [" + nameOfFile2Compress + "].");


### PR DESCRIPTION
I imagine you'll want this coded slightly differently, but this illustrates the problem.
