### PR TITLE
Update SyslogAppenderTest to explicitly set maximum syslog message size (for test stability)

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SyslogAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SyslogAppenderTest.java
@@ -16,6 +16,7 @@ package ch.qos.logback.classic.net;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.net.DatagramSocket;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -182,7 +183,7 @@ public class SyslogAppenderTest {
   }
 
   @Test
-  public void large() throws InterruptedException {
+  public void large() throws Exception {
     setMockServerAndConfigure(2);
     StringBuilder largeBuf = new StringBuilder();
     for (int i = 0; i < 2 * 1024 * 1024; i++) {
@@ -198,19 +199,20 @@ public class SyslogAppenderTest {
     mockServer.join(8000);
     assertTrue(mockServer.isFinished());
  
-   // both messages received
+    // both messages received
     assertEquals(2, mockServer.getMessageList().size());
 
-   String expected = "<"
+    String expected = "<"
         + (SyslogConstants.LOG_MAIL + SyslogConstants.DEBUG_SEVERITY) + ">";
     String expectedPrefix = "<\\d{2}>\\w{3} \\d{2} \\d{2}(:\\d{2}){2} [\\w.-]* ";
     String threadName = Thread.currentThread().getName();
 
     // large message is truncated
+    final int maxDatagramSize = new DatagramSocket().getSendBufferSize();
     String largeMsg = mockServer.getMessageList().get(0);
     assertTrue(largeMsg.startsWith(expected));
     String largeRegex = expectedPrefix + "\\[" + threadName + "\\] " + loggerName
-        + " " + "a{64000,66000}";
+        + " " + "a{" + (maxDatagramSize - 2000) + "," + maxDatagramSize + "}";
     checkRegexMatch(largeMsg, largeRegex);
 
     String msg = mockServer.getMessageList().get(1);

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java
@@ -40,7 +40,7 @@ public abstract class SyslogAppenderBase<E> extends AppenderBase<E> {
   protected String suffixPattern;
   SyslogOutputStream sos;
   int port = SyslogConstants.SYSLOG_PORT;
-  int maxMessageSize = 65000;
+  int maxMessageSize;
 
   public void start() {
     int errorCount = 0;
@@ -51,6 +51,15 @@ public abstract class SyslogAppenderBase<E> extends AppenderBase<E> {
 
     try {
       sos = new SyslogOutputStream(syslogHost, port);
+
+      final int systemDatagramSize = sos.getSendBufferSize();
+      if (maxMessageSize == 0) {
+        addInfo("Defaulting maxMessageSize to system datagram size of [" + systemDatagramSize + "]");
+        maxMessageSize = systemDatagramSize;
+      } else if (maxMessageSize > systemDatagramSize) {
+        addWarn("maxMessageSize of [" + maxMessageSize + "] is larger than the system defined datagram size of [" + systemDatagramSize + "].");
+        addWarn("This may result in dropped logs.");
+      }
     } catch (UnknownHostException e) {
       addError("Could not create SyslogWriter", e);
       errorCount++;

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -87,4 +87,7 @@ public class SyslogOutputStream extends OutputStream {
     baos.write(b);
   }
 
+  int getSendBufferSize() throws SocketException {
+    return ds.getSendBufferSize();
+  }
 }


### PR DESCRIPTION
While trying to run the unit tests on my FreeBSD system, there was a failure:

```
java.lang.AssertionError: The string [<23>Nov 15 21:50:41 qk.local [main] ch.qos.logback.classic.net.SyslogAppenderTest hello] did not match regex [<\d{2}>\w{3} \d{2} \d{2}(:\d{2}){2} [\w.-]* \[main\] ch.qos.logback.classic.net.SyslogAppenderTest a{64000,66000}]
```

I found that it was due to FreeBSD's maximum UDP datagram size being 9216 bytes by default. The `SyslogAppender` uses a default of `65000`, which works fine for Linux systems. 

It seemed prudent to utilize the SyslogAppender option to explicitly set the maximum size of a message and then update the test accordingly. This also becomes the first test to cover `SyslogAppender.setMaxMessageSize()` and it should make the test more stable for different environments.
