### PR TITLE
Make sure AsyncAppenderBaseTest tests have a timeout (LBGENERAL-54).

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
@@ -56,7 +56,7 @@ public class AsyncAppenderBaseTest {
   }
 
 
-  @Test
+  @Test(timeout = 2000)
   public void smoke() {
     asyncAppenderBase.addAppender(listAppender);
     asyncAppenderBase.start();
@@ -76,7 +76,7 @@ public class AsyncAppenderBaseTest {
     assertTrue(delayingListAppender.interrupted);
   }
 
-  @Test
+  @Test(timeout = 2000)
   public void noEventLoss() {
     int bufferSize = 10;
     int loopLen = bufferSize * 2;
@@ -90,7 +90,7 @@ public class AsyncAppenderBaseTest {
     verify(delayingListAppender, loopLen);
   }
 
-  @Test
+  @Test(timeout = 2000)
   public void lossyAppenderShouldOnlyLooseCertainEvents() {
     int bufferSize = 5;
     int loopLen = bufferSize * 2;
@@ -105,7 +105,7 @@ public class AsyncAppenderBaseTest {
     verify(delayingListAppender, loopLen-2);
   }
 
-  @Test
+  @Test(timeout = 2000)
   public void lossyAppenderShouldLooseNoneIfDiscardingThresholdIsZero() {
     int bufferSize = 5;
     int loopLen = bufferSize * 2;


### PR DESCRIPTION
I had an issue where I wasn't able to run the tests because the build hung
after ch.qos.logback.core.util.StatusPrinterTest. By git bisecting I found
that the issue was in the f2d15babe3275e7b0d618a020f09a863a0fa6a54 commit.

Eventually after much trial and error & head-scratching I stumbed upon a fix
involving making sure that each AsyncAppenderBaseTest test method had a
timeout.
