### PR TITLE
Minor improvements to CyclicBufferAppender, and tests

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/read/CyclicBufferAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/read/CyclicBufferAppender.java
@@ -54,12 +54,16 @@ public class CyclicBufferAppender<E> extends AppenderBase<E> {
     }
   }
 
-  public Object get(int i) {
+  public E get(int i) {
     if (isStarted()) {
       return cb.get(i);
     } else {
       return null;
     }
+  }
+
+  public void reset() {
+    cb.clear();
   }
 
   /**

--- a/logback-core/src/test/java/ch/qos/logback/core/read/CyclicBufferAppenderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/read/CyclicBufferAppenderTest.java
@@ -1,0 +1,50 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ *
+ * Copyright 2013 SURFnet bv, The Netherlands
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.read;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CyclicBufferAppenderTest {
+
+  private CyclicBufferAppender<String> cyclicBufferAppender;
+
+  @Before
+  public void before() {
+    cyclicBufferAppender = new CyclicBufferAppender<String>();
+    cyclicBufferAppender.start();
+  }
+
+  @Test
+    public void reset() {
+
+    cyclicBufferAppender.append("foobar");
+    assertEquals(1, cyclicBufferAppender.getLength());
+    cyclicBufferAppender.reset();
+    assertEquals(0, cyclicBufferAppender.getLength());
+  }
+
+  @Test
+  public void genericGet() {
+    cyclicBufferAppender.append("Some string");
+    // get() now has type information, assigning to String should work without cast.
+    String foo = cyclicBufferAppender.get(0);
+    assertEquals("Some string", foo);
+  }
+
+
+}


### PR DESCRIPTION
Hi,

I did two minor improvements for CyclicBufferAppender:
- get() could take advantage of the generic type E.
- an added method reset() to clear the cyclic buffer
