### PR TITLE
Fix for LOGBACK-266 - FixedWindowRollingPolicy MAX_WINDOW_SIZE too small

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/FixedWindowRollingPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/FixedWindowRollingPolicy.java
@@ -40,9 +40,9 @@ public class FixedWindowRollingPolicy extends RollingPolicyBase {
   public static final String ZIP_ENTRY_DATE_PATTERN = "yyyy-MM-dd_HHmm";
 
   /**
-   * It's almost always a bad idea to have a large window size, say over 12.
+   * It's almost always a bad idea to have a large window size, say over 20.
    */
-  private static int MAX_WINDOW_SIZE = 12;
+  private static int MAX_WINDOW_SIZE = 20;
 
   public FixedWindowRollingPolicy() {
     minIndex = 1;


### PR DESCRIPTION
Fix for http://jira.qos.ch/browse/LOGBACK-266

I've made the limit overridable by subclasses, and increased the limit from 12 to 20.

However, maybe the limit should be much higher like 100, since some filesystems can do very fast renames (unlike NTFS)..  But I didn't want to be too bold so just increased to 20.
