### PR TITLE
LOGBACK-869: Marked rollover in RollingFileAppender#subAppend() as privileged

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
@@ -19,6 +19,8 @@ import ch.qos.logback.core.rolling.helper.FileNamePattern;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 import static ch.qos.logback.core.CoreConstants.CODES_URL;
 
@@ -160,16 +162,22 @@ public class RollingFileAppender<E> extends FileAppender<E> {
    * This method differentiates RollingFileAppender from its super class.
    */
   @Override
-  protected void subAppend(E event) {
+  protected void subAppend(final E event) {
     // The roll-over check must precede actual writing. This is the
     // only correct behavior for time driven triggers.
 
     // We need to synchronize on triggeringPolicy so that only one rollover
     // occurs at a time
     synchronized (triggeringPolicy) {
-      if (triggeringPolicy.isTriggeringEvent(currentlyActiveFile, event)) {
-        rollover();
-      }
+      AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @Override
+        public Void run() {
+          if (triggeringPolicy.isTriggeringEvent(currentlyActiveFile, event)) {
+            rollover();
+          }
+          return null;
+        }
+      });
     }
 
     super.subAppend(event);


### PR DESCRIPTION
Fixes the security issue reported by http://jira.qos.ch/browse/LOGBACK-869.
