### PR TITLE
Throw exception if configuration file has unexpected extension

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/ContextInitializer.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/ContextInitializer.java
@@ -23,6 +23,7 @@ import ch.qos.logback.classic.BasicConfigurator;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.gaffer.GafferUtil;
 import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.LogbackException;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.status.ErrorStatus;
 import ch.qos.logback.core.status.InfoStatus;
@@ -68,11 +69,12 @@ public class ContextInitializer {
         sm.add(new ErrorStatus("Groovy classes are not available on the class path. ABORTING INITIALIZATION.",
                 loggerContext));
       }
-    }
-    if (url.toString().endsWith("xml")) {
+    } else if (url.toString().endsWith("xml")) {
       JoranConfigurator configurator = new JoranConfigurator();
       configurator.setContext(loggerContext);
       configurator.doConfigure(url);
+    } else {
+      throw new LogbackException("Unexpected filename extension of file [" + url.toString() + "]. Should be either .groovy or .xml");
     }
   }
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
@@ -18,7 +18,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 import org.junit.After;
@@ -33,9 +36,12 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.LogbackException;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.status.StatusListener;
 import ch.qos.logback.core.status.TrivialStatusListener;
+import ch.qos.logback.core.util.Loader;
 
 public class ContextInitializerTest {
 
@@ -119,5 +125,43 @@ public class ContextInitializerTest {
     doAutoConfigFromSystemProperties(ClassicTestConstants.INPUT_PREFIX + "autoConfig.xml");
     sll = lc.getStatusManager().getCopyOfStatusListenerList();
     assertTrue(sll.size() +" should be 1", sll.size() == 1);
+  }
+
+  @Test
+  public void shouldConfigureFromXmlFile() throws MalformedURLException, JoranException {
+    LoggerContext loggerContext = new LoggerContext();
+    ContextInitializer initializer = new ContextInitializer(loggerContext);
+    assertNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
+
+    URL configurationFileUrl = Loader.getResource("BOO_logback-test.xml", Thread.currentThread().getContextClassLoader());
+    initializer.configureByResource(configurationFileUrl);
+
+    assertNotNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
+  }
+
+  @Test
+  public void shouldConfigureFromGroovyScript() throws MalformedURLException, JoranException {
+    LoggerContext loggerContext = new LoggerContext();
+    ContextInitializer initializer = new ContextInitializer(loggerContext);
+    assertNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
+
+    URL configurationFileUrl = Loader.getResource("test.groovy", Thread.currentThread().getContextClassLoader());
+    initializer.configureByResource(configurationFileUrl);
+
+    assertNotNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
+  }
+
+  @Test
+  public void shouldThrowExceptionIfUnexpectedConfigurationFileExtension() throws JoranException {
+    LoggerContext loggerContext = new LoggerContext();
+    ContextInitializer initializer = new ContextInitializer(loggerContext);
+
+    URL configurationFileUrl = Loader.getResource("README.txt", Thread.currentThread().getContextClassLoader());
+    try {
+      initializer.configureByResource(configurationFileUrl);
+      fail("Should throw LogbackException");
+    } catch (LogbackException expectedException) {
+      // pass
+    }
   }
 }

--- a/logback-classic/src/test/resources/test.groovy
+++ b/logback-classic/src/test/resources/test.groovy
@@ -1,0 +1,15 @@
+import ch.qos.logback.core.ConsoleAppender
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder
+import ch.qos.logback.classic.PatternLayout
+import ch.qos.logback.classic.Level
+import ch.qos.logback.core.status.OnConsoleStatusListener
+import ch.qos.logback.classic.Logger
+
+appender("C", ConsoleAppender) {
+  encoder(LayoutWrappingEncoder) {
+    layout(PatternLayout) {
+      pattern = "%m%n"
+    }
+  }
+}
+root Level.WARN, ["C"]


### PR DESCRIPTION
Hi,

We recently had an issue where our Logback XML configuration file (specified via a system property) didn't have the extension ".xml". This didn't work, but we didn't get any feedback on it (other than no entries in our log file).

This change (with included unit tests) makes logback-classic throw an exception when provided with a file without the appropriate extension.

Sincerely,
Halvard
