### PR TITLE
Propertyaction handle filenotfound gracefully

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/PropertyAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/PropertyAction.java
@@ -22,6 +22,7 @@ import ch.qos.logback.core.util.Loader;
 import ch.qos.logback.core.util.OptionHelper;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -101,8 +102,10 @@ public class PropertyAction extends Action {
       try {
         FileInputStream istream = new FileInputStream(file);
         loadAndSetProperties(ec, istream, scope);
-      } catch (IOException e) {
-        addError("Could not read properties file [" + file + "].", e);
+      } catch (FileNotFoundException e) {
+        addError("Could not find properties file [" + file + "].");
+      } catch (IOException e1) {
+        addError("Could not read properties file [" + file + "].", e1);
       }
     } else if (checkResourceAttributeSanity(attributes)) {
       String resource = attributes.getValue(RESOURCE_ATTRIBUTE);

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/action/PropertyActionTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/action/PropertyActionTest.java
@@ -156,6 +156,6 @@ public class PropertyActionTest  {
   private boolean checkFileErrors() {
     Iterator it = context.getStatusManager().getCopyOfStatusList().iterator();
     ErrorStatus es1 = (ErrorStatus)it.next();
-    return "Could not read properties file [toto].".equals(es1.getMessage());
+    return "Could not find properties file [toto].".equals(es1.getMessage());
   }
 }


### PR DESCRIPTION
In case a property file is referenced which does not exists, this PR will not print the whole stacktrace. This is then the same way missing esources are treated. It also fixes the typo mentioned in LBCORE-84
