### PR TITLE
Fix for LBCORE-235 - restore RenameUtil.renameByCopying() call

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RenameUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RenameUtil.java
@@ -63,7 +63,8 @@ public class RenameUtil extends ContextAwareBase {
       boolean result = fromFile.renameTo(toFile);
 
       if (!result) {
-        addWarn("Failed to rename file [" + fromFile + "] to [" + toFile + "]. Attempting rename by copying.");
+        addInfo("Failed to rename file [" + fromFile.getAbsolutePath() + "] to [" + 
+          toFile.getAbsolutePath() + "]. Attempting rename by copying.");
         try {
           renameByCopying(from, to);
         } catch(RolloverFailure e) {


### PR DESCRIPTION
Minor patch to RenameUtil to restore the renameByCopying() call that used to be made when the file rename fails. This handles the situation we're seeing when the rename fails due to an attempt to move the file to a different filesystem as part of a rolling strategy (ie: operational --> archive file systems).
