### PR TITLE
Handle RejectedExecutionException in ConcurrentServerRunner

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/server/ConcurrentServerRunner.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/server/ConcurrentServerRunner.java
@@ -151,7 +151,7 @@ public abstract class ConcurrentServerRunner<T extends Client>
       }
     }
     catch (InterruptedException ex) {
-      // ok... we'll shut down
+      assert true;  // ok... we'll shut down
     }
     catch (SocketException ex) {
       logInfo(ex.toString());


### PR DESCRIPTION
When the Executor rejects a request to execute a client runner, close the client's socket to avoid a temporary resource leak.
