### PR TITLE
Fix for LOGBACK-230 - Support attribute "optional" in include element

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/IncludeAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/IncludeAction.java
@@ -39,8 +39,10 @@ public class IncludeAction extends Action {
   private static final String FILE_ATTR = "file";
   private static final String URL_ATTR = "url";
   private static final String RESOURCE_ATTR = "resource";
+  private static final String OPTIONAL_ATTR = "optional";
 
   private String attributeInUse;
+  private boolean optional;
 
   @Override
   public void begin(InterpretationContext ec, String name, Attributes attributes)
@@ -49,6 +51,7 @@ public class IncludeAction extends Action {
     SaxEventRecorder recorder = new SaxEventRecorder();
 
     this.attributeInUse = null;
+    this.optional = OptionHelper.toBoolean(attributes.getValue(OPTIONAL_ATTR), false);
 
     if (!checkAttributes(attributes)) {
       return;
@@ -140,8 +143,10 @@ public class IncludeAction extends Action {
     try {
       return url.openStream();
     } catch (IOException e) {
-      String errMsg = "Failed to open [" + url.toString() + "]";
-      addError(errMsg, e);
+      if (!optional) {
+        String errMsg = "Failed to open [" + url.toString() + "]";
+        addError(errMsg, e);
+      }
       return null;
     }
   }

--- a/logback-core/src/test/input/joran/inclusion/topOptional.xml
+++ b/logback-core/src/test/input/joran/inclusion/topOptional.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE x>
+
+<x>
+  <include optional="true" file="nonExistentFile.xml" />
+
+  <stack name="IA"/>
+  <stack name="IB"/>
+</x>

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/action/IncludeActionTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/action/IncludeActionTest.java
@@ -60,6 +60,8 @@ public class IncludeActionTest {
 
   static final String TOP_BY_FILE = INCLUSION_DIR_PREFIX + "topByFile.xml";
 
+  static final String TOP_OPTIONAL = INCLUSION_DIR_PREFIX + "topOptional.xml";
+
   static final String INTERMEDIARY_FILE = INCLUSION_DIR_PREFIX
       + "intermediaryByFile.xml";
 
@@ -112,6 +114,12 @@ public class IncludeActionTest {
   public void basicFile() throws JoranException {
     System.setProperty(INCLUDE_KEY, INCLUDED_FILE);
     tc.doConfigure(TOP_BY_FILE);
+    verifyConfig(new String[] { "IA", "IB" });
+  }
+
+  @Test
+  public void optionalFile() throws JoranException {
+    tc.doConfigure(TOP_OPTIONAL);
     verifyConfig(new String[] { "IA", "IB" });
   }
 


### PR DESCRIPTION
Support attribute "optional" in include element to prevent errors on
inclusion of non-existent files without requiring Janino and
FileExistsPropertyDefiner.
