### PR TITLE
LOGBACK-320.   Added request duration to the AccessEvent. 

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -50,6 +50,13 @@
       <optional>true</optional>
     </dependency>
 
+      <dependency>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-coyote</artifactId>
+          <scope>compile</scope>
+          <optional>true</optional>
+      </dependency>
+
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>

--- a/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
@@ -14,8 +14,6 @@
 package ch.qos.logback.access.jetty;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -43,7 +41,6 @@ import ch.qos.logback.core.spi.FilterAttachable;
 import ch.qos.logback.core.spi.FilterAttachableImpl;
 import ch.qos.logback.core.spi.FilterReply;
 import ch.qos.logback.core.status.ErrorStatus;
-import ch.qos.logback.core.status.WarnStatus;
 import ch.qos.logback.core.util.OptionHelper;
 
 /**
@@ -132,10 +129,14 @@ public class RequestLogImpl extends ContextBase implements RequestLog,
   }
 
   public void log(Request jettyRequest, Response jettyResponse) {
-    JettyServerAdapter adapter = new JettyServerAdapter(jettyRequest,
+      long now = System.currentTimeMillis();
+      
+      long duration = now - jettyRequest.getTimeStamp();
+
+      JettyServerAdapter adapter = new JettyServerAdapter(jettyRequest,
             jettyResponse);
     IAccessEvent accessEvent = new AccessEvent(jettyRequest, jettyResponse,
-            adapter);
+            adapter, duration);
     if (getFilterChainDecision(accessEvent) == FilterReply.DENY) {
       return;
     }

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -78,15 +78,22 @@ public class AccessEvent implements Serializable, IAccessEvent {
    */
   private long timeStamp = 0;
 
-  public AccessEvent(HttpServletRequest httpRequest,
-      HttpServletResponse httpResponse, ServerAdapter adapter) {
-    this.httpRequest = httpRequest;
-    this.httpResponse = httpResponse;
-    this.timeStamp = System.currentTimeMillis();
-    this.serverAdapter = adapter;
-  }
+    /**
+     * The number of milliseconds elapsed from the inception of the request until the creation of the log event.
+     */
+    private long duration = 0;
 
-  /**
+    public AccessEvent(HttpServletRequest httpRequest,
+                       HttpServletResponse httpResponse, ServerAdapter adapter, long duration) {
+        this.httpRequest = httpRequest;
+        this.httpResponse = httpResponse;
+        this.timeStamp = System.currentTimeMillis();
+        this.serverAdapter = adapter;
+
+        this.duration = duration;
+    }
+
+    /**
    * Returns the underlying HttpServletRequest. After serialization the returned 
    * value will be null. 
    * 
@@ -222,6 +229,10 @@ public class AccessEvent implements Serializable, IAccessEvent {
     }
     return remoteAddr;
   }
+
+    public long getRequestDuration() {
+        return duration;
+    }
 
   public String getRequestHeader(String key) {
     String result = null;

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
@@ -79,6 +79,8 @@ public interface IAccessEvent extends DeferredProcessingAware {
 
   String getRemoteAddr();
 
+  long getRequestDuration();
+
   String getRequestHeader(String key);
 
   Enumeration getRequestHeaderNames();

--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
@@ -177,8 +177,12 @@ public class LogbackValve extends ValveBase implements Lifecycle, Context,
 
       getNext().invoke(request, response);
 
-      TomcatServerAdapter adapter = new TomcatServerAdapter(request, response);
-      IAccessEvent accessEvent = new AccessEvent(request, response, adapter);
+      long now = System.currentTimeMillis();
+
+      long duration = now - request.getCoyoteRequest().getStartTime();
+
+        TomcatServerAdapter adapter = new TomcatServerAdapter(request, response);
+      IAccessEvent accessEvent = new AccessEvent(request, response, adapter, duration);
 
       if (getFilterChainDecision(accessEvent) == FilterReply.DENY) {
         return;

--- a/logback-access/src/test/java/ch/qos/logback/access/boolex/JaninoEventEvaluatorTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/boolex/JaninoEventEvaluatorTest.java
@@ -52,7 +52,7 @@ public class JaninoEventEvaluatorTest {
   public void smoke() throws EvaluationException {
     evaluator.setExpression("event.getProtocol().equals(\"testProtocol\")");
     evaluator.start();
-    IAccessEvent ae = new AccessEvent(request, response, serverAdapter);
+    IAccessEvent ae = new AccessEvent(request, response, serverAdapter, 100);
     assertTrue( evaluator.evaluate(ae));
   }
 
@@ -61,7 +61,7 @@ public class JaninoEventEvaluatorTest {
     evaluator.setExpression("String protocol = event.getProtocol();" +
             "return protocol.equals(\"testProtocol\");");
     evaluator.start();
-    IAccessEvent ae = new AccessEvent(request, response, serverAdapter);
+    IAccessEvent ae = new AccessEvent(request, response, serverAdapter, 100);
     assertTrue(evaluator.evaluate(ae));
   }
 
@@ -69,7 +69,7 @@ public class JaninoEventEvaluatorTest {
   public void invalidExpression() throws EvaluationException {
     evaluator.setExpression("return true");
     evaluator.start();
-    IAccessEvent ae = new AccessEvent(request, response, serverAdapter);
+    IAccessEvent ae = new AccessEvent(request, response, serverAdapter, 100);
    try {
      evaluator.evaluate(ae);
      fail("Was expecting an exception");

--- a/logback-access/src/test/java/ch/qos/logback/access/db/DBAppenderHSQLTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/db/DBAppenderHSQLTest.java
@@ -219,6 +219,6 @@ public class DBAppenderHSQLTest {
     DummyResponse response = new DummyResponse();
     DummyServerAdapter adapter = new DummyServerAdapter(request, response);
 
-    return new AccessEvent(request, response, adapter);
+    return new AccessEvent(request, response, adapter, 100);
   }
 }

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyAccessEventBuilder.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyAccessEventBuilder.java
@@ -24,7 +24,7 @@ public class DummyAccessEventBuilder {
     DummyResponse response = new DummyResponse();
     DummyServerAdapter adapter = new DummyServerAdapter(request, response);
     
-    return new AccessEvent(request, response, adapter);
+    return new AccessEvent(request, response, adapter, 100);
   }
   
 }

--- a/logback-access/src/test/java/ch/qos/logback/access/net/URLEvaluatorTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/net/URLEvaluatorTest.java
@@ -62,14 +62,14 @@ public class URLEvaluatorTest  {
   @Test
   public void testExpectFalse() throws EvaluationException {
     request.setRequestUri("test");
-    IAccessEvent ae = new AccessEvent(request, response, serverAdapter);
+    IAccessEvent ae = new AccessEvent(request, response, serverAdapter, 100);
     assertFalse(evaluator.evaluate(ae));
   }
   
   @Test
   public void testExpectTrue() throws EvaluationException {
     request.setRequestUri(expectedURL1);   
-    IAccessEvent ae = new AccessEvent(request, response, serverAdapter);
+    IAccessEvent ae = new AccessEvent(request, response, serverAdapter, 100);
     assertTrue(evaluator.evaluate(ae));    
   }
   
@@ -77,7 +77,7 @@ public class URLEvaluatorTest  {
   public void testExpectTrueMultiple() throws EvaluationException {
     evaluator.addURL(expectedURL2);
     request.setRequestUri(expectedURL2);    
-    IAccessEvent ae = new AccessEvent(request, response, serverAdapter);
+    IAccessEvent ae = new AccessEvent(request, response, serverAdapter, 100);
     assertTrue(evaluator.evaluate(ae));    
   }
 }

--- a/logback-access/src/test/java/ch/qos/logback/access/pattern/ConverterTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/pattern/ConverterTest.java
@@ -194,7 +194,7 @@ public class ConverterTest  {
 
   private IAccessEvent createEvent() {
     DummyServerAdapter dummyAdapter = new DummyServerAdapter(request, response);
-    return new AccessEvent(request, response, dummyAdapter);
+    return new AccessEvent(request, response, dummyAdapter, 100);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,12 @@
         <version>${tomcat.version}</version>
       </dependency>
 
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-coyote</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>


### PR DESCRIPTION
In order to populate this data, I needed to modify both the tomcat and jetty infrastructure classes to calculate the time for the request duration. Multiple tests were updated as well to make use of the new constructor that takes a duration.
