### PR TITLE
LOGBACK-802 Documentation: Use JQuery for trim() so that pages work in IE8 and other old browsers

### DIFF
--- a/logback-site/src/site/pages/js/decorator.js
+++ b/logback-site/src/site/pages/js/decorator.js
@@ -93,9 +93,8 @@ function capitaliseFirstLetter(str) {
 
 
 function camelCase(str) {  
-  var res = str.trim().replace(/\s\w/g, function(match) {
-              return match.trim().toUpperCase();
-            });
-  return res;
+  return $.trim(str).replace(/\s\w/g, function(match) {
+    return $.trim(match).toUpperCase();
+  });
 }
 


### PR DESCRIPTION
LOGBACK-802

`decorator.js` adds anchor markup to elements dynamically using `String.trim()`. This does [not work in IE8](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Browser_compatibility). Switching to JQuery's trim() utility handles this browser issue.

`decorator.js` already requires JQuery (it makes use of that same `$.trim` method elsewhere in the file)
