### PR TITLE
LOGBACK-796 RollingFileAppender should have error when File matches FileNamePattern

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import static ch.qos.logback.core.CoreConstants.CODES_URL;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.rolling.helper.CompressionMode;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
 /**
  * <code>RollingFileAppender</code> extends {@link FileAppender} to backup the
  * log files depending on {@link RollingPolicy} and {@link TriggeringPolicy}.
@@ -41,6 +42,16 @@ public class RollingFileAppender<E> extends FileAppender<E> {
           + getName());
       addWarn("For more information, please visit "+CODES_URL+"#rfa_no_tp");
       return;
+    }
+    
+    // sanity check for http://jira.qos.ch/browse/LOGBACK-796
+    if (triggeringPolicy instanceof RollingPolicyBase) {
+    	final RollingPolicyBase base = (RollingPolicyBase) triggeringPolicy;
+        final FileNamePattern pattern = new FileNamePattern(base.getFileNamePattern(), getContext());
+		final String activeFileName = base.getActiveFileName();
+		if (activeFileName.matches(pattern.toRegex())) {
+        	addError("File property must not match fileNamePattern");
+        }
     }
 
     // we don't want to void existing log files

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/RollingFileAppenderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/RollingFileAppenderTest.java
@@ -128,8 +128,9 @@ public class RollingFileAppenderTest extends AbstractAppenderTest<Object> {
     rfa.setTriggeringPolicy(new SizeBasedTriggeringPolicy<Object>());
     rfa.setFile("x");
     StatusChecker statusChecker = new StatusChecker(context.getStatusManager());
-    statusChecker.containsMatch(Status.ERROR,
+    boolean containsMatch = statusChecker.containsMatch(Status.ERROR,
             "File property must be set before any triggeringPolicy ");
+    assertTrue(containsMatch);
   }
 
   @Test
@@ -191,6 +192,22 @@ public class RollingFileAppenderTest extends AbstractAppenderTest<Object> {
     assertFalse(fwRollingPolicy.isStarted());
     assertFalse(sbTriggeringPolicy.isStarted());
 
+  }
+  
+  /**
+   * Test for http://jira.qos.ch/browse/LOGBACK-796
+   */
+  @Test
+  public void testFileShouldNotMatchFileNamePattern() {
+    rfa.setContext(context);
+    rfa.setFile(CoreTestConstants.OUTPUT_DIR_PREFIX + "x-2012.log");
+    tbrp.setFileNamePattern(CoreTestConstants.OUTPUT_DIR_PREFIX + "x-%d{yyyy}.log");
+    rfa.setTriggeringPolicy(tbrp);
+    rfa.start();
+    StatusChecker statusChecker = new StatusChecker(context.getStatusManager());
+    final String msg = "File property must not match fileNamePattern";
+	boolean containsMatch = statusChecker.containsMatch(Status.ERROR, msg);
+    assertTrue("Missing error: " + msg, containsMatch);
   }
 
 }


### PR DESCRIPTION
#### Why

Ceki said:

> File property and the archived files should not point to the same
> file path. When you wish them to point to the same path, then File
> property should be omitted.

From http://mailman.qos.ch/pipermail/logback-user/2013-January/003655.html

I've added the code / test for this.
#### What
- I've logged the issue at http://jira.qos.ch/browse/LOGBACK-796
- I wasn't sure where to add the check, but I added it to `RollingFileAppender.start()` because that's where other checks where (as opposed to `RollingPolicyBase`, where it seemed like the checks should be)
- I wanted to make the least changes to the code, so I didn't want to add the concept of validation to file name patterns.
- The additional test went into `RollingFileAppenderTest`
- All tests in logback-core (except Scala tests) still pass. :)
#### Other

Feedback, comments, etc. welcome.
