### PR TITLE
Cleanup HTML syntax issues in manual (e.g., extraneous tags)

### DIFF
--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -42,7 +42,7 @@
     <script src="../templates/creative.js" type="text/javascript"></script>
     <script src="../templates/setup.js" type="text/javascript"></script>
     
-    <h2 class=class="doAnchor" name="whatIsAnAppender">What is an Appender?</h2>
+    <h2 class="doAnchor" name="whatIsAnAppender">What is an Appender?</h2>
     
 		<p>Logback delegates the task of writing a logging event to
 		components called appenders.  Appenders must implement the <a
@@ -4115,7 +4115,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
 		
 		<p>The <a href="../xref/ch/qos/logback/access/net/SSLSocketAppender.html">
     <code>SSLSocketAppender</code></a> extends the basic 
-    <code>SocketAppender</code></a> allowing logging to a remote entity over 
+    <code>SocketAppender</code> allowing logging to a remote entity over
     the Secure Sockets Layer (SSL).
     </p>
     
@@ -4140,7 +4140,7 @@ public class CountingConsoleAppender extends AppenderBase&lt;ILoggingEvent> {
     
     <p>The <a href="../xref/ch/qos/logback/access/net/server/SSLServerSocketAppender.html">
     <code>SSLSocketAppender</code></a> extends the basic 
-    <code>ServerSocketAppender</code></a> allowing logging to a remote entity 
+    <code>ServerSocketAppender</code> allowing logging to a remote entity
     over the Secure Sockets Layer (SSL).
     </p>
     

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -1939,7 +1939,7 @@ java.lang.Exception: display
   &lt;/root>
 &lt;/configuration> </pre>
     
-		<h1 class="doAnchor" name="logback-access">Logback access</a></h1>
+		<h1 class="doAnchor" name="logback-access">Logback access</h1>
 
 		<p>Most logback-access layouts are mere adaptations of
 		logback-classic layouts. Logback-classic and logback-access

--- a/logback-site/src/site/pages/manual/receivers.html
+++ b/logback-site/src/site/pages/manual/receivers.html
@@ -427,7 +427,7 @@
       <span class="prop">reconnectionDelay</span> property as shown in the
       example configuration.<p class="source">java -Dhost=localhost -Dport=6000 \
       chapters.receivers.socket.ReceiverExample \
-      src/main/java/chapters/receivers/socket/receiver3.xml</p></p>
+      src/main/java/chapters/receivers/socket/receiver3.xml</p>
 
       <p>We can provide a remote appender to which our example receiver
       can connect, using the same appender example used previously.  The 


### PR DESCRIPTION
This pull request fixes a few minor HTML syntax issues in the manual. These issues were minor enough that browsers likely rendered the pages properly.
- Extraneous </a> or </p> tags
- mistype with class attribute

(Issues were identified with IntelliJ Inspection)
