### PR TITLE
LOGBACK-466 Documentation: Fix syntax issues with GEventEvaluator example

### DIFF
--- a/logback-site/src/site/pages/manual/filters.html
+++ b/logback-site/src/site/pages/manual/filters.html
@@ -318,9 +318,8 @@ public class SampleFilter extends Filter&gt;ILoggingEvent> {
     <b>&lt;filter class="ch.qos.logback.core.filter.EvaluatorFilter">      
       &lt;evaluator class="ch.qos.logback.classic.boolex.GEventEvaluator"> 
         &lt;expression>
-           e.level.toInt() >= WARN.toInt()
-             &amp;amp;&amp;amp;  &lt;!-- Stands for &amp;&amp; in XML -->
-           !(e.mdc?.get("req.userAgent") ~= /Googlebot|msnbot|Yahoo/ )
+           e.level.toInt() >= WARN.toInt() &amp;amp;&amp;amp;  &lt;!-- Stands for &amp;&amp; in XML -->
+           !(e.mdc?.get("req.userAgent") =~ /Googlebot|msnbot|Yahoo/ )
         &lt;/expression>
       &lt;/evaluator>
       &lt;OnMismatch>DENY&lt;/OnMismatch>


### PR DESCRIPTION
The [GEventEvaluator example in the documentation](http://logback.qos.ch/manual/filters.html#GEventEvaluator) has two syntax errors:
- `=~` should be used for a regex comparison with groovy, not `~=`
- the `&&` on the line by itself is not valid groovy and causes the example to fail

I was investigating [LOGBACK-466](http://jira.qos.ch/browse/LOGBACK-466) when I found this. I think that bug should be able to be resolved.
