### PR TITLE
amendment for LOGBACK-644: suppress errors for nonexistent resource includes

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/IncludeAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/IncludeAction.java
@@ -154,9 +154,11 @@ public class IncludeAction extends Action {
   URL resourceAsURL(String resourceAttribute) {
     URL url = Loader.getResourceBySelfClassLoader(resourceAttribute);
     if (url == null) {
-      String errMsg = "Could not find resource corresponding to ["
-              + resourceAttribute + "]";
-      addError(errMsg);
+      if (!optional) {
+        String errMsg = "Could not find resource corresponding to ["
+                + resourceAttribute + "]";
+        addError(errMsg);
+      }
       return null;
     } else
       return url;

--- a/logback-core/src/test/input/joran/inclusion/topOptionalResource.xml
+++ b/logback-core/src/test/input/joran/inclusion/topOptionalResource.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE x>
+
+<x>
+  <include optional="true" resource="nonExistentResource.xml" />
+
+  <stack name="IA"/>
+  <stack name="IB"/>
+</x>

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/action/IncludeActionTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/action/IncludeActionTest.java
@@ -62,6 +62,8 @@ public class IncludeActionTest {
 
   static final String TOP_OPTIONAL = INCLUSION_DIR_PREFIX + "topOptional.xml";
 
+  static final String TOP_OPTIONAL_RESOURCE = INCLUSION_DIR_PREFIX + "topOptionalResource.xml";
+
   static final String INTERMEDIARY_FILE = INCLUSION_DIR_PREFIX
       + "intermediaryByFile.xml";
 
@@ -122,6 +124,14 @@ public class IncludeActionTest {
     tc.doConfigure(TOP_OPTIONAL);
     verifyConfig(new String[] { "IA", "IB" });
     StatusPrinter.print(context);
+  }
+
+  @Test
+  public void optionalResource() throws JoranException {
+    tc.doConfigure(TOP_OPTIONAL_RESOURCE);
+    verifyConfig(new String[] { "IA", "IB" });
+    StatusPrinter.print(context);
+    assertEquals(Status.INFO, statusChecker.getHighestLevel(0));
   }
 
   @Test


### PR DESCRIPTION
Nonexistent resources would still generate errors when included with attribute "optional" set to true.
This patch addresses this issue.
Unit test is included.
