### PR TITLE
Limit the maximumMessageSize for SyslogAppender to be 65000

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SyslogAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SyslogAppenderTest.java
@@ -16,7 +16,6 @@ package ch.qos.logback.classic.net;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.net.DatagramSocket;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -208,11 +207,11 @@ public class SyslogAppenderTest {
     String threadName = Thread.currentThread().getName();
 
     // large message is truncated
-    final int maxDatagramSize = new DatagramSocket().getSendBufferSize();
+    final int maxMessageSize = sa.getMaxMessageSize();
     String largeMsg = mockServer.getMessageList().get(0);
     assertTrue(largeMsg.startsWith(expected));
     String largeRegex = expectedPrefix + "\\[" + threadName + "\\] " + loggerName
-        + " " + "a{" + (maxDatagramSize - 2000) + "," + maxDatagramSize + "}";
+        + " " + "a{" + (maxMessageSize - 2000) + "," + maxMessageSize + "}";
     checkRegexMatch(largeMsg, largeRegex);
 
     String msg = mockServer.getMessageList().get(1);

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java
@@ -33,6 +33,7 @@ public abstract class SyslogAppenderBase<E> extends AppenderBase<E> {
 
   final static String SYSLOG_LAYOUT_URL = CoreConstants.CODES_URL
       + "#syslog_layout";
+  final static int MAX_MESSAGE_SIZE_LIMIT = 65000;
 
   Layout<E> layout;
   String facilityStr;
@@ -54,8 +55,8 @@ public abstract class SyslogAppenderBase<E> extends AppenderBase<E> {
 
       final int systemDatagramSize = sos.getSendBufferSize();
       if (maxMessageSize == 0) {
-        addInfo("Defaulting maxMessageSize to system datagram size of [" + systemDatagramSize + "]");
-        maxMessageSize = systemDatagramSize;
+        maxMessageSize = Math.min(systemDatagramSize, MAX_MESSAGE_SIZE_LIMIT);
+        addInfo("Defaulting maxMessageSize to [" + maxMessageSize + "]");
       } else if (maxMessageSize > systemDatagramSize) {
         addWarn("maxMessageSize of [" + maxMessageSize + "] is larger than the system defined datagram size of [" + systemDatagramSize + "].");
         addWarn("This may result in dropped logs.");


### PR DESCRIPTION
The `SyslogAppenderTest#large()` test has been failing on the [Jenkins CI server](https://logback.ci.cloudbees.com/job/logback/) since 455bb2dec289878291eb2879ed5dd0ad84d5d0e9. It appears that the EC2 host running the tests has its `net.core.wmem_default` sysctl set to `229376`, meaning that the autodetection code from that commit was setting the maximum message size to 112k. This value is larger than the size of a UDP datagram, meaning that the log message would be lost in this situation.

This pull request alters the previous max message size detection code to place an upper limit on the option to be 65000 bytes. This is the value that was in place prior to 455bb2dec289878291eb2879ed5dd0ad84d5d0e9.
