### PR TITLE
Fix for LOGBACK-873 - lazy format message

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
@@ -112,10 +112,9 @@ public class LoggingEvent implements ILoggingEvent {
 
     this.message = message;
 
-    FormattingTuple ft = MessageFormatter.arrayFormat(message, argArray);
-    formattedMessage = ft.getMessage();
 
     if (throwable == null) {
+      FormattingTuple ft = MessageFormatter.arrayFormat(null, argArray);
       argumentArray = ft.getArgArray();
       throwable = ft.getThrowable();
     } else {


### PR DESCRIPTION
Do not format message on construction of LoggingEvent, wait until getFormattedMessage() is called.  

Fixes http://jira.qos.ch/browse/LOGBACK-873. 
Re-fixes http://jira.qos.ch/browse/LOGBACK-495
