### PR TITLE
ShutdownHook Configuration  Element

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
@@ -117,9 +117,11 @@ public class ContextBase implements Context, LifeCycle {
   }
 
   /**
-   * Clear the internal objectMap and all properties.
+   * Clear the internal objectMap and all properties. Removes registered
+   * shutdown hook
    */
   public void reset() {
+	removeShutdownHook();
     getLifeCycleManager().reset();
     propertyMap.clear();
     objectMap.clear();
@@ -167,6 +169,19 @@ public class ContextBase implements Context, LifeCycle {
     if (executorService != null) {
       ExecutorServiceUtil.shutdown(executorService);
       executorService = null;
+    }
+  }
+  
+  private void removeShutdownHook() {
+    Thread hook = (Thread)getObject(CoreConstants.SHUTDOWN_HOOK_THREAD);
+    if(hook != null) {
+      putObject(CoreConstants.SHUTDOWN_HOOK_THREAD, null);
+      try {
+        Runtime.getRuntime().removeShutdownHook(hook);
+      }catch(IllegalStateException e) {
+        //if JVM is already shutting down, ISE is thrown
+        //no need to do anything else
+      }
     }
   }
   

--- a/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -136,6 +136,9 @@ public class CoreConstants {
 
   public static final String SAFE_JORAN_CONFIGURATION = "SAFE_JORAN_CONFIGURATION";
   public static final String XML_PARSING = "XML_PARSING";
+  
+  // Context Object name for the shutdown hook
+  public static final String SHUTDOWN_HOOK_THREAD = "SHUTDOWN_HOOK";
 
 
 

--- a/logback-core/src/main/java/ch/qos/logback/core/hook/DelayingShutdownHook.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/hook/DelayingShutdownHook.java
@@ -1,0 +1,58 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.hook;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.ContextBase;
+
+/**
+ * ShutdownHook implementation that stops the Logback context after a specified
+ * delay. 
+ * 
+ * @author Mike Reinhold
+ */
+public class DelayingShutdownHook extends ShutdownHookBase {
+  /**
+   * Default immediate shutdown of the context
+   */
+  public static final long DEFAULT_DELAY = 0;
+  
+  /**
+   * The delay in milliseconds before the ShutdownHook stops the
+   * Logback context
+   */
+  private long delay;
+    
+  public DelayingShutdownHook() {
+    delay = DEFAULT_DELAY;
+  }
+
+  public long getDelay() {
+    return delay;
+  }
+
+  public void setDelay(long delay) {
+    this.delay = delay;
+  }
+
+  public void run() {
+    try {
+      Thread.sleep(delay);
+    } catch (InterruptedException e) {
+      addError("");
+    }
+    
+    super.stop();
+  }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/hook/ShutdownHook.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/hook/ShutdownHook.java
@@ -1,0 +1,24 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.hook;
+
+import ch.qos.logback.core.spi.ContextAware;
+
+/**
+ * Interface describing a logback shutdown hook implementation
+ * 
+ * @author Mike Reinhold
+ */
+public interface ShutdownHook extends Runnable, ContextAware {
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/hook/ShutdownHookBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/hook/ShutdownHookBase.java
@@ -1,0 +1,42 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.hook;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.spi.ContextAwareBase;
+
+/**
+ * Base class for classes implementing a Logback ShutdownHook via extension
+ * 
+ * @author Mike Reinhold
+ */
+public abstract class ShutdownHookBase extends ContextAwareBase implements ShutdownHook {
+  
+  public ShutdownHookBase() {
+  }  
+  
+  /**
+   * Default method for stopping the Logback context
+   */
+  protected void stop() {
+    addInfo("Logback context being closed automatically via shutdown hook");
+    
+    Context hookContext = getContext();
+    if (hookContext instanceof ContextBase) {
+      ContextBase context = (ContextBase) hookContext;
+      context.stop();
+    }
+  }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/hook/package.html
+++ b/logback-core/src/main/java/ch/qos/logback/core/hook/package.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+
+<html>
+<head>
+<title></title>
+</head>
+
+<body>
+
+<p>Contains the shutdown hook functionality of logback,
+including the interface and base class for implementing 
+hooks as well as some default implementations, such as 
+@link{ch.qos.logback.core.hook.DelayingShutdownHook}
+</p>
+
+</body>
+</html>

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/JoranConfiguratorBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/JoranConfiguratorBase.java
@@ -28,6 +28,7 @@ import ch.qos.logback.core.joran.action.NestedComplexPropertyIA;
 import ch.qos.logback.core.joran.action.NewRuleAction;
 import ch.qos.logback.core.joran.action.ParamAction;
 import ch.qos.logback.core.joran.action.PropertyAction;
+import ch.qos.logback.core.joran.action.ShutdownHookAction;
 import ch.qos.logback.core.joran.action.StatusListenerAction;
 import ch.qos.logback.core.joran.action.TimestampAction;
 import ch.qos.logback.core.joran.spi.ElementSelector;
@@ -65,7 +66,7 @@ abstract public class JoranConfiguratorBase extends GenericConfigurator {
         new PropertyAction());
 
     rs.addRule(new ElementSelector("configuration/timestamp"), new TimestampAction());
-
+    rs.addRule(new ElementSelector("configuration/shutdownHook"), new ShutdownHookAction());
     rs.addRule(new ElementSelector("configuration/define"), new DefinePropertyAction());
 
     // the contextProperty pattern is deprecated. It is undocumented

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/ShutdownHookAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/ShutdownHookAction.java
@@ -1,0 +1,90 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.joran.action;
+
+import org.xml.sax.Attributes;
+
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.hook.ShutdownHookBase;
+import ch.qos.logback.core.joran.spi.ActionException;
+import ch.qos.logback.core.joran.spi.InterpretationContext;
+import ch.qos.logback.core.util.OptionHelper;
+
+/**
+ * Action which handles <shutdownHook> elements in configuration files.
+ * 
+ * @author Mike Reinhold
+ */
+public class ShutdownHookAction extends Action {
+  
+  ShutdownHookBase hook;
+  private boolean inError;
+  
+  /**
+   * Instantiates a shutdown hook of the given class and sets its name.
+   * 
+   * The hook thus generated is placed in the {@link InterpretationContext}'s
+   * shutdown hook bag.
+   */
+  @Override
+  public void begin(InterpretationContext ic, String name, Attributes attributes) throws ActionException {    
+    hook = null;
+    inError = false;
+    
+    String className = attributes.getValue(CLASS_ATTRIBUTE);
+    if (OptionHelper.isEmpty(className)) {
+      addError("Missing class name for shutdown hook. Near [" + name
+          + "] line " + getLineNumber(ic));
+      inError = true;
+      return;
+    }
+      
+    try {
+      addInfo("About to instantiate shutdown hook of type [" + className + "]");
+
+      hook = (ShutdownHookBase) OptionHelper.instantiateByClassName(className,
+          ShutdownHookBase.class, context);
+      hook.setContext(context);
+          
+      ic.pushObject(hook);
+    }catch (Exception e) {
+      inError = true;
+      addError("Could not create a shutdown hook of type [" + className + "].", e);
+      throw new ActionException(e);
+    }
+  }
+  
+  /**
+   * Once the children elements are also parsed, now is the time to activate the
+   * shutdown hook options.
+   */
+  @Override
+  public void end(InterpretationContext ic, String name) throws ActionException {
+    if (inError) {
+      return;
+    }
+      
+    Object o = ic.peekObject();
+    if (o != hook) {
+      addWarn("The object at the of the stack is not the hook pushed earlier.");
+    } else {
+      ic.popObject();
+        
+      Thread hookThread = new Thread(hook, "Logback shutdown hook [" + context.getName() + "]");
+          
+      context.putObject(CoreConstants.SHUTDOWN_HOOK_THREAD, hookThread);
+      Runtime.getRuntime().addShutdownHook(hookThread);      
+    }
+  } 
+}

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -708,6 +708,13 @@ import ch.qos.logback.classic.LoggerContext;
    href="http://docs.oracle.com/javaee/6/api/javax/servlet/ServletContextListener.html#contextDestroyed(javax.servlet.ServletContextEvent)">contextDestroyed</a>
    method of <code>ServletContextListener</code> in order to stop
    logback-classic and release resources.
+   </p>
+   
+   <p>In some cases, such as shutdown hooks expect Logback to be available,
+   it may not be possible to stop logback-classic prior to shotdown of the
+   Java Virtual Machine. See below for how to <a href="#stopContextWithHook">
+   Automatically Stop logback-classic</a>.
+   </p>
 
    <h2 class="doAnchor" name="syntax">Configuration file syntax</h2>
 
@@ -1982,7 +1989,37 @@ fileName=myApp.log
   <p>
   </p>
   
-
+  <h2 class="doAnchor" name="stopContextWithHook">Stopping logback-classic 
+   Automatically</h2>
+   
+   <p>Under certain scenarios, it may be necessary to have logback stop
+   its context during JVM shutdown, for instance in the event that
+   application shutdown hooks attempt to write log events. If the context
+   is stopped before the JVM begins to shutdown, these shutdown hooks will
+   not be able to log their events. Logback provides a shutdown hook 
+   configuration element for triggering closure of the Logback context automatically
+   during JVM shutdown.
+   </p>
+   
+   <h3 class=doAnchor" name="delayingShutdownHook">Delaying Shutdown Hook</h3>
+   <p>The default implementation, ch.qos.logback.core.hook.DelayingShutdownHook, simply 
+   waits for the specified <code>delay</code> before calling <code>Context.stop()</code>.
+   The default <code>delay</code> is 0 ms, indicating immediate shutdown. Semantics of
+   the <code>delay</code> parameter are the same as those of <code>Thread.sleep(long)</code>.
+   </p>
+   
+    <pre class="prettyprint source">&lt;configuration debug="true">
+  <b>&lt;shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook">
+    &lt;delay>1000&lt;/delay>
+  &lt;/shutdownHook></b>
+  .... 
+&lt;/configuration></pre>
+   
+   <h3 class="doAnchor" name="customShutdownHook">Custom Shutdown Hook</h3>
+   <p>It is possible to provide a different implementation of 
+   <code>ch.qos.logback.core.hook.ShutdownHook</code> if alternate shutdown logic
+   is needed for your application. 
+   </p>
 
   <script src="../templates/footer.js" type="text/javascript"></script>
 </div>

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -35,6 +35,11 @@
     the appender to flush events, up to a maximum delay, during a stop
     of the LoggerContext. This can be used to ensure that all queued
     events are flushed.</p>
+    
+    <p>Added new configuration element <code>shutdownHook</code> to allow the
+    user to specify a ShutdownHook implementation that will stop the Logback
+    context upon JVM exit.
+    </p>
 
     <h3>2nd of April, 2014 - Release of version 1.1.2</h3>
 


### PR DESCRIPTION
Added configuration framework for having Logback automatically stop its
context via a shutdown hook. Enabled via the shutdownHook configuration
element (backed by the Joran ShutdownHookAction). 

Basic implementation provided, DelayingShutdownHook, stops the Logback
context after a specified delay (default is 0 for immediate shutdown).

Updated news page under revision 1.1.3 and added details to the
configuration manual page.
