### PR TITLE
always close jdbc Statement/ResultSet in finally

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/db/DBAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/db/DBAppender.java
@@ -104,7 +104,7 @@ public class DBAppender extends DBAppenderBase<IAccessEvent> {
     Enumeration names = event.getRequestHeaderNames();
     if (names.hasMoreElements()) {
       PreparedStatement insertHeaderStatement = connection
-          .prepareStatement(insertHeaderSQL);
+        .prepareStatement(insertHeaderSQL);
 
       
       while (names.hasMoreElements()) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
@@ -13,12 +13,13 @@
  */
 package ch.qos.logback.classic.db;
 
+import static ch.qos.logback.core.db.DBHelper.closeStatement;
+
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -215,10 +216,10 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     if (propertiesKeys.size() > 0) {
       PreparedStatement insertPropertiesStatement = null;
       try {
-          insertPropertiesStatement = connection
-              .prepareStatement(insertPropertiesSQL);
+        insertPropertiesStatement = connection
+          .prepareStatement(insertPropertiesSQL);
 
-      for (String key : propertiesKeys) {
+        for (String key : propertiesKeys) {
           String value = mergedMap.get(key);
 
           insertPropertiesStatement.setLong(1, eventId);
@@ -236,7 +237,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
           insertPropertiesStatement.executeBatch();
         }
       } finally {
-        ch.qos.logback.core.db.DBHelper.closeStatement(insertPropertiesStatement);
+        closeStatement(insertPropertiesStatement);
       }
     }
   }
@@ -305,7 +306,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
         exceptionStatement.executeBatch();
       }
     } finally {
-      ch.qos.logback.core.db.DBHelper.closeStatement(exceptionStatement);
+      closeStatement(exceptionStatement);
     }
 
   }

--- a/logback-core/src/main/java/ch/qos/logback/core/db/DBAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/db/DBAppenderBase.java
@@ -162,7 +162,12 @@ public abstract class DBAppenderBase<E> extends UnsynchronizedAppenderBase<E> {
       long eventId = rs.getLong(1);
       return eventId;
     } finally {
-      if (rs!=null) try {rs.close();} catch (Exception e) {}
+      if (rs!=null) {
+        try {
+          rs.close();
+        } catch (SQLException e) {
+        }
+      }
       DBHelper.closeStatement(idStatement);
     }
   }


### PR DESCRIPTION
I'm use logback DBAppender with pooled Oracle connection.
When logger failed to insert rows (by some reason): cursor was not closed.
And after some time, all calls to pooled conneciton return error: `ORA-01000: maximum open cursors exceeded`
