### PR TITLE
Fix some typos in manual

### DIFF
--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -503,7 +503,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
    <p><span class="label notice">Immediate Flush</span> By default,
    each log event is immediately flushed to the underlying output
    stream. This default approach is safer in the sense that logging
-   events are not lost in case your applicaiton exits without properly
+   events are not lost in case your application exits without properly
    closing appenders. However, for significantly increased logging
    throughput, you may want to set the <span
    class="prop">immediateFlush</span> property of the underlying
@@ -3939,7 +3939,7 @@ import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
     
     <p><span class="label notice">Lossy behavior</span> In light of
     the discussion above and in order to reduce blocking, by default,
-    when less than 20% of the queue capacilty remains,
+    when less than 20% of the queue capacity remains,
     <code>AsyncAppender</code> will drop events of level TRACE, DEBUG
     and INFO keeping only events of level WARN and ERROR. This
     strategy ensures non-blocking handling of logging events (hence

--- a/logback-site/src/site/pages/manual/groovy.html
+++ b/logback-site/src/site/pages/manual/groovy.html
@@ -94,7 +94,7 @@
     <h2 class="doAnchor">Automatic imports</h2>
 
     <p><span class="label">Since 1.0.10</span> In order to reduce
-    unnecessary boilerplace several common types and packages are
+    unnecessary boilerplate several common types and packages are
     imported automatically.  Thus, as long as you are only configuring
     built-in appenders, layouts etc. you do not need to add the
     corresponding import statement into your script. You will need
@@ -192,7 +192,7 @@
 
   <pre class="prettyprint source">logger("com.foo", DEBUG, ["CONSOLE"])</pre>
     
-   <p>The next script is similiar to the previous one, except that it
+   <p>The next script is similar to the previous one, except that it
    also sets the the additivity flag of the "com.foo" logger to
    false.</p>
 

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -1051,7 +1051,7 @@ Wrapped by: org.springframework.BeanCreationException: Error creating bean with 
 
          <p>The %rootException converter admits the same optional
          parameters as the %xException converter described above,
-         including depth and eveluators. It outputs also packaging
+         including depth and evaluators. It outputs also packaging
          information. In short, %rootException is very similar to
          %xException, only the order of exception output is reversed.
          </p>

--- a/logback-site/src/site/pages/manual/usingSSL.html
+++ b/logback-site/src/site/pages/manual/usingSSL.html
@@ -164,7 +164,7 @@
         <tr>
           <td><code>javax.net.ssl.keyStore</code></td>
           <td>Specifies a filesystem path to the file containing your
-              server components's private key and certificate.</td>
+              server components' private key and certificate.</td>
         </tr>
         <tr>
           <td><code>javax.net.ssl.keyStoreType</code></td>
@@ -654,7 +654,7 @@
           <td><code>String</code></td>
           <td>
             <p>Specifies a comma-separated list of SSL cipher spec names or
-               patterns to disable during session negotation.  This property is 
+               patterns to disable during session negotiation.  This property is
                used to filter the cipher suites supported by the SSL engine, 
                such that any cipher spec matched by this property is disabled.
             </p>
@@ -674,7 +674,7 @@
           <td><code>String</code></td>
           <td>
             <p>Specifies a comma-separated list of SSL cipher spec names or
-               patterns to enable during session negotation.  This property is 
+               patterns to enable during session negotiation.  This property is
                used to filter the cipher suites supported by the SSL engine, 
                such that only those cipher suites matched by this property are 
                enabled.
@@ -695,7 +695,7 @@
           <td><code>String</code></td>
           <td>
             <p>Specifies a comma-separated list of SSL protocol names or
-               patterns to disable during session negotation.  This property is 
+               patterns to disable during session negotiation.  This property is
                used to filter the protocols supported by the SSL engine, 
                such that any protocol matched by this property is disabled.
             </p>
@@ -715,7 +715,7 @@
           <td><code>String</code></td>
           <td>
             <p>Specifies a comma-separated list of SSL protocol names or
-               patterns to enable during session negotation.  This property is 
+               patterns to enable during session negotiation.  This property is
                used to filter the protocols supported by the SSL engine, 
                such that only those protocols matched by this property are 
                enabled.

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -511,7 +511,7 @@
     in <code><a
     href="manual/appenders.html#smtpIncludeCallerData">SMTPAppender</a></code>
     to precompute caller data before storing events for future
-    transmission. This property adresses <a
+    transmission. This property addresses <a
     href="http://jira.qos.ch/browse/LOGBACK-734">LOGBACK-734</a>
     reported by Patrick Hogarty.
     </p>

--- a/logback-site/src/site/pages/setup.html
+++ b/logback-site/src/site/pages/setup.html
@@ -164,7 +164,7 @@
    a Groovy-based configurator so there is a dependency on the Groovy
    language. It follows that your IDE should have plugins for Maven
    and Groovy in order to <em>build</em> logback from your within
-   IDE. The Groovy dependecy just mentioned is a <em>build-time</em>
+   IDE. The Groovy dependency just mentioned is a <em>build-time</em>
    dependency. The only mandatory logback dependency at runrime is the
    JRE, unless of course you wish to use the Groovy configurator in
    which case Groovy runtime will be a required dependency as

--- a/logback-site/src/site/pages/volunteer.html
+++ b/logback-site/src/site/pages/volunteer.html
@@ -60,7 +60,7 @@
 
       <p>The Groovy configurator, aka Gaffer, although pretty cool, is
       not getting the attention it deserves. The amount of code
-      involved, altough not completely trivial, is far from
+      involved, although not completely trivial, is far from
       insurmountable. We are looking for a volunteer to take over
       Gaffer.
        </p>


### PR DESCRIPTION
This pull request fixes a few small typos in the manual (and one in news.html)
