### PR TITLE
Typo in documentation: changed .? to ?. in text.

### DIFF
--- a/logback-site/src/site/pages/manual/filters.html
+++ b/logback-site/src/site/pages/manual/filters.html
@@ -345,7 +345,7 @@ public class SampleFilter extends Filter&gt;ILoggingEvent> {
     <code>/Googlebot|msnbot|Yahoo/</code> regular expression. Note
     that since the MDC map can be null, we are also using Groovy's <a
     href="http://groovy.codehaus.org/Null+Object+Pattern">safe
-    dereferencing operator</a>, that is the .? operator. The equivalent
+    dereferencing operator</a>, that is the ?. operator. The equivalent
     logic would have been much longer if expressed in Java.
     </p>
     


### PR DESCRIPTION
The example was already correct.

Cheers,
Joern.
