### PR TITLE
Documentation: Fix typos in site and manual

### DIFF
--- a/logback-site/src/site/pages/codes.html
+++ b/logback-site/src/site/pages/codes.html
@@ -368,7 +368,7 @@
   <p>When the <span class="option">file</span> property matches the
   regular expression defined by <span
   class="option">fileNamePattern</span>, there is a risk of
-  collison. A collision occurs when the active log file as defined by
+  collision. A collision occurs when the active log file as defined by
   the <span class="option">file</span> property has the same path as
   an existing log archive. Such a collision will result in the log
   archive being overwritten.
@@ -437,7 +437,7 @@
  
    <h4 class="doAnchor" name="renamingErrorOnUnix">On Unix-*</h4>
   
-   <p>On the Unix flatform, the basic/quick rename method supplied by
+   <p>On the Unix platform, the basic/quick rename method supplied by
    the JDK does not work if the source and target files are located on
    different file systems. In order to deal with this contingency,
    logback will resort to renaming by copying if all following three

--- a/logback-site/src/site/pages/faq.html
+++ b/logback-site/src/site/pages/faq.html
@@ -302,7 +302,7 @@
         <dt>
           <a name="setup_jetty"  href="#">
             How can Jetty be instructed to use logback-classic as its
-            logging implementataion?
+            logging implementation?
           </a>
         </dt>
         

--- a/logback-site/src/site/pages/job.html
+++ b/logback-site/src/site/pages/job.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <title>Carrer at QOS.ch</title>
+    <title>Careers at QOS.ch</title>
     <link rel="stylesheet" type="text/css" href="css/common.css" />
     <link rel="stylesheet" type="text/css" href="css/screen.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="css/_print.css" media="print" />

--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -985,7 +985,7 @@ public interface RollingPolicy extends LifeCycle {
        <td class="small">
          <em>/foo/%d{yyyy-MM,<b>aux</b>}/%d.log</em>
        </td>
-       <td>Rollover daily. Archives located under a folder contaning
+       <td>Rollover daily. Archives located under a folder containing
        year and month.
        </td>
        <td>In this example, the first %d token is marked as
@@ -3650,7 +3650,7 @@ logger.error(<b>notifyAdmin</b>,
 				<td>A nested appender which has not been accessed beyond the
 				<span class="prop">timeout</span> duration is deemed stale. A
 				stale appender is closed and unreferenced by
-				<code>SiftingAppender</code>. The dfault value for <span
+				<code>SiftingAppender</code>. The default value for <span
 				class="prop">timeout</span> is 30 minutes.</td>
 			</tr>
 			<tr>
@@ -3681,7 +3681,7 @@ logger.error(<b>notifyAdmin</b>,
     criteria are computed at runtime by a discriminator. The user can
     specify the selection criteria with the help of a <code><a
     href="../xref/ch/qos/logback/core/sift/Discriminator.html">Discriminator</a></code>. Let
-    us now study an eaxample.
+    us now study an example.
     </p>
  
     <h4>Example</h4>
@@ -3736,10 +3736,10 @@ logger.debug("Alice says hello"); </p>
     <p>In the absence of a class attribute, it is assumed that the
     discriminator type is <a
     href="../xref/ch/qos/logback/classic/sift/MDCBasedDiscriminator.html">MDCBasedDiscriminator</a>.
-    The discrimating value is the MDC value associated with the key
+    The discriminating value is the MDC value associated with the key
     given by the <span class="prop">key</span> property. However, if
     that MDC value is null, then <span
-    class="prop">defaultValue</span> is used as the discrimating
+    class="prop">defaultValue</span> is used as the discriminating
     value.
     </p>
 

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -775,8 +775,8 @@ Caller+2   at mainPackage.ConfigTester.main(ConfigTester.java:38)</pre>
 					value corresponding to the key 'userid' will be output. If
 					the value is null, then the <a
 					href="configuration.html#defaultValuesForVariables">default
-					value</a> speficied after the <b>:-</b> operator is
-					output. If no deault value is specified than the empty
+					value</a> specified after the <b>:-</b> operator is
+					output. If no default value is specified than the empty
 					string is output.
 					</p>
 
@@ -1361,7 +1361,7 @@ Wrapped by: org.springframework.BeanCreationException: Error creating bean with 
 
     <p>Below is a configuration file illustrating coloring. Note the
     %cyan conversion specifier enclosing "%logger{15}". This will
-    output the logger name abreviated to 15 characters in cyan. The
+    output the logger name abbreviated to 15 characters in cyan. The
     %highlight conversion specifier prints its sub-pattern in bold-red
     for events of level ERROR, in red for WARN, in BLUE for INFO, and
     in the default color for other levels.</p>

--- a/logback-site/src/site/pages/manual/receivers.html
+++ b/logback-site/src/site/pages/manual/receivers.html
@@ -279,7 +279,7 @@
       See <a href="usingSSL.html">Using SSL</a> for details on 
       configuring SSL properties for Logback components.</p>    
  
-      <p>We can run this configurtation using the same example server
+      <p>We can run this configuration using the same example server
       configuration, with just a couple of additional configuration
       properties:</p>
 

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -550,7 +550,7 @@
 
     <p><a
     href="manual/appenders.html#SMTPAppender"><code>SMTPAppender</code></a>
-    now supports the retreival of a <code>javax.mail.Session</code>
+    now supports the retrieval of a <code>javax.mail.Session</code>
     resource from JNDI. This feature was requested in <a
     href="http://jira.qos.ch/browse/LBCLASSIC-332">LBCLASSIC-332</a>
     by Hrotko Gabor.</p>
@@ -588,8 +588,8 @@
 
     <p><code>SMTPAppender</code> now admits the <span
     class="prop">asynchronousSending</span> property, set to 'true' by
-    default. However, it can be set to 'false' for syncronous email
-    transmisison. This property was requested in <a
+    default. However, it can be set to 'false' for synchronous email
+    transmission. This property was requested in <a
     href="http://jira.qos.ch/browse/LBCLASSIC-323">LBCLASSIC-323</a>
     by Patrick Houk.</p>
 
@@ -660,8 +660,8 @@
     </p>
 
     <p><code>SMTPAppender</code> failed to transmit messages under JDK
-    1.5. After some investigation, Dave dicovered that this was due to
-    setting the <code>corePoolSize</code> parameter of the relavant
+    1.5. After some investigation, Dave discovered that this was due to
+    setting the <code>corePoolSize</code> parameter of the relevant
     <code>ThreadPoolExecutor</code> to 0. Setting
     <code>corePoolSize</code> to a higher value, e.g. 1, under JDK 1.5
     solves the problem and fixes <a
@@ -741,7 +741,7 @@
     name pattern of <a
     href="manual/appenders.html#TimeBasedRollingPolicy">TimeBasedRollingPolicy</a>. Auxiliary
     %d tokens must be marked as such by passing the AUX
-    paramater. This feature was requested in <a
+    parameter. This feature was requested in <a
     href="http://jira.qos.ch/browse/LBCORE-242">LBCORE-242</a> by
     Thomas Corte.</p>
 
@@ -857,7 +857,7 @@
 
     <p>Logback-classic now supports printing stack traces "root cause
     first" instead of the standard "root cause last". See the
-    documentaiton for <a
+    documentation for <a
     href="manual/layouts.html#rootException">%rootException</a>
     converter for further details. The <code>%rootException</code>
     converter was contributed by Tomasz Nurkiewicz in relation with <a
@@ -882,7 +882,7 @@
 
     <p><code>LogbackMDCAdapter</code> now synchronizes over its thread
     local map. This prevents
-    <code>ConcurrentModificationException</code> from occuring while a
+    <code>ConcurrentModificationException</code> from occurring while a
     child thread copies the map from the parent. This fixes <a
     href="http://jira.qos.ch/browse/LBCLASSIC-289">LBCLASSIC-289</a>
     reported by Josh Oddman.</p>
@@ -1687,7 +1687,7 @@ ALTER TABLE logging_event ADD arg3 VARCHAR(254);</pre>
 
     <h3>29th of December 2008 - Release of version 0.9.14</h3>
 
-    <p>Corrected a serious dead-lock problem occuring during
+    <p>Corrected a serious dead-lock problem occurring during
     configuration. It was reported in <a
     href="http://jira.qos.ch/browse/LBCLASSIC-81">LBCLASSIC-81</a> by
     Holger Mense.</p>

--- a/logback-site/src/site/pages/recipes/emailPerTransaction.html
+++ b/logback-site/src/site/pages/recipes/emailPerTransaction.html
@@ -358,7 +358,7 @@ MDC.put("txId", transactionId); </pre>
      buffers</a>.  </p>
 
      <p>To deal with this problem, we instruct SMTPAppender to discard
-     apprioate buffer at the end of each transaction. This is done by
+     the appropriate buffer at the end of each transaction. This is done by
      logging an event marked as "FINALIZE_SESSION". Here is a modified
      version of <code>PrimeAction</code> which marks the end of a
      transaction with "FINALIZE_SESSION".

--- a/logback-site/src/site/pages/setup.html
+++ b/logback-site/src/site/pages/setup.html
@@ -258,7 +258,7 @@
      in $LOGBACK_HOME</li>
 
      <li>In Eclipse, import the logback project: Import&rarr;
-     General&rarr; Existing Prokects into Workspace, select
+     General&rarr; Existing Projects into Workspace, select
      $LOGBACK_HOME folder for the import
      </li>   
      

--- a/logback-site/src/site/pages/volunteer.html
+++ b/logback-site/src/site/pages/volunteer.html
@@ -92,7 +92,7 @@
 
         <li><a
         href="http://logback.qos.ch/jenkins/job/logback/149/">build
-        #149</a> with test faulure in <a
+        #149</a> with test failure in <a
         href="http://logback.qos.ch/jenkins/job/logback/ch.qos.logback$logback-classic/149/testReport/junit/ch.qos.logback.classic.joran/JoranConfiguratorTest/levelChangePropagator1/">JoranConfiguratorTest.levelChangePropagator1</a>
         probable cause: parallel execution, j.u.l. shared-state
         overridden by levelChangePropagator0 while levelChangePropagator1 is running
@@ -100,7 +100,7 @@
 
         <li><a
         href="http://logback.qos.ch/jenkins/job/logback/298/">build
-        #298</a> with test faulure in <a
+        #298</a> with test failure in <a
         href="http://logback.qos.ch/jenkins/job/logback/ch.qos.logback$logback-core/298/testReport/junit/ch.qos.logback.core/AsyncAppenderBaseTest/workerShouldStopEvenIfInterruptExceptionConsumedWithinSubappender/">AsyncAppenderBaseTest</a>
         probable cause: race condition
         </li>
@@ -108,7 +108,7 @@
 
         <li><a
         href="http://logback.qos.ch/jenkins/job/logback/91/">build
-        #91</a> with test faulure in <a
+        #91</a> with test failure in <a
         href="http://logback.qos.ch/jenkins/job/logback/ch.qos.logback$logback-classic/91/testReport/junit/ch.qos.logback.classic.net/SMTPAppender_GreenTest/testMultipleTo/">SMTPAppender_GreenTest</a>
         probable cause: race condition, GreenMail server not running
         at time of message transmission</li>


### PR DESCRIPTION
This pull request fixes a few typos in logback-site, in the manual, FAQ and old news items.
