### PR TITLE
Introduce AsyncAppender for logback-access

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
@@ -1,0 +1,37 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.access;
+
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.AsyncAppenderBase;
+
+/**
+ * Asynchronous appender for logback-access.
+ *
+ * @author Konstantin Pavlov
+ * @since 1.1.2
+ */
+public class AsyncAppender extends AsyncAppenderBase<IAccessEvent> {
+
+    /**
+     * No events are discardable.
+     *
+     * @param event an event to check
+     * @return false always.
+     */
+    protected boolean isDiscardable(IAccessEvent event) {
+        return false;
+    }
+}

--- a/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
@@ -1,0 +1,30 @@
+package ch.qos.logback.access;
+
+import ch.qos.logback.access.dummy.DummyRequest;
+import ch.qos.logback.access.dummy.DummyResponse;
+import ch.qos.logback.access.dummy.DummyServerAdapter;
+import ch.qos.logback.access.spi.AccessEvent;
+import ch.qos.logback.access.spi.IAccessEvent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class AsyncAppenderTest {
+
+    AsyncAppender asyncAppender = new AsyncAppender();
+
+    private static IAccessEvent createAccessEvent() {
+        DummyRequest request = new DummyRequest();
+        request.setRequestUri("");
+        DummyResponse response = new DummyResponse();
+        DummyServerAdapter adapter = new DummyServerAdapter(request, response);
+
+        return new AccessEvent(request, response, adapter);
+    }
+
+    @Test
+    public void accessEventIsNeverDiscardable() throws Exception {
+        final IAccessEvent dummyAccessEvent = createAccessEvent();
+        assertFalse(asyncAppender.isDiscardable(dummyAccessEvent));
+    }
+}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/AsyncAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/AsyncAppender.java
@@ -41,6 +41,7 @@ public class AsyncAppender extends AsyncAppenderBase<ILoggingEvent> {
     return level.toInt() <= Level.INFO_INT;
   }
 
+  @Override
   protected void preprocess(ILoggingEvent eventObject) {
     eventObject.prepareForDeferredProcessing();
     if(includeCallerData)


### PR DESCRIPTION
Proposed fix for http://jira.qos.ch/browse/LOGBACK-827

Async appender is intended to fix issues like that:

<pre>
18:31:29,255 |-ERROR in ch.qos.logback.classic.AsyncAppender[access.file.async] - Appender [access.file.async] failed to append. java.lang.ClassCastException: ch.qos.logback.access.spi.AccessEvent cannot be cast to ch.qos.logback.classic.spi.ILoggingEvent
    at java.lang.ClassCastException: ch.qos.logback.access.spi.AccessEvent cannot be cast to ch.qos.logback.classic.spi.ILoggingEvent
    at  at ch.qos.logback.classic.AsyncAppender.preprocess(AsyncAppender.java:28)
    at  at ch.qos.logback.core.AsyncAppenderBase.append(AsyncAppenderBase.java:129)
    at  at ch.qos.logback.core.UnsynchronizedAppenderBase.doAppend(UnsynchronizedAppenderBase.java:88)
    at  at ch.qos.logback.core.spi.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:48)
    at  at ch.qos.logback.access.tomcat.LogbackValve.invoke(LogbackValve.java:199)
    at  at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
    at  at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:408)
    at  at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1040)
    at  at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:607)
    at  at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:313)
    at  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at  at java.lang.Thread.run(Thread.java:744)
</pre>


Example `logback-access.xml`:

``` xml
<?xml version='1.0' encoding='utf-8'?>
<configuration>

    <!-- always a good activate OnConsoleStatusListener -->
    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>

    <!-- See for reference: http://logback.qos.ch/access.html#configuration -->
    <appender name="access.file" class="ch.qos.logback.core.rolling.RollingFileAppender">
        <file>${catalina.base}/logs/access.log</file>
        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
            <!-- rollover daily -->
            <fileNamePattern>${catalina.base}/logs/access.%d{yyyy-MM-dd}.%i.log.tar.gz</fileNamePattern>
            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                <!-- or whenever the file size reaches 100MB -->
                <maxFileSize>100KB</maxFileSize>
            </timeBasedFileNamingAndTriggeringPolicy>
        </rollingPolicy>
        <encoder>
            <pattern>combined</pattern>
        </encoder>
    </appender>

    <appender name="access.file.async" class="ch.qos.logback.access.AsyncAppender">
        <appender-ref ref="access.file"/>
    </appender>

    <appender-ref ref="access.file.async"/>
</configuration>
```
