### PR TITLE
fix logback-767

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/StatusListenerConfigHelper.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/StatusListenerConfigHelper.java
@@ -39,16 +39,16 @@ public class StatusListenerConfigHelper {
       try {
         listener = (StatusListener) OptionHelper.instantiateByClassName(
             listenerClass, StatusListener.class, loggerContext);
-        if(listener instanceof ContextAware) // LOGBACK-767
-          ((ContextAware) listener).setContext(loggerContext);
-        if(listener instanceof LifeCycle)  // LOGBACK-767
-          ((LifeCycle) listener).start();
       } catch (Exception e) {
         // printing on the console is the best we can do
         e.printStackTrace();
       }
     }
     if (listener != null) {
+      if(listener instanceof ContextAware) // LOGBACK-767
+        ((ContextAware) listener).setContext(loggerContext);
+      if(listener instanceof LifeCycle)  // LOGBACK-767
+        ((LifeCycle) listener).start();
       loggerContext.getStatusManager().add(listener);
     }
   }


### PR DESCRIPTION
StatusListener has two instances OnConsoleStatusListener and instance by
 seted classname.
 The second be Judged that is ContextAware and LifeCycle's implement and start it.
 but The first is not to Judged.

 all StatusListener must be Judged and start it.
