### PR TITLE
LOGBACK-927 Update logback-access Common Log Format to use MMM rather than MM for month

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -56,7 +56,7 @@ public class CoreConstants {
   /**
    * Time format used in Common Log Format
    */
-  public static final String CLF_DATE_PATTERN = "dd/MM/yyyy:HH:mm:ss Z";
+  public static final String CLF_DATE_PATTERN = "dd/MMM/yyyy:HH:mm:ss Z";
 
   /**
    * The key used in locating the evaluator map in context's object map.

--- a/logback-site/src/site/pages/demo.html
+++ b/logback-site/src/site/pages/demo.html
@@ -354,18 +354,18 @@
 
 <p>Here is a sample output for this appender.</p>
 
-<div class="source"><pre>127.0.0.1 - - 22/01/2007:14:35:40 +0100 GET /logback-demo/ViewStatii.do HTTP/1.1 200 3660
-127.0.0.1 - - 22/01/2007:14:35:41 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
-127.0.0.1 - - 22/01/2007:14:35:42 +0100 GET /logback-demo/lastLog/ HTTP/1.1 200 948
-127.0.0.1 - - 22/01/2007:14:35:42 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
-127.0.0.1 - - 22/01/2007:14:35:43 +0100 GET /logback-demo/prime.jsp HTTP/1.1 200 1296
-127.0.0.1 - - 22/01/2007:14:35:44 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
-127.0.0.1 - - 22/01/2007:14:35:45 +0100 GET /logback-demo/lottery.jsp HTTP/1.1 200 1209
-127.0.0.1 - - 22/01/2007:14:35:46 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
-127.0.0.1 - - 22/01/2007:14:35:48 +0100 GET /logback-demo/reload.jsp HTTP/1.1 200 1335
-127.0.0.1 - - 22/01/2007:14:35:49 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
-127.0.0.1 - - 22/01/2007:14:35:54 +0100 GET /logback-demo/login.jsp HTTP/1.1 200 1214
-127.0.0.1 - - 22/01/2007:14:35:55 +0100 GET /logback-demo/Logout.do HTTP/1.1 200 1000</pre></div>
+<div class="source"><pre>127.0.0.1 - - 22/Jan/2007:14:35:40 +0100 GET /logback-demo/ViewStatii.do HTTP/1.1 200 3660
+127.0.0.1 - - 22/Jan/2007:14:35:41 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
+127.0.0.1 - - 22/Jan/2007:14:35:42 +0100 GET /logback-demo/lastLog/ HTTP/1.1 200 948
+127.0.0.1 - - 22/Jan/2007:14:35:42 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
+127.0.0.1 - - 22/Jan/2007:14:35:43 +0100 GET /logback-demo/prime.jsp HTTP/1.1 200 1296
+127.0.0.1 - - 22/Jan/2007:14:35:44 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
+127.0.0.1 - - 22/Jan/2007:14:35:45 +0100 GET /logback-demo/lottery.jsp HTTP/1.1 200 1209
+127.0.0.1 - - 22/Jan/2007:14:35:46 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
+127.0.0.1 - - 22/Jan/2007:14:35:48 +0100 GET /logback-demo/reload.jsp HTTP/1.1 200 1335
+127.0.0.1 - - 22/Jan/2007:14:35:49 +0100 GET /logback-demo/index.jsp HTTP/1.1 200 2389
+127.0.0.1 - - 22/Jan/2007:14:35:54 +0100 GET /logback-demo/login.jsp HTTP/1.1 200 1214
+127.0.0.1 - - 22/Jan/2007:14:35:55 +0100 GET /logback-demo/Logout.do HTTP/1.1 200 1000</pre></div>
 
   <h4>Filtering</h4>
 

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -2075,13 +2075,13 @@ java.lang.Exception: display
           <p>Outputs the date of the logging event.  The date
           conversion specifier may be followed by a set of braces
           containing a date and time pattern strings used by
-          <code>java.text.SimpleDateFormat</code>.  <em>ABSOLUTE</em>,
-          <em>DATE</em> or <em>ISO8601</em> are also valid values.
+          <code>java.text.SimpleDateFormat</code>.  <em>ISO8601</em>
+          is also a valid value.
 					</p>
-					<p>For example, <b>%d{HH:mm:ss,SSS}</b>,
-					<b>%d{dd&#160;MMM&#160;yyyy&#160;;HH:mm:ss,SSS}</b> or
-					<b>%d{DATE}</b>.  If no date format specifier is given then
-					ISO8601 format is assumed.
+					<p>For example, <b>%t{HH:mm:ss,SSS}</b> or
+					<b>%t{dd&nbsp;MMM&nbsp;yyyy&nbsp;;HH:mm:ss,SSS}</b>.
+					If no date format specifier is given then the
+					Common Log Format date format is assumed, that is: <b>%t{dd/MMM/yyyy:HH:mm:ss&nbsp;Z}</b>
 					</p>
         </td>
       </tr>


### PR DESCRIPTION
LOGBACK-927
- Updates the default Common Log Format date for logback-access to include the 3-character abbreviated month, rather than digits. This format should now conform to the CLF format [defined by apache httpd](https://httpd.apache.org/docs/trunk/logs.html#common)
- Updates issues in the documentation for the logback-access PatternLayout:
  - Default date format is now defined as CLF (rather than ISO8601)
  - Removed references to magic strings `ABSOLUTE`, `DATE`, which aren't valid
  - Updated date specifiers to be %t rather than %d
