### PR TITLE
fixed for LOGBACK-952

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/Loader.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/Loader.java
@@ -54,9 +54,9 @@ public class Loader {
                   // Using SecurityException instead of AccessControlException.
                   // See bug LOGBACK-760.
                   return false;
-                }catch(Exception ex ){ //fixed for LOGBACK-952 
-                    ex.printStackTrace();
-                    return false;
+                } catch (Exception ex) { //fixed for LOGBACK-952 
+                  ex.printStackTrace();
+                  return false;
                 }
               }
             });


### PR DESCRIPTION
logback  not work on aix with ibm java 1.6

Caused by: java.lang.NullPointerException on :
ch.qos.logback.core.util.Loader.<clinit>(Loader.java:46)
http://jira.qos.ch/browse/LOGBACK-952
