### PR TITLE
removed name property from SocketRemote

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/SocketRemoteAction.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/SocketRemoteAction.java
@@ -46,15 +46,6 @@ public class SocketRemoteAction extends Action {
           className, SocketRemote.class, context);
       remote.setContext(context);
 
-      String remoteName = ic.subst(attributes.getValue(NAME_ATTRIBUTE));
-      if (OptionHelper.isEmpty(remoteName)) {
-        addWarn("No name given for remote of type " + className
-            + "].");
-      } else {
-        remote.setName(remoteName);
-        addInfo("Naming remote as [" + remoteName + "]");
-      }
-
       ic.pushObject(remote);
     }
     catch (Exception ex) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketRemote.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketRemote.java
@@ -51,7 +51,6 @@ public class SocketRemote extends ContextAwareBase
 
   private static final int DEFAULT_ACCEPT_CONNECTION_DELAY = 5000;
   
-  private String name = toString();
   private String address;
   private InetAddress inetAddress;
   private int port;
@@ -76,15 +75,14 @@ public class SocketRemote extends ContextAwareBase
     int errorCount = 0;
     if (port == 0) {
       errorCount++;
-      addError("No port was configured for remote " + name 
-          + ". For more information, please visit http://logback.qos.ch/codes.html#receiver_no_port");
+      addError("No port was configured for remote. "
+          + "For more information, please visit http://logback.qos.ch/codes.html#receiver_no_port");
     }
 
     if (address == null) {
       errorCount++;
-      addError("No remote address was configured for remote " + name
-          + name
-          + ". For more information, please visit http://logback.qos.ch/codes.html#receiver_no_host");
+      addError("No remote address was configured for remote. " 
+          + "For more information, please visit http://logback.qos.ch/codes.html#receiver_no_host");
     }
     
     if (reconnectionDelay == 0) {
@@ -102,7 +100,7 @@ public class SocketRemote extends ContextAwareBase
     }
         
     if (errorCount == 0) {
-      remoteId = "remote " + name + " [" + address + ":" + port + "]: ";
+      remoteId = "remote " + address + ":" + port + ": ";
       executor = createExecutorService();
       executor.execute(this);
       started = true;
@@ -238,10 +236,6 @@ public class SocketRemote extends ContextAwareBase
     return Executors.newCachedThreadPool();
   }
   
-  public void setName(String name) {
-    this.name = name;
-  }
-
   public void setAddress(String address) {
     this.address = address;
   }


### PR DESCRIPTION
The name served no real purpose, while creating potential for confusion
and additional noise in the configuration.
