### PR TITLE
Set thread name

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
@@ -15,9 +15,12 @@
 package ch.qos.logback.core.util;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import ch.qos.logback.core.CoreConstants;
 
@@ -25,8 +28,21 @@ import ch.qos.logback.core.CoreConstants;
  * Static utility methods for manipulating an {@link ExecutorService}.
  * 
  * @author Carl Harris
+ * @author Mikhail Mazursky
  */
 public class ExecutorServiceUtil {
+
+  private static final ThreadFactory THREAD_FACTORY = new ThreadFactory() {
+
+    private final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+    public Thread newThread(Runnable r) {
+      Thread thread = defaultFactory.newThread(r);
+      thread.setName("logback-" + threadNumber.getAndIncrement());
+      return thread;
+    }
+  };
 
   /**
    * Creates an executor service suitable for use by logback components.
@@ -36,7 +52,8 @@ public class ExecutorServiceUtil {
     return new ThreadPoolExecutor(CoreConstants.CORE_POOL_SIZE, 
         CoreConstants.MAX_POOL_SIZE,
         0L, TimeUnit.MILLISECONDS,
-        new SynchronousQueue<Runnable>());
+        new SynchronousQueue<Runnable>(),
+        THREAD_FACTORY);
   }
   
   /**


### PR DESCRIPTION
It is much easier to identify threads in thread dumps when they have meaningful names.
