### PR TITLE
changed transform access pro package protected to protected LBCORE-237

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/CompositeConverter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/CompositeConverter.java
@@ -27,7 +27,7 @@ abstract public class CompositeConverter<E> extends DynamicConverter<E> {
     return transform(intermediary);
   }
 
-  abstract String transform(String in);
+  protected abstract String transform(String in);
 
   public void setChildConverter(Converter<E> child) {
     childConverter = child;

--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/IdentityCompositeConverter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/IdentityCompositeConverter.java
@@ -16,7 +16,7 @@ package ch.qos.logback.core.pattern;
 public class IdentityCompositeConverter<E> extends CompositeConverter<E> {
 
   @Override
-  String transform(String in) {
+  protected String transform(String in) {
     return in;
   }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/ReplacingCompositeConverter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/ReplacingCompositeConverter.java
@@ -42,7 +42,7 @@ public class ReplacingCompositeConverter<E> extends CompositeConverter<E> {
   }
 
   @Override
-  String transform(String in) {
+  protected String transform(String in) {
     if (!started)
       return in;
     return pattern.matcher(in).replaceAll(replacement);


### PR DESCRIPTION
I would like to suugest to change ch.qos.logback.core.pattern.CompositeConverter#transform access from package protected to protected, which allow successor classes to be placed in package different from ch.qos.logback.core.pattern

http://jira.qos.ch/browse/LBCORE-237
