### PR TITLE
UnknownHostException recovery attempt.

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/ContextUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/ContextUtil.java
@@ -54,6 +54,9 @@ public class ContextUtil extends ContextAwareBase {
     while (interfaces.hasMoreElements()) {
       NetworkInterface networkInterface = interfaces.nextElement();
       Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
+      if (inetAddresses == null) {
+        continue;
+      }
       while(inetAddresses.hasMoreElements()) {
         InetAddress ipAddress = inetAddresses.nextElement();
         if (invalidAddress(ipAddress)) {


### PR DESCRIPTION
A small patch to handle the situation where a system lacks a defined hostname.
