### PR TITLE
changed SocketRemote address property to host

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketRemote.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketRemote.java
@@ -51,8 +51,8 @@ public class SocketRemote extends ContextAwareBase
 
   private static final int DEFAULT_ACCEPT_CONNECTION_DELAY = 5000;
   
-  private String address;
-  private InetAddress inetAddress;
+  private String host;
+  private InetAddress address;
   private int port;
   private int reconnectionDelay;
   private int acceptConnectionTimeout = DEFAULT_ACCEPT_CONNECTION_DELAY;
@@ -79,9 +79,9 @@ public class SocketRemote extends ContextAwareBase
           + "For more information, please visit http://logback.qos.ch/codes.html#receiver_no_port");
     }
 
-    if (address == null) {
+    if (host == null) {
       errorCount++;
-      addError("No remote address was configured for remote. " 
+      addError("No host name or address was configured for remote. " 
           + "For more information, please visit http://logback.qos.ch/codes.html#receiver_no_host");
     }
     
@@ -91,16 +91,16 @@ public class SocketRemote extends ContextAwareBase
     
     if (errorCount == 0) {
       try {
-        inetAddress = InetAddress.getByName(address);
+        address = InetAddress.getByName(host);
       }
       catch (UnknownHostException ex) {
-        addError("unknown host: " + address);
+        addError("unknown host: " + host);
         errorCount++;
       }
     }
         
     if (errorCount == 0) {
-      remoteId = "remote " + address + ":" + port + ": ";
+      remoteId = "remote " + host + ":" + port + ": ";
       executor = createExecutorService();
       executor.execute(this);
       started = true;
@@ -132,7 +132,7 @@ public class SocketRemote extends ContextAwareBase
   public void run() {
     try {
       LoggerContext lc = awaitConfiguration();      
-      SocketConnector connector = createConnector(inetAddress, port, 0, 
+      SocketConnector connector = createConnector(address, port, 0, 
           reconnectionDelay);
       while (!executor.isShutdown() && 
           !Thread.currentThread().isInterrupted()) {
@@ -145,7 +145,7 @@ public class SocketRemote extends ContextAwareBase
         }
         socket = connector.awaitConnection();
         dispatchEvents(lc);
-        connector = createConnector(inetAddress, port, reconnectionDelay);
+        connector = createConnector(address, port, reconnectionDelay);
       }
     }
     catch (InterruptedException ex) {
@@ -236,12 +236,12 @@ public class SocketRemote extends ContextAwareBase
     return Executors.newCachedThreadPool();
   }
   
-  public void setAddress(String address) {
-    this.address = address;
+  public void setHost(String host) {
+    this.host = host;
   }
 
-  public void setRemoteAddress(String address) {
-    setAddress(address);
+  public void setRemoteHost(String host) {
+    setHost(host);
   }
   
   public void setPort(int port) {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SSLSocketRemoteTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SSLSocketRemoteTest.java
@@ -43,7 +43,7 @@ public class SSLSocketRemoteTest {
   @Test
   public void testUsingDefaultConfig() throws Exception {
     // should be able to start successfully with no SSL configuration at all
-    remote.setAddress(InetAddress.getLocalHost().getHostAddress());
+    remote.setHost(InetAddress.getLocalHost().getHostAddress());
     remote.setPort(6000);
     remote.start();
     assertNotNull(remote.getSocketFactory());

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SocketRemoteTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SocketRemoteTest.java
@@ -102,12 +102,12 @@ public class SocketRemoteTest {
   @Test
   public void testStartNoRemoteAddress() throws Exception {
     remote.start();
-    assertTrue(context.getLastStatus().getMessage().contains("address"));
+    assertTrue(context.getLastStatus().getMessage().contains("host"));
   }
 
   @Test
   public void testStartNoPort() throws Exception {
-    remote.setAddress(TEST_HOST_NAME);
+    remote.setHost(TEST_HOST_NAME);
     remote.start();
     assertTrue(context.getLastStatus().getMessage().contains("port"));
   }
@@ -115,14 +115,14 @@ public class SocketRemoteTest {
   @Test
   public void testStartUnknownHost() throws Exception {
     remote.setPort(6000);
-    remote.setAddress(TEST_HOST_NAME);
+    remote.setHost(TEST_HOST_NAME);
     remote.start();
     assertTrue(context.getLastStatus().getMessage().contains("unknown host"));
   }
   
   @Test
   public void testStartStop() throws Exception {
-    remote.setAddress(InetAddress.getLocalHost().getHostName());
+    remote.setHost(InetAddress.getLocalHost().getHostName());
     remote.setPort(6000);
     remote.setAcceptConnectionTimeout(DELAY / 2);
     remote.start();
@@ -136,7 +136,7 @@ public class SocketRemoteTest {
   
   @Test
   public void testServerSlowToAcceptConnection() throws Exception {
-    remote.setAddress(InetAddress.getLocalHost().getHostName());
+    remote.setHost(InetAddress.getLocalHost().getHostName());
     remote.setPort(6000);
     remote.setAcceptConnectionTimeout(DELAY / 4);
     remote.start();
@@ -147,7 +147,7 @@ public class SocketRemoteTest {
 
   @Test
   public void testServerDropsConnection() throws Exception {
-    remote.setAddress(InetAddress.getLocalHost().getHostName());
+    remote.setHost(InetAddress.getLocalHost().getHostName());
     remote.setPort(6000);
     remote.start();
     assertTrue(remote.awaitConnectorCreated(DELAY));
@@ -157,7 +157,7 @@ public class SocketRemoteTest {
   
   @Test
   public void testDispatchEventForEnabledLevel() throws Exception {
-    remote.setAddress(InetAddress.getLocalHost().getHostName());
+    remote.setHost(InetAddress.getLocalHost().getHostName());
     remote.setPort(6000);
     remote.start();
     assertTrue(remote.awaitConnectorCreated(DELAY));
@@ -183,7 +183,7 @@ public class SocketRemoteTest {
 
   @Test
   public void testNoDispatchEventForDisabledLevel() throws Exception {
-    remote.setAddress(InetAddress.getLocalHost().getHostName());
+    remote.setHost(InetAddress.getLocalHost().getHostName());
     remote.setPort(6000);
     remote.start();
     assertTrue(remote.awaitConnectorCreated(DELAY));

--- a/logback-examples/src/main/java/chapters/appenders/socket/remoteClient.xml
+++ b/logback-examples/src/main/java/chapters/appenders/socket/remoteClient.xml
@@ -13,7 +13,7 @@
   </appender>
   
   <remote class="ch.qos.logback.classic.net.SocketRemote">
-    <address>${address}</address>
+    <host>${host}</host>
     <port>${port}</port>
     <reconnectionDelay>5000</reconnectionDelay>
   </remote>

--- a/logback-examples/src/main/java/chapters/appenders/socket/ssl/remoteClient.xml
+++ b/logback-examples/src/main/java/chapters/appenders/socket/ssl/remoteClient.xml
@@ -13,7 +13,7 @@
   </appender>
   
   <remote class="ch.qos.logback.classic.net.SSLSocketRemote">
-    <address>${address}</address>
+    <host>${host}</host>
     <port>${port}</port>
     <reconnectionDelay>5000</reconnectionDelay>
     <ssl>


### PR DESCRIPTION
SocketAppenderBase uses 'remoteHost'.  The 'remote' suffix seems a
little redundant when configuring the property inside of a <remote>
component, so the preferred name is 'host' in SocketRemote.  However,
for consistency with SocketAppenderBase, this property can also be set
using 'remoteHost'.
