### PR TITLE
LBACCESS-25 Remove two infinite loops in AccessConverter#addError methods.

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/AccessConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/AccessConverter.java
@@ -57,11 +57,11 @@ abstract public class AccessConverter extends DynamicConverter<IAccessEvent> imp
   }
 
   public void addError(String msg) {
-    addError(msg);
+    cab.addError(msg);
   }
 
   public void addError(String msg, Throwable ex) {
-    addError(msg, ex);
+    cab.addError(msg, ex);
   }
   
 }


### PR DESCRIPTION
See http://jira.qos.ch/browse/LBACCESS-25
