### PR TITLE
LOGBACK-384 - IllegalArgumentException for logger name with mixed '.' and '$'

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LoggerNameUtil.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LoggerNameUtil.java
@@ -13,10 +13,10 @@
  */
 package ch.qos.logback.classic.util;
 
+import ch.qos.logback.core.CoreConstants;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import ch.qos.logback.core.CoreConstants;
 
 /**
  * Utility class for analysing logger names.
@@ -37,12 +37,14 @@ public class LoggerNameUtil {
    * @return
    */
   public static int getSeparatorIndexOf(String name, int fromIndex) {
-      int dotIndex = name.indexOf(CoreConstants.DOT, fromIndex);
-      int dollarIndex = name.indexOf(CoreConstants.DOLLAR, fromIndex);
-      if (dotIndex == -1 && dollarIndex == -1) return -1;
-      if (dotIndex == -1) return dollarIndex;
-      if (dollarIndex == -1) return dotIndex;
-      return dotIndex < dollarIndex ? dotIndex : dollarIndex;
+    int dotIndex = name.indexOf(CoreConstants.DOT, fromIndex);
+    int dollarIndex = name.indexOf(CoreConstants.DOLLAR, fromIndex);
+
+    if (dotIndex == -1 && dollarIndex == -1) return -1;
+    if (dotIndex == -1) return dollarIndex;
+    if (dollarIndex == -1) return dotIndex;
+
+    return dotIndex < dollarIndex ? dotIndex : dollarIndex;
   }
 
   public static List<String> computeNameParts(String loggerName) {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/LoggerNameUtilTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/LoggerNameUtilTest.java
@@ -13,10 +13,10 @@
  */
 package ch.qos.logback.classic.util;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
Fixing the logic to treat '$' and '.' at same level as per comment [1]. Also adding a testcase

[1] http://jira.qos.ch/browse/LOGBACK-384?focusedCommentId=13105&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13105
