### PR TITLE
Fixing debug messages by starting OnConsoleStatusListener when debug flag is set to true

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/status/OnConsoleStatusListener.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/status/OnConsoleStatusListener.java
@@ -14,7 +14,6 @@
 package ch.qos.logback.core.status;
 
 import ch.qos.logback.core.Context;
-import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.ContextAwareBase;
 import ch.qos.logback.core.spi.LifeCycle;
 import ch.qos.logback.core.util.StatusPrinter;
@@ -93,5 +92,6 @@ public class OnConsoleStatusListener extends ContextAwareBase implements StatusL
     OnConsoleStatusListener onConsoleStatusListener = new OnConsoleStatusListener();
     onConsoleStatusListener.setContext(context);
     context.getStatusManager().add(onConsoleStatusListener);
+	onConsoleStatusListener.start();
   }
 }


### PR DESCRIPTION
In version 1.0.1 there was introduced change in implementation of debug messages: "Setting the debug attribute to true in the <configuration> element now registers a OnConsoleStatusListener with the StatusManager". 

The problem is that OnConsoleStatusListener registered that way is never started and debug messages are not printed out. 

Change that I've made starts listener directly after it is created.
