### PR TITLE
fix for  form posts losing data

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/servlet/Util.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/servlet/Util.java
@@ -22,7 +22,7 @@ public class Util {
 
   public static boolean isFormUrlEncoded(HttpServletRequest request) {
     if ("POST".equalsIgnoreCase(request.getMethod())
-        && AccessConstants.X_WWW_FORM_URLECODED.equals(request.getContentType())) {
+        && request.getContentType().startsWith(AccessConstants.X_WWW_FORM_URLECODED)) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
match start of content type so ex: application/x-www-form-urlencoded; charset=UTF-8 matches
