### PR TITLE
LOGBACK-300: Fixed OSGi-Manifest

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -150,6 +150,20 @@
         <configuration>
           <instructions>
             <Export-Package>ch.qos.logback.access.*</Export-Package>
+            <!--
+                It is necessary to specify the rolling file packages as classes
+                are created via IOC (xml config files). They won't be found by
+                Bnd's analysis of java code.
+            -->
+            <Import-Package>
+                ch.qos.logback.core.rolling,
+                ch.qos.logback.core.rolling.helper,
+                javax.servlet.*;version="2.5",
+                javax.*;resolution:=optional,
+                org.apache.catalina.*;version="7.0.21";resolution:=optional,
+                org.eclipse.jetty.*;version="7.5.1";resolution:=optional,
+                *
+            </Import-Package>
             <Bundle-RequiredExecutionEnvironment>J2SE-1.5
             </Bundle-RequiredExecutionEnvironment>
           </instructions>


### PR DESCRIPTION
Added Import-Package for core.rolling and core.rolling.helper.

Imports of Jetty and Tomcat packages are optional as you normally can not satisify both (typically there is either Tomcat or Jetty present as OSGi web container).

The version constraints for Jetty and Tomcat packages are set to the minimum versions required to compile the logback-access module (currently Jetty 7.5.1 and Tomcat 7.0.21).
