### PR TITLE
LOGBACK-943 Support an unlimited number of nested variables in config file

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/OptionHelper.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/OptionHelper.java
@@ -114,12 +114,7 @@ public class OptionHelper {
    */
   public static String substVars(String input, PropertyContainer pc0, PropertyContainer pc1) {
     try {
-      String replacement = NodeToStringTransformer.substituteVariable(input, pc0, pc1);
-      // for backward compatibility sake, perform one level of recursion
-      if(replacement.contains(DELIM_START)) {
-        replacement =  NodeToStringTransformer.substituteVariable(replacement, pc0, pc1);
-      }
-      return replacement;
+      return NodeToStringTransformer.substituteVariable(input, pc0, pc1);
     } catch (ScanException e) {
       throw new IllegalArgumentException("Failed to parse input [" + input + "]", e);
     }

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -28,7 +28,15 @@
     announce</a> mailing list.</p>
 
 
+    <hr width="80%" align="center" />
 
+    <h3>, 2014 - Release of version 1.1.1</h3>
+
+    <p>Logback now supports an unlimited level of
+    <a href="manual/configuration.html#variableSubstitution">variable
+    substitution</a> nesting rather than being limited to one level deep.
+    (<a href="http://jira.qos.ch/browse/LOGBACK-943">LOGBACK-943</a>)
+    </p>
 
     <hr width="80%" align="center" />
 


### PR DESCRIPTION
[LOGBACK-943](http://jira.qos.ch/browse/LOGBACK-943)

Logback was limited to only doing variable substitution one level deep:

```
FOO=foo
FOOBAR=${foo}bar
RESULT=${FOOBAR}.log
```

However, it did not allow for any more than one level of substitution:

```
FOO=foo
FOOBAR=${foo}bar
RESULT=${FOOBAR}.log
FINAL_RESULT=logs/${RESULT}
```

This pull request allows for unlimited nesting. Possibly there is some reason why it was limited to only one level deep, but I don't know of one.
