### PR TITLE
Use ServiceLoader pattern to control logback bootstrap process

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/Configurator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/Configurator.java
@@ -1,0 +1,33 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2014, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.spi;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.spi.ContextAware;
+
+/**
+ * Allows programmatic initialization and configuration of Logback.
+ * The ServiceLoader is typically used to instantiate implementations and
+ * thus implementations will need to follow the guidelines of the ServiceLoader 
+ * specifically a no-arg constructor is required.
+ */
+public interface Configurator extends ContextAware {
+
+  /**
+   * The context will also be set before this method is called via
+   * {@link ContextAware#setContext(ch.qos.logback.core.Context)}.
+   */
+  public void configure(LoggerContext loggerContext);
+
+}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/EnvUtil.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/EnvUtil.java
@@ -13,6 +13,9 @@
  */
 package ch.qos.logback.classic.util;
 
+import java.lang.reflect.Method;
+import java.util.Iterator;
+
 import ch.qos.logback.core.util.Loader;
 
 /**
@@ -21,14 +24,76 @@ import ch.qos.logback.core.util.Loader;
 public class EnvUtil {
 
 
+  /*
+   * Used to replace the ClassLoader that the ServiceLoader uses for unit testing.
+   * We need this to mock the resources the ServiceLoader attempts to load from 
+   * /META-INF/services thus keeping the projects src/test/resources clean 
+   * (see src/test/resources/README.txt).
+   */
+  static ClassLoader testServiceLoaderClassLoader = null;
+  
   static public boolean isGroovyAvailable() {
     ClassLoader classLoader = Loader.getClassLoaderOfClass(EnvUtil.class);
     try {
-      Class bindingClass = classLoader.loadClass("groovy.lang.Binding");
+      Class<?> bindingClass = classLoader.loadClass("groovy.lang.Binding");
       return (bindingClass != null);
     } catch (ClassNotFoundException e) {
       return false;
     }
   }
+  
+  
+  /**
+   * Take advantage of Java SE 6's java.util.ServiceLoader API.
+   * Using reflection so that there is no compile-time dependency on SE 6.
+   */
+  static private final Method serviceLoaderLoadMethod;
+  static private final Method serviceLoaderIteratorMethod;
+  static {
+    Method tLoadMethod = null;
+    Method tIteratorMethod = null;
+    try {
+      Class<?> clazz = Class.forName("java.util.ServiceLoader");
+      tLoadMethod = clazz.getMethod("load", Class.class, ClassLoader.class);
+      tIteratorMethod = clazz.getMethod("iterator");
+    } catch (ClassNotFoundException ce) {
+      // Running on Java SE 5
+    } catch (NoSuchMethodException ne) {
+      // Shouldn't happen
+    }
+    serviceLoaderLoadMethod = tLoadMethod;
+    serviceLoaderIteratorMethod = tIteratorMethod;
+  }
+
+  static public boolean isServiceLoaderAvailable() {
+    return (serviceLoaderLoadMethod != null && serviceLoaderIteratorMethod != null);
+  }
+  
+  private static ClassLoader getServiceLoaderClassLoader() {
+    return testServiceLoaderClassLoader == null ? Loader.getClassLoaderOfClass(EnvUtil.class) : testServiceLoaderClassLoader;
+  }
+  
+  @SuppressWarnings("unchecked")
+  public static <T> T loadFromServiceLoader(Class<T> c) {
+    if (isServiceLoaderAvailable()) {
+      Object loader;
+      try {
+        loader = serviceLoaderLoadMethod.invoke(null, c, getServiceLoaderClassLoader() );
+      } catch (Exception e) {
+        throw new IllegalStateException("Cannot invoke java.util.ServiceLoader#load()", e);
+      }
+
+      Iterator<T> it;
+      try {
+        it = (Iterator<T>) serviceLoaderIteratorMethod.invoke(loader);
+      } catch (Exception e) {
+        throw new IllegalStateException("Cannot invoke java.util.ServiceLoader#iterator()", e);
+      }
+      if (it.hasNext())
+        return it.next();
+    }
+    return null;
+  }
+  
 
 }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/MockConfigurator.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/MockConfigurator.java
@@ -1,0 +1,14 @@
+package ch.qos.logback.classic.util;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.Configurator;
+import ch.qos.logback.core.spi.ContextAwareBase;
+
+public class MockConfigurator extends ContextAwareBase implements Configurator {
+
+  static LoggerContext context = null;
+
+  public void configure(LoggerContext loggerContext) {
+    context = loggerContext;
+  }
+}

--- a/logback-classic/src/test/resources/FAKE_META_INF_SERVICES_ch_qos_logback_classic_spi_Configurator
+++ b/logback-classic/src/test/resources/FAKE_META_INF_SERVICES_ch_qos_logback_classic_spi_Configurator
@@ -1,0 +1,1 @@
+ch.qos.logback.classic.util.MockConfigurator

--- a/logback-classic/src/test/resources/README.txt
+++ b/logback-classic/src/test/resources/README.txt
@@ -1,5 +1,5 @@
 
-Few test cases InitializationTest requite the presence of logback.xml or logback-test.xml
+Few test cases InitializationTest require the presence of logback.xml or logback-test.xml
 to be present in the classpath. However, this conflict with the logback-examples module. 
 In particular, when users attempt to follow the manual by importing the project in an IDE 
 such as Eclipse.

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -98,7 +98,17 @@
         classpath</a>..</p>
       </li>
       
-      <li><p>If neither file is found, logback configures itself
+      <li><p>If no such file is found, and the executing JVM has the  
+      <a href="http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html">
+      ServiceLoader</a> (JDK 6 and above) the ServiceLoader will be used to resolve an 
+      implementation of <a href="../xref/ch/qos/logback/classic/spi/Configurator.html">
+      <code>com.qos.logback.classic.spi.Configurator</code></a>.
+      The first implementation found will be used. 
+      See <a href="http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html">
+      ServiceLoader documentation for more details</a>.
+      </li>
+      
+      <li><p>If none of the above succeeds, logback configures itself
       automatically using the <a
       href="../xref/ch/qos/logback/classic/BasicConfigurator.html"><code>BasicConfigurator</code></a>
       which will cause logging output to be directed to the console.


### PR DESCRIPTION
Currently there is no way to control the static initialization of logback such that you can do your own configuration of Logback with out hijacking an existing configuration. This change allows you to use the common [ServiceLoader ](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html) pattern from JDK6 to load a new SPI called `Configurator` that will allow custom initialization of the root appender similar to what BasicConfigurator is currently doing. I have Backported the `ServiceLoader` as its only available in JDK6 and above.

More detail is on my SO Post: http://stackoverflow.com/questions/22335441/configure-logback-to-defer-to-java-configuration-aka-plain-java-configuration-of
