### PR TITLE
Introducing AbstractDiscriminator base class

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/sift/AccessEventDiscriminator.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/sift/AccessEventDiscriminator.java
@@ -17,8 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import ch.qos.logback.access.spi.IAccessEvent;
-import ch.qos.logback.core.sift.Discriminator;
-import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.sift.AbstractDiscriminator;
 
 /**
  * 
@@ -30,10 +29,7 @@ import ch.qos.logback.core.spi.ContextAwareBase;
  * @author Ceki G&uuml;lc&uuml;
  * 
  */
-public class AccessEventDiscriminator extends ContextAwareBase implements
-    Discriminator<IAccessEvent> {
-
-  boolean started = false;
+public class AccessEventDiscriminator extends AbstractDiscriminator<IAccessEvent> {
 
   /**
    * At present time the followed fields can be designated: COOKIE,
@@ -120,10 +116,7 @@ public class AccessEventDiscriminator extends ContextAwareBase implements
     return null;
   }
 
-  public boolean isStarted() {
-    return started;
-  }
-
+  @Override
   public void start() {
 
     int errorCount = 0;
@@ -150,10 +143,6 @@ public class AccessEventDiscriminator extends ContextAwareBase implements
     if (errorCount == 0) {
       started = true;
     }
-  }
-
-  public void stop() {
-    started = false;
   }
 
   public void setFieldName(FieldName fieldName) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/sift/ContextBasedDiscriminator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/sift/ContextBasedDiscriminator.java
@@ -14,8 +14,7 @@
 package ch.qos.logback.classic.sift;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.sift.Discriminator;
-import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.sift.AbstractDiscriminator;
 
 /**
  * This discriminator returns the value context to which this event is attached
@@ -27,12 +26,10 @@ import ch.qos.logback.core.spi.ContextAwareBase;
  * @author Ceki G&uuml;lc&uuml;
  * 
  */
-public class ContextBasedDiscriminator extends ContextAwareBase implements
-    Discriminator<ILoggingEvent> {
+public class ContextBasedDiscriminator extends AbstractDiscriminator<ILoggingEvent> {
 
   private static final String KEY = "contextName";
   private String defaultValue;
-  private boolean started = false;
 
   /**
    * Return the name of the current context name as found in the logging event.
@@ -45,18 +42,6 @@ public class ContextBasedDiscriminator extends ContextAwareBase implements
     } else {
       return contextName;
     }
-  }
-
-  public boolean isStarted() {
-    return started;
-  }
-
-  public void start() {
-    started = true;
-  }
-
-  public void stop() {
-    started = false;
   }
 
   public String getKey() {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/sift/JNDIBasedContextDiscriminator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/sift/JNDIBasedContextDiscriminator.java
@@ -17,8 +17,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.selector.ContextSelector;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.util.ContextSelectorStaticBinder;
-import ch.qos.logback.core.sift.Discriminator;
-import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.sift.AbstractDiscriminator;
 
 /**
  * This discriminator returns the value context as determined by JNDI. If the
@@ -30,12 +29,10 @@ import ch.qos.logback.core.spi.ContextAwareBase;
  * @author Ceki G&uuml;lc&uuml;
  * 
  */
-public class JNDIBasedContextDiscriminator extends ContextAwareBase implements
-    Discriminator<ILoggingEvent> {
+public class JNDIBasedContextDiscriminator extends AbstractDiscriminator<ILoggingEvent> {
 
   private static final String KEY = "contextName";
   private String defaultValue;
-  private boolean started = false;
 
   /**
    * Return the name of the current context name as found in the logging event.
@@ -54,18 +51,6 @@ public class JNDIBasedContextDiscriminator extends ContextAwareBase implements
     }
 
     return lc.getName();
-  }
-
-  public boolean isStarted() {
-    return started;
-  }
-
-  public void start() {
-    started = true;
-  }
-
-  public void stop() {
-    started = false;
   }
 
   public String getKey() {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/sift/MDCBasedDiscriminator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/sift/MDCBasedDiscriminator.java
@@ -14,8 +14,7 @@
 package ch.qos.logback.classic.sift;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.sift.Discriminator;
-import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.sift.AbstractDiscriminator;
 import ch.qos.logback.core.util.OptionHelper;
 
 import java.util.Map;
@@ -28,12 +27,10 @@ import java.util.Map;
  *
  * @author Ceki G&uuml;lc&uuml;
  */
-public class MDCBasedDiscriminator extends ContextAwareBase implements
-        Discriminator<ILoggingEvent> {
+public class MDCBasedDiscriminator extends AbstractDiscriminator<ILoggingEvent> {
 
   private String key;
   private String defaultValue;
-  private boolean started = false;
 
   /**
    * Return the value associated with an MDC entry designated by the Key
@@ -54,10 +51,7 @@ public class MDCBasedDiscriminator extends ContextAwareBase implements
     }
   }
 
-  public boolean isStarted() {
-    return started;
-  }
-
+  @Override
   public void start() {
     int errors = 0;
     if (OptionHelper.isEmpty(key)) {
@@ -71,10 +65,6 @@ public class MDCBasedDiscriminator extends ContextAwareBase implements
     if (errors == 0) {
       started = true;
     }
-  }
-
-  public void stop() {
-    started = false;
   }
 
   public String getKey() {

--- a/logback-core/src/main/java/ch/qos/logback/core/sift/AbstractDiscriminator.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/sift/AbstractDiscriminator.java
@@ -1,0 +1,26 @@
+package ch.qos.logback.core.sift;
+
+import ch.qos.logback.core.spi.ContextAwareBase;
+
+/**
+ * Base implementation of {@link Discriminator} that provides basic lifecycle management
+ *
+ * @author Tomasz Nurkiewicz
+ * @since 3/29/13, 3:28 PM
+ */
+public abstract class AbstractDiscriminator<E> extends ContextAwareBase implements Discriminator<E> {
+
+  protected boolean started;
+
+  public void start() {
+    started = true;
+  }
+
+  public void stop() {
+    started = false;
+  }
+
+  public boolean isStarted() {
+    return started;
+  }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/sift/DefaultDiscriminator.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/sift/DefaultDiscriminator.java
@@ -13,16 +13,13 @@
  */
 package ch.qos.logback.core.sift;
 
-import ch.qos.logback.core.sift.Discriminator;
 
 /**
  * @author Ceki G&uuml;c&uuml;
  */
-public class DefaultDiscriminator<E> implements Discriminator<E> {
+public class DefaultDiscriminator<E> extends AbstractDiscriminator<E> {
 
   static public final String DEFAULT = "default";
-
-  boolean started = false;
 
   public String getDiscriminatingValue(E e) {
     return DEFAULT;
@@ -32,15 +29,4 @@ public class DefaultDiscriminator<E> implements Discriminator<E> {
     return DEFAULT;
   }
 
-  public void start() {
-    started = true;
-  }
-
-  public void stop() {
-    started = false;
-  }
-
-  public boolean isStarted() {
-    return started;  
-  }
 }


### PR DESCRIPTION
Introducing `AbstractDiscriminator` base class to avoid repeated `start()`/`stop()` implementation in each concrete `Discriminator<E>`.

`started` field extracted to base class. Shouldn't it be `volatile`?

I have commit rights but wanted someone to review this first and pull.
