### PR TITLE
Add an origin column to the database that is set in configuration

### DIFF
--- a/logback-access/src/test/input/integration/db/mysql-with-driver.xml
+++ b/logback-access/src/test/input/integration/db/mysql-with-driver.xml
@@ -10,6 +10,7 @@
 			<user>root</user>
 			<password></password>
 		</connectionSource>
+        <origin>Integration Test</origin>
 	</appender>
 
 

--- a/logback-access/src/test/input/integration/db/oracle10g-with-driver.xml
+++ b/logback-access/src/test/input/integration/db/oracle10g-with-driver.xml
@@ -10,6 +10,7 @@
 			<user>hr</user>
 			<password>hr</password>
 		</connectionSource>
+        <origin>Integration Test</origin>
 	</appender>
 
 

--- a/logback-access/src/test/input/integration/db/oracle11g-with-driver.xml
+++ b/logback-access/src/test/input/integration/db/oracle11g-with-driver.xml
@@ -9,6 +9,7 @@
 			<user>SCOTT</user>
 			<password>SCOTT</password>
 		</connectionSource>
+        <origin>Integration Test</origin>
 	</appender>
 	
 	

--- a/logback-access/src/test/input/integration/db/postgresql-with-driver.xml
+++ b/logback-access/src/test/input/integration/db/postgresql-with-driver.xml
@@ -9,6 +9,7 @@
       <user>logback</user>
       <password>logback</password>
     </connectionSource>
+    <origin>Integration Test</origin>
   </appender>
 	
   <appender-ref ref="DB" />

--- a/logback-access/src/test/input/integration/db/sqlserver-with-driver.xml
+++ b/logback-access/src/test/input/integration/db/sqlserver-with-driver.xml
@@ -9,6 +9,7 @@
 			<user>logback</user>
 			<password>logback</password>
 		</connectionSource>
+        <origin>Integration Test</origin>
 	</appender>
 	
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
@@ -45,6 +45,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
   protected String insertExceptionSQL;
   protected String insertSQL;
   protected static final Method GET_GENERATED_KEYS_METHOD;
+  protected String origin;
 
   private DBNameResolver dbNameResolver;
 
@@ -62,7 +63,8 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
   static final int  CALLER_CLASS_INDEX = 12;
   static final int  CALLER_METHOD_INDEX = 13;
   static final int  CALLER_LINE_INDEX = 14;
-  static final int  EVENT_ID_INDEX  = 15;
+  static final int  ORIGIN = 15;
+  static final int  EVENT_ID_INDEX  = 16;
 
   static final StackTraceElement EMPTY_CALLER_DATA = CallerData.naInstance();
 
@@ -83,7 +85,15 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     this.dbNameResolver = dbNameResolver;
   }
 
-  @Override
+  public String getOrigin() {
+    return origin;
+  }
+
+  public void setOrigin(String origin) {
+    this.origin = origin;
+  }
+
+@Override
   public void start() {
     if (dbNameResolver == null)
       dbNameResolver = new DefaultDBNameResolver();
@@ -127,6 +137,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     stmt.setString(LEVEL_STRING_INDEX, event.getLevel().toString());
     stmt.setString(THREAD_NAME_INDEX, event.getThreadName());
     stmt.setShort(REFERENCE_FLAG_INDEX, DBHelper.computeReferenceMask(event));
+    stmt.setString(ORIGIN, getOrigin()) ;
   }
 
   void bindLoggingEventArgumentsWithPreparedStatement(PreparedStatement stmt,
@@ -210,7 +221,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
 
       for (Iterator i = propertiesKeys.iterator(); i.hasNext();) {
         String key = (String) i.next();
-        String value = (String) mergedMap.get(key);
+        String value = mergedMap.get(key);
 
         insertPropertiesStatement.setLong(1, eventId);
         insertPropertiesStatement.setString(2, key);
@@ -295,4 +306,5 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     }
     exceptionStatement.close();
   }
+
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/SQLBuilder.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/SQLBuilder.java
@@ -57,8 +57,9 @@ public class SQLBuilder {
     sqlBuilder.append(dbNameResolver.getColumnName(ColumnName.CALLER_FILENAME)).append(", ");
     sqlBuilder.append(dbNameResolver.getColumnName(ColumnName.CALLER_CLASS)).append(", ");
     sqlBuilder.append(dbNameResolver.getColumnName(ColumnName.CALLER_METHOD)).append(", ");
-    sqlBuilder.append(dbNameResolver.getColumnName(ColumnName.CALLER_LINE)).append(") ");
-    sqlBuilder.append("VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    sqlBuilder.append(dbNameResolver.getColumnName(ColumnName.CALLER_LINE)).append(", ");
+    sqlBuilder.append(dbNameResolver.getColumnName(ColumnName.ORIGIN)).append(") ");
+    sqlBuilder.append("VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
     return sqlBuilder.toString();
   }
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/names/ColumnName.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/names/ColumnName.java
@@ -16,7 +16,7 @@ package ch.qos.logback.classic.db.names;
 public enum ColumnName {
 
   EVENT_ID,
-  
+
   TIMESTMP,
   FORMATTED_MESSAGE,
   LOGGER_NAME,
@@ -31,7 +31,8 @@ public enum ColumnName {
   CALLER_CLASS,
   CALLER_METHOD,
   CALLER_LINE,
-  
+  ORIGIN,
+
   // MDC
   MAPPED_KEY,
   MAPPED_VALUE,

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/db2.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/db2.sql
@@ -34,7 +34,8 @@ CREATE TABLE logging_event
     caller_class      VARCHAR(254) NOT NULL,
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
-    event_id           INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1)
+    event_id           INTEGER GENERATED ALWAYS AS IDENTITY (START WITH 1),
+    origin           VARCHAR(254)
   );
 
 CREATE TABLE logging_event_property

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/h2.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/h2.sql
@@ -28,7 +28,8 @@ CREATE TABLE logging_event (
   caller_class VARCHAR(256), 
   caller_method VARCHAR(256), 
   caller_line CHAR(4),
-  event_id IDENTITY NOT NULL);
+  event_id IDENTITY NOT NULL,
+  origin VARCHAR(256));
 
 
 CREATE TABLE logging_event_property (

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/hsqldb.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/hsqldb.sql
@@ -28,7 +28,8 @@ CREATE TABLE logging_event (
   caller_class VARCHAR(256), 
   caller_method VARCHAR(256), 
   caller_line CHAR(4),
-  event_id BIGINT NOT NULL IDENTITY);
+  event_id BIGINT NOT NULL IDENTITY,
+  origin VARCHAR(256));
 
 
 CREATE TABLE logging_event_property (

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/mssql.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/mssql.sql
@@ -30,6 +30,7 @@ CREATE TABLE logging_event
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
     event_id          DECIMAL(40) NOT NULL identity,
+    origin           VARCHAR(254)
     PRIMARY KEY(event_id) 
   ) 
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/mysql.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/mysql.sql
@@ -34,7 +34,8 @@ CREATE TABLE logging_event
     caller_class      VARCHAR(254) NOT NULL,
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
-    event_id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY
+    event_id          BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    origin           VARCHAR()254)
   );
 COMMIT;
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/oracle.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/oracle.sql
@@ -37,7 +37,8 @@ CREATE TABLE logging_event
     caller_class      VARCHAR(254) NOT NULL,
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
-    event_id          NUMBER(10) PRIMARY KEY
+    event_id          NUMBER(10) PRIMARY KEY,
+    origin           VARCHAR(254)
   );
 
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/postgresql.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/postgresql.sql
@@ -33,7 +33,8 @@ CREATE TABLE logging_event
     caller_class      VARCHAR(254) NOT NULL,
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
-    event_id          BIGINT DEFAULT nextval('logging_event_id_seq') PRIMARY KEY
+    event_id          BIGINT DEFAULT nextval('logging_event_id_seq') PRIMARY KEY,
+    origin           VARCHAR(254)
   );
 
 CREATE TABLE logging_event_property

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/sqllite.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/sqllite.sql
@@ -34,7 +34,8 @@ CREATE TABLE logging_event
     caller_class      VARCHAR(254) NOT NULL,
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
-    event_id          INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+    event_id          INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    origin           VARCHAR(254)
   );
 COMMIT;
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/script/sybaseSqlAnywhere.sql
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/script/sybaseSqlAnywhere.sql
@@ -28,6 +28,7 @@ CREATE TABLE logging_event
   caller_method     VARCHAR(254) NOT NULL,
   caller_line       varCHAR(4) NOT NULL,
   event_id          int NOT NULL DEFAULT AUTOINCREMENT,
+  origin           VARCHAR(254)
   PRIMARY KEY(event_id) 
 ) 			
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderHSQLTestFixture.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderHSQLTestFixture.java
@@ -112,18 +112,19 @@ public class DBAppenderHSQLTestFixture  {
     buf.append("LEVEL_STRING VARCHAR(256) NOT NULL,");
     buf.append("THREAD_NAME VARCHAR(256),");
     buf.append("REFERENCE_FLAG SMALLINT,");
-    
+
     buf.append("ARG0 VARCHAR(256),");
     buf.append("ARG1 VARCHAR(256),");
     buf.append("ARG2 VARCHAR(256),");
     buf.append("ARG3 VARCHAR(256),");
-    
-    
+
+
     buf.append("CALLER_FILENAME VARCHAR(256), ");
     buf.append("CALLER_CLASS VARCHAR(256), ");
     buf.append("CALLER_METHOD VARCHAR(256), ");
     buf.append("CALLER_LINE CHAR(4), ");
-    buf.append("EVENT_ID BIGINT NOT NULL IDENTITY);");
+    buf.append("EVENT_ID BIGINT NOT NULL IDENTITY, ");
+    buf.append("ORIGIN VARCHAR(256) );") ;
     query(conn, buf.toString());
 
     buf = new StringBuffer();

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/SQLBuilderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/SQLBuilderTest.java
@@ -36,7 +36,7 @@ public class SQLBuilderTest {
     String sql = SQLBuilder.buildInsertSQL(nameResolver);
 
     //then
-    final String expected = "INSERT INTO logging_event (timestmp, formatted_message, logger_name, level_string, thread_name, reference_flag, arg0, arg1, arg2, arg3, caller_filename, caller_class, caller_method, caller_line) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    final String expected = "INSERT INTO logging_event (timestmp, formatted_message, logger_name, level_string, thread_name, reference_flag, arg0, arg1, arg2, arg3, caller_filename, caller_class, caller_method, caller_line, origin) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     assertThat(sql).isEqualTo(expected);
   }
 


### PR DESCRIPTION
The reason for this change is to enable you to have a tag in the configuration file called “Origin” that will then be placed in the row of the database. The system supports the class and line, but no way to tell what application generated a message. If you have three applications all writing to the same database log there is no good way to distinguish which application generated which message.
