### PR TITLE
Fix for LOGBACK-782: Syslog suffixPattern property cant start with a character in range [a-zA-Z0-9]

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SyslogAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SyslogAppender.java
@@ -50,7 +50,7 @@ public class SyslogAppender extends SyslogAppenderBase<ILoggingEvent> {
   }
 
   String getPrefixPattern() {
-    return "%syslogStart{" + getFacility() + "}%nopex";
+    return "%syslogStart{" + getFacility() + "}%nopex{}";
   }
 
   /*


### PR DESCRIPTION
Fix for issue LOGBACK-782 with test

The fix consists of forcing the nopex variable to be defined with no arguments, so the parser wont get confused and try parsing the %nopex variable concatenated with the next string
