### PR TITLE
LOGBACK-268 - Fair locking in OutputStreamAppender

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -136,7 +136,8 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
    *          The path to the log file.
    */
   public void openFile(String file_name) throws IOException {
-    synchronized (lock) {
+    lock.lock();
+    try {
       File file = new File(file_name);
       if (FileUtil.isParentDirectoryCreationRequired(file)) {
         boolean result = FileUtil.createMissingParentDirectories(file);
@@ -150,6 +151,8 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
           file, append);
       resilientFos.setContext(context);
       setOutputStream(resilientFos);
+    } finally {
+      lock.unlock();
     }
   }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
@@ -126,7 +126,8 @@ public class RollingFileAppender<E> extends FileAppender<E> {
    * Implemented by delegating most of the rollover work to a rolling policy.
    */
   public void rollover() {
-    synchronized (lock) {
+    lock.lock();
+    try {
       // Note: This method needs to be synchronized because it needs exclusive
       // access while it closes and then re-opens the target file.
       //
@@ -153,6 +154,8 @@ public class RollingFileAppender<E> extends FileAppender<E> {
       } catch (IOException e) {
         addError("setFile(" + fileName + ", false) call failed.", e);
       }
+    } finally {
+      lock.unlock();
     }
   }
 

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -47,6 +47,11 @@
     (<a href="http://jira.qos.ch/browse/LOGBACK-960">LOGBACK-960</a>)
     </p>
 
+    <p>Use fair locking in <code>OutputStreamAppender</code>. Patch provided by
+    Sergey Bykov.
+    (<a href="http://jira.qos.ch/browse/LOGBACK-268">LOGBACK-268</a>)
+    </p>
+
     <hr width="80%" align="center" />
 
     <h3>5th of February, 2014 - Release of version 1.1.1</h3>


### PR DESCRIPTION
Fix LOGBACK-268 by using a fair ReentrantLock (instead of object
synchronization).
