### PR TITLE
Fixes LBCLASSIC-156.

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SocketAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SocketAppenderBase.java
@@ -135,8 +135,10 @@ public abstract class SocketAppenderBase<E> extends AppenderBase<E> {
       if (reconnectionDelay > 0) {
         msg += " We will try again later.";
         fireConnector(); // fire the connector thread
+        addInfo(msg, e);
+      } else {
+        addWarn(msg, e);
       }
-      addWarn(msg, e);
     }
   }
 


### PR DESCRIPTION
SocketAppender is only emitting a warning if reconnectionDelay<=0.
Otherwise an info message is added similarly to the behavior of Connector.
This seems to be a reasonable way of handling the situation where the server is started while the application is already running.
