### PR TITLE
LOGBACK-350 Prevent SocketNode constructor blocking due to lack of data from client

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketNode.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketNode.java
@@ -72,6 +72,7 @@ public class SocketNode implements Runnable {
           .getInputStream()));
     } catch (Exception e) {
       logger.error("Could not open ObjectInputStream to " + socket, e);
+      closed = true;
     }
 
     ILoggingEvent event;


### PR DESCRIPTION
The constructor creates an ObjectInputStream, and this blocks until the stream header is received from the client.

If the client doesn't send a stream header, construction of the SocketNode will hang, preventing SimpleSocketServer from accepting new clients.

This change moves the construction of the ObjectInputStream into SocketNode.run. As SimpleSocketServer runs this method in a new thread, a rogue client won't prevent subsequent ones being able to connect.
