### PR TITLE
Fixing the log "Could not parser [l as an integer"

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
@@ -57,7 +57,7 @@ public class ThrowableProxyConverter extends ThrowableHandlingConverter {
           // we add one because, printing starts at offset 1
           lengthOption = Integer.parseInt(lengthStr) + 1;
         } catch (NumberFormatException nfe) {
-          addError("Could not parser [" + lengthStr + " as an integer");
+          addError("Could not parse [" + lengthStr + "] as an integer");
           lengthOption = Integer.MAX_VALUE;
         }
       }


### PR DESCRIPTION
Now will display the (supposedly) correct one:
"Could not parse [l] as an integer".
