### PR TITLE
Removes redundant and forever dangling connection

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/db/DataSourceConnectionSource.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/db/DataSourceConnectionSource.java
@@ -41,16 +41,7 @@ public class DataSourceConnectionSource extends ConnectionSourceBase {
     if (dataSource == null) {
       addWarn("WARNING: No data source specified");
     } else {
-      Connection connection = null;
-      try {
-        connection = getConnection();
-      } catch (SQLException se) {
-        addWarn("Could not get a connection to discover the dialect to use.",
-            se);
-      }
-      if (connection != null) {
-        discoverConnectionProperties();
-      }
+      discoverConnectionProperties();
       if (!supportsGetGeneratedKeys()
           && getSQLDialectCode() == SQLDialectCode.UNKNOWN_DIALECT) {
         addWarn("Connection does not support GetGeneratedKey method and could not discover the dialect.");


### PR DESCRIPTION
The DataSourceConnectionSource.start() method opens a new connection
only to determine whether or not the discoverConnectionProperties()
should be called. This is unnecessary since that method will perform
the same check and issue a very similar warning. A more serious
problem is that the connection is never closed.

This commit removes the use of this extra connection completely. I
think this is the last issue in need of a fix before LOGBACK-376 can
be closed.
