### PR TITLE
Fix for LBCORE-220

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/db/DBAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/db/DBAppenderBase.java
@@ -102,12 +102,8 @@ public abstract class DBAppenderBase<E> extends UnsynchronizedAppenderBase<E> {
         insertStatement = connection.prepareStatement(getInsertSQL());
       }
 
-      long eventId;
-      // inserting an event and getting the result must be exclusive
-      synchronized (this) {
-        subAppend(eventObject, connection, insertStatement);
-        eventId = selectEventId(insertStatement, connection);
-      }
+      subAppend(eventObject, connection, insertStatement);
+      long eventId = selectEventId(insertStatement, connection);
       secondarySubAppend(eventObject, connection, eventId);
 
       // we no longer need the insertStatement


### PR DESCRIPTION
Remove the unnecessary synchronisation as detailed in http://jira.qos.ch/browse/LBCORE-220 from the DBAppenderBase; all methods for retrieving the eventId are suitable for use in a multithreaded environment.
