### PR TITLE
Introduce AsyncAppender for logback-access: LOGBACK-827

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
@@ -1,0 +1,37 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.access;
+
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.AsyncAppenderBase;
+
+/**
+ * Asynchronous appender for logback-access.
+ *
+ * @author Konstantin Pavlov
+ * @since 1.1.2
+ */
+public class AsyncAppender extends AsyncAppenderBase<IAccessEvent> {
+
+    /**
+     * No events are discardable.
+     *
+     * @param event an event to check
+     * @return false always.
+     */
+    protected boolean isDiscardable(IAccessEvent event) {
+        return false;
+    }
+}

--- a/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
@@ -21,9 +21,19 @@ import ch.qos.logback.core.AsyncAppenderBase;
  * Asynchronous appender for logback-access.
  *
  * @author Konstantin Pavlov
- * @since 1.1.2
+ * @since 1.1.3
  */
 public class AsyncAppender extends AsyncAppenderBase<IAccessEvent> {
+
+    /**
+     * Prepares {@code eventObject} for deferred processing.
+     *
+     * @param eventObject an event to preprocess
+     */
+    @Override
+    protected void preprocess(IAccessEvent eventObject) {
+        eventObject.prepareForDeferredProcessing();
+    }
 
     /**
      * No events are discardable.

--- a/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
@@ -1,0 +1,30 @@
+package ch.qos.logback.access;
+
+import ch.qos.logback.access.dummy.DummyRequest;
+import ch.qos.logback.access.dummy.DummyResponse;
+import ch.qos.logback.access.dummy.DummyServerAdapter;
+import ch.qos.logback.access.spi.AccessEvent;
+import ch.qos.logback.access.spi.IAccessEvent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class AsyncAppenderTest {
+
+    AsyncAppender asyncAppender = new AsyncAppender();
+
+    private static IAccessEvent createAccessEvent() {
+        DummyRequest request = new DummyRequest();
+        request.setRequestUri("");
+        DummyResponse response = new DummyResponse();
+        DummyServerAdapter adapter = new DummyServerAdapter(request, response);
+
+        return new AccessEvent(request, response, adapter);
+    }
+
+    @Test
+    public void accessEventIsNeverDiscardable() throws Exception {
+        final IAccessEvent dummyAccessEvent = createAccessEvent();
+        assertFalse(asyncAppender.isDiscardable(dummyAccessEvent));
+    }
+}

--- a/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
@@ -5,26 +5,67 @@ import ch.qos.logback.access.dummy.DummyResponse;
 import ch.qos.logback.access.dummy.DummyServerAdapter;
 import ch.qos.logback.access.spi.AccessEvent;
 import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.read.ListAppender;
+import ch.qos.logback.core.status.OnConsoleStatusListener;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class AsyncAppenderTest {
 
-    AsyncAppender asyncAppender = new AsyncAppender();
+    private static Random random = new Random();
+    private ListAppender<IAccessEvent> listAppender = new ListAppender<IAccessEvent>();
+    private OnConsoleStatusListener onConsoleStatusListener = new OnConsoleStatusListener();
+    private AsyncAppender asyncAppender = new AsyncAppender();
 
-    private static IAccessEvent createAccessEvent() {
-        DummyRequest request = new DummyRequest();
-        request.setRequestUri("");
+    private static IAccessEvent createAccessEvent(final String uri) {
+        final DummyRequest request = new DummyRequest();
         DummyResponse response = new DummyResponse();
         DummyServerAdapter adapter = new DummyServerAdapter(request, response);
 
-        return new AccessEvent(request, response, adapter);
+        return new AccessEvent(request, response, adapter) {
+            @Override
+            public void prepareForDeferredProcessing() {
+                request.setRequestUri(uri);
+                super.prepareForDeferredProcessing();
+            }
+        };
+    }
+
+    @Before
+    public void setUp() {
+        onConsoleStatusListener.start();
+
+        listAppender.setName("list");
+        listAppender.start();
+    }
+
+    @Test
+    public void eventWasPreparedForDeferredProcessing() {
+        asyncAppender.addAppender(listAppender);
+        asyncAppender.start();
+
+        String uri = "uri:" + random.nextLong();
+        IAccessEvent dummyAccessEvent = createAccessEvent(uri);
+
+        asyncAppender.doAppend(dummyAccessEvent);
+
+        asyncAppender.stop();
+        assertFalse(asyncAppender.isStarted());
+
+        assertEquals(1, listAppender.list.size());
+        IAccessEvent e = listAppender.list.get(0);
+
+        assertEquals(uri, e.getRequestURI());
     }
 
     @Test
     public void accessEventIsNeverDiscardable() throws Exception {
-        final IAccessEvent dummyAccessEvent = createAccessEvent();
+        final IAccessEvent dummyAccessEvent = createAccessEvent("");
         assertFalse(asyncAppender.isDiscardable(dummyAccessEvent));
     }
 }

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
@@ -13,307 +13,301 @@
  */
 package ch.qos.logback.access.dummy;
 
+import ch.qos.logback.access.AccessConstants;
+
+import javax.servlet.*;
+import javax.servlet.http.*;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.*;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
-
-import ch.qos.logback.access.AccessConstants;
-
 public class DummyRequest implements HttpServletRequest {
 
-  public final static String  DUMMY_CONTENT_STRING = "request contents";
-  public final static byte[] DUMMY_CONTENT_BYTES = DUMMY_CONTENT_STRING.getBytes(); 
+    public final static String DUMMY_CONTENT_STRING = "request contents";
+    public final static byte[] DUMMY_CONTENT_BYTES = DUMMY_CONTENT_STRING.getBytes();
+    public static final String DUMMY_RESPONSE_CONTENT_STRING = "response contents";
+    public static final byte[] DUMMY_RESPONSE_CONTENT_BYTES = DUMMY_RESPONSE_CONTENT_STRING.getBytes();
+    Hashtable<String, String> headerNames;
+    String uri;
 
-  
-  public static final String DUMMY_RESPONSE_CONTENT_STRING = "response contents";
-  public static final byte[] DUMMY_RESPONSE_CONTENT_BYTES =DUMMY_RESPONSE_CONTENT_STRING.getBytes();
-  
-  Hashtable<String, String> headerNames;
-  String uri;
-
-  public DummyRequest() {
-    headerNames = new Hashtable<String, String>();
-    headerNames.put("headerName1", "headerValue1");
-    headerNames.put("headerName2", "headerValue2");
-  }
-
-  public String getAuthType() {
-    return null;
-  }
-
-  public String getContextPath() {
-    return null;
-  }
-
-  public Cookie[] getCookies() {
-    Cookie cookie = new Cookie("testName", "testCookie");
-    return new Cookie[] { cookie };
-  }
-
-  public long getDateHeader(String arg0) {
-    return 0;
-  }
-
-  public String getHeader(String key) {
-    return headerNames.get(key);
-  }
-
-  public Enumeration getHeaderNames() {
-    return headerNames.keys();
-  }
-
-  public Enumeration getHeaders(String arg0) {
-    return null;
-  }
-
-  public int getIntHeader(String arg0) {
-    return 0;
-  }
-
-  public String getMethod() {
-    return "testMethod";
-  }
-
-  public String getPathInfo() {
-    return null;
-  }
-
-  public String getPathTranslated() {
-    return null;
-  }
-
-  public String getQueryString() {
-    return null;
-  }
-
-  public String getRemoteUser() {
-    return "testUser";
-  }
-
-  public String getRequestURI() {
-    return uri;
-  }
-
-  public StringBuffer getRequestURL() {
-    return new StringBuffer(uri);
-  }
-
-  public String getRequestedSessionId() {
-    return null;
-  }
-
-  public String getServletPath() {
-    return null;
-  }
-
-  public HttpSession getSession() {
-    return null;
-  }
-
-  public HttpSession getSession(boolean arg0) {
-    return null;
-  }
-
-  public Principal getUserPrincipal() {
-    return null;
-  }
-
-  public boolean isRequestedSessionIdFromCookie() {
-    return false;
-  }
-
-  public boolean isRequestedSessionIdFromURL() {
-    return false;
-  }
-
-  public boolean isRequestedSessionIdFromUrl() {
-    return false;
-  }
-
-  public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
-    return false;  //To change body of implemented methods use File | Settings | File Templates.
-  }
-
-  public void login(String username, String password) throws ServletException {
-    //To change body of implemented methods use File | Settings | File Templates.
-  }
-
-  public void logout() throws ServletException {
-    //To change body of implemented methods use File | Settings | File Templates.
-  }
-
-  public Collection<Part> getParts() throws IOException, IllegalStateException, ServletException {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
-
-  public Part getPart(String name) throws IOException, IllegalStateException, ServletException {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
-
-  public boolean isRequestedSessionIdValid() {
-    return false;
-  }
-
-  public boolean isUserInRole(String arg0) {
-    return false;
-  }
-
-  public Object getAttribute(String key) {
-    if (key.equals("testKey")) {
-      return "testKey";
-    } else if (AccessConstants.LB_INPUT_BUFFER.equals(key)) {
-      return DUMMY_CONTENT_BYTES;
-    } else if (AccessConstants.LB_OUTPUT_BUFFER.equals(key)) {
-      return DUMMY_RESPONSE_CONTENT_BYTES;
-    } else {
-      return null;
+    public DummyRequest() {
+        headerNames = new Hashtable<String, String>();
+        headerNames.put("headerName1", "headerValue1");
+        headerNames.put("headerName2", "headerValue2");
     }
-  }
 
-  public Enumeration getAttributeNames() {
-    return null;
-  }
+    public String getAuthType() {
+        return null;
+    }
 
-  public String getCharacterEncoding() {
-    return null;
-  }
+    public String getContextPath() {
+        return null;
+    }
 
-  public int getContentLength() {
-    return 0;
-  }
+    public Cookie[] getCookies() {
+        Cookie cookie = new Cookie("testName", "testCookie");
+        return new Cookie[]{cookie};
+    }
 
-  public String getContentType() {
-    return null;
-  }
+    public long getDateHeader(String arg0) {
+        return 0;
+    }
 
-  public ServletInputStream getInputStream() throws IOException {
-    return null;
-  }
+    public String getHeader(String key) {
+        return headerNames.get(key);
+    }
 
-  public String getLocalAddr() {
-    return null;
-  }
+    public Enumeration<String> getHeaderNames() {
+        return headerNames.keys();
+    }
 
-  public String getLocalName() {
-    return null;
-  }
+    public Enumeration<String> getHeaders(String arg0) {
+        return null;
+    }
 
-  public int getLocalPort() {
-    return 11;
-  }
+    public int getIntHeader(String arg0) {
+        return 0;
+    }
 
-  public ServletContext getServletContext() {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public String getMethod() {
+        return "testMethod";
+    }
 
-  public AsyncContext startAsync() {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public String getPathInfo() {
+        return null;
+    }
 
-  public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public String getPathTranslated() {
+        return null;
+    }
 
-  public boolean isAsyncStarted() {
-    return false;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public String getQueryString() {
+        return null;
+    }
 
-  public boolean isAsyncSupported() {
-    return false;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public String getRemoteUser() {
+        return "testUser";
+    }
 
-  public AsyncContext getAsyncContext() {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public String getRequestURI() {
+        return uri;
+    }
 
-  public DispatcherType getDispatcherType() {
-    return null;  //To change body of implemented methods use File | Settings | File Templates.
-  }
+    public StringBuffer getRequestURL() {
+        return new StringBuffer(uri);
+    }
 
-  public Locale getLocale() {
-    return null;
-  }
+    public String getRequestedSessionId() {
+        return null;
+    }
 
-  public Enumeration getLocales() {
-    return null;
-  }
+    public String getServletPath() {
+        return null;
+    }
 
-  public String getParameter(String arg0) {
-    return null;
-  }
+    public HttpSession getSession() {
+        return null;
+    }
 
-  public Map getParameterMap() {
-    return null;
-  }
+    public HttpSession getSession(boolean arg0) {
+        return null;
+    }
 
-  public Enumeration getParameterNames() {
-    return null;
-  }
+    public Principal getUserPrincipal() {
+        return null;
+    }
 
-  public String[] getParameterValues(String arg0) {
-    return null;
-  }
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
 
-  public String getProtocol() {
-    return "testProtocol";
-  }
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
 
-  public BufferedReader getReader() throws IOException {
-    return null;
-  }
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
 
-  public String getRealPath(String arg0) {
-    return null;
-  }
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        return false;
+    }
 
-  public String getRemoteAddr() {
-    return "testRemoteAddress";
-  }
+    public void login(String username, String password) throws ServletException {
+    }
 
-  public String getRemoteHost() {
-    return "testHost";
-  }
+    public void logout() throws ServletException {
+    }
 
-  public int getRemotePort() {
-    return 0;
-  }
+    public Collection<Part> getParts() throws IOException, IllegalStateException, ServletException {
+        return null;
+    }
 
-  public RequestDispatcher getRequestDispatcher(String arg0) {
-    return null;
-  }
+    public Part getPart(String name) throws IOException, IllegalStateException, ServletException {
+        return null;
+    }
 
-  public String getScheme() {
-    return null;
-  }
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
 
-  public String getServerName() {
-    return "testServerName";
-  }
+    public boolean isUserInRole(String arg0) {
+        return false;
+    }
 
-  public int getServerPort() {
-    return 0;
-  }
+    public Object getAttribute(String key) {
+        if (key.equals("testKey")) {
+            return "testKey";
+        } else if (AccessConstants.LB_INPUT_BUFFER.equals(key)) {
+            return DUMMY_CONTENT_BYTES;
+        } else if (AccessConstants.LB_OUTPUT_BUFFER.equals(key)) {
+            return DUMMY_RESPONSE_CONTENT_BYTES;
+        } else {
+            return null;
+        }
+    }
 
-  public boolean isSecure() {
-    return false;
-  }
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
 
-  public void removeAttribute(String arg0) {
-  }
+    public String getCharacterEncoding() {
+        return null;
+    }
 
-  public void setAttribute(String arg0, Object arg1) {
-  }
+    public void setCharacterEncoding(String arg0)
+            throws UnsupportedEncodingException {
+    }
 
-  public void setCharacterEncoding(String arg0)
-      throws UnsupportedEncodingException {
-  }
-  
-  public void setRequestUri(String uri) {
-    this.uri = uri;
-  }
+    public int getContentLength() {
+        return 0;
+    }
+
+    public String getContentType() {
+        return null;
+    }
+
+    public ServletInputStream getInputStream() throws IOException {
+        return null;
+    }
+
+    public String getLocalAddr() {
+        return null;
+    }
+
+    public String getLocalName() {
+        return null;
+    }
+
+    public int getLocalPort() {
+        return 11;
+    }
+
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    public AsyncContext startAsync() {
+        return null;
+    }
+
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+        return null;
+    }
+
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    public Locale getLocale() {
+        return null;
+    }
+
+    public Enumeration<Locale> getLocales() {
+        return null;
+    }
+
+    public String getParameter(String arg0) {
+        return null;
+    }
+
+    public Map<String, String[]> getParameterMap() {
+        return null;
+    }
+
+    public Enumeration<String> getParameterNames() {
+        return null;
+    }
+
+    public String[] getParameterValues(String arg0) {
+        return null;
+    }
+
+    public String getProtocol() {
+        return "testProtocol";
+    }
+
+    public BufferedReader getReader() throws IOException {
+        return null;
+    }
+
+    public String getRealPath(String arg0) {
+        return null;
+    }
+
+    public String getRemoteAddr() {
+        return "testRemoteAddress";
+    }
+
+    public String getRemoteHost() {
+        return "testHost";
+    }
+
+    public int getRemotePort() {
+        return 0;
+    }
+
+    public RequestDispatcher getRequestDispatcher(String arg0) {
+        return null;
+    }
+
+    public String getScheme() {
+        return null;
+    }
+
+    public String getServerName() {
+        return "testServerName";
+    }
+
+    public int getServerPort() {
+        return 0;
+    }
+
+    public boolean isSecure() {
+        return false;
+    }
+
+    public void removeAttribute(String arg0) {
+    }
+
+    public void setAttribute(String arg0, Object arg1) {
+    }
+
+    public void setRequestUri(String uri) {
+        this.uri = uri;
+    }
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/AsyncAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/AsyncAppender.java
@@ -41,6 +41,7 @@ public class AsyncAppender extends AsyncAppenderBase<ILoggingEvent> {
     return level.toInt() <= Level.INFO_INT;
   }
 
+  @Override
   protected void preprocess(ILoggingEvent eventObject) {
     eventObject.prepareForDeferredProcessing();
     if(includeCallerData)


### PR DESCRIPTION
Introduced `ch.qos.logback.access.AsyncAppender` which accepts `IAccessEvents`. 
Standard AsyncAppender from logback-classic does not support IAccessEvents and fails with exception:

```
18:31:29,255 |-ERROR in ch.qos.logback.classic.AsyncAppender[access.file.async] - Appender [access.file.async] failed to append. java.lang.ClassCastException: ch.qos.logback.access.spi.AccessEvent cannot be cast to ch.qos.logback.classic.spi.ILoggingEvent
    at java.lang.ClassCastException: ch.qos.logback.access.spi.AccessEvent cannot be cast to ch.qos.logback.classic.spi.ILoggingEvent
    at  at ch.qos.logback.classic.AsyncAppender.preprocess(AsyncAppender.java:28)
```

Proposed fix for http://jira.qos.ch/browse/LOGBACK-827

Example `logback-access.xml`:

``` xml
<?xml version='1.0' encoding='utf-8'?>
<configuration>

    <!-- always a good activate OnConsoleStatusListener -->
    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>

    <!-- See for reference: http://logback.qos.ch/access.html#configuration -->
    <appender name="access.file" class="ch.qos.logback.core.rolling.RollingFileAppender">
        <file>${catalina.base}/logs/access.log</file>
        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
            <!-- rollover daily -->
            <fileNamePattern>${catalina.base}/logs/access.%d{yyyy-MM-dd}.%i.log.tar.gz</fileNamePattern>
            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                <!-- or whenever the file size reaches 100MB -->
                <maxFileSize>100KB</maxFileSize>
            </timeBasedFileNamingAndTriggeringPolicy>
        </rollingPolicy>
        <encoder>
            <pattern>combined</pattern>
        </encoder>
    </appender>

    <appender name="access.file.async" class="ch.qos.logback.access.AsyncAppender">
        <appender-ref ref="access.file"/>
    </appender>

    <appender-ref ref="access.file.async"/>
</configuration>
```
