### PR TITLE
Fixing JNDI lookup of non-String entries

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/JNDIUtil.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/JNDIUtil.java
@@ -35,7 +35,7 @@ public class JNDIUtil {
       return null;
     }
     try {
-      return (String) ctx.lookup(name);
+      return ctx.lookup(name).toString();
     } catch (NamingException e) {
       return null;
     }


### PR DESCRIPTION
Casting fails for any entry type other then String.
Should be able to look up Boolean, for example.
