### PR TITLE
Add getMonthRegexByLocale

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/CharSequenceToRegexMapper.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/CharSequenceToRegexMapper.java
@@ -13,6 +13,8 @@
  */
 package ch.qos.logback.core.util;
 
+import java.util.Locale;
+
 /**
  * This class supports mapping character sequences to
  * regular expressions as appropriate for SimpleDateFormatter.
@@ -21,6 +23,36 @@ package ch.qos.logback.core.util;
  * 
  */
 class CharSequenceToRegexMapper {
+
+  String getMonthRegexByLocale(){
+    Locale lo = Locale.getDefault();
+  
+    if(lo.getLanguage().equals("bg")){ 
+      return ".{1,11}"; // Bulgarian
+    }
+    else if(lo.getLanguage().equals("cs")){
+      // 
+      return ".{1,8}";  // Czech
+    }
+    else if(lo.getLanguage().equals("hi")){
+      return ".{2,8}";  // Hindi
+     }
+    else if(lo.getLanguage().equals("ja")){
+      return ".{1,3}";  // Japanese
+    }
+    else if(lo.getLanguage().equals("ko")){
+      return ".{2,3}";  // Korean
+    }
+    else if(lo.getLanguage().equals("vi")){
+      return ".{5,14}"; // Vietnamese
+    }
+    else if(lo.getLanguage().equals("zh")){
+      return ".{2,3}";  // Chinese
+    }
+    else{
+      return ".{3,12}";
+    }
+  }
 
   String toRegex(CharSequenceState css) {
     final int occurrences = css.occurrences;
@@ -31,7 +63,7 @@ class CharSequenceToRegexMapper {
       return ".*";
     case 'M':
       if (occurrences >= 3) {
-        return ".{3,12}";
+    	return  getMonthRegexByLocale();
       } else {
         return number(occurrences);
       }
@@ -50,7 +82,10 @@ class CharSequenceToRegexMapper {
     case 'S':
       return number(occurrences);
     case 'E':
-      return ".{2,12}";
+      if (occurrences <= 3) {
+        return ".{1,8}";
+      }
+      return ".{3,12}";
     case 'a':
       return ".{2}";
     case 'Z':


### PR DESCRIPTION
```
logback-core 
```

I am Korean, and live in Seoul. Korea
I use Korean

I cloned logback.
and run "mvn test".

Failed ....

month(ch.qos.logback.core.util.DatePatternToRegexTest)  Time elapsed: 0 sec <<< FAILURE!
java.lang.AssertionError: [2009-9월-03] does not match regex [\d{4}-.{3,12}-\d{2}]
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.assertTrue(Assert.java:43)
    at ch.qos.logback.core.util.DatePatternToRegexTest.verify(DatePatternToRegexTest.java:105)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:89)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:93)
    at ch.qos.logback.core.util.DatePatternToRegexTest.month(DatePatternToRegexTest.java:56)
...

dot(ch.qos.logback.core.util.DatePatternToRegexTest)  Time elapsed: 0 sec <<< FAILURE!
java.lang.AssertionError: [2009.9월.03] does not match regex [\d{4}..{3,12}.\d{2}]
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.assertTrue(Assert.java:43)
    at ch.qos.logback.core.util.DatePatternToRegexTest.verify(DatePatternToRegexTest.java:105)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:89)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:93)
    at ch.qos.logback.core.util.DatePatternToRegexTest.dot(DatePatternToRegexTest.java:62)
...

timeZone(ch.qos.logback.core.util.DatePatternToRegexTest)  Time elapsed: 0 sec  <<< FAILURE!
java.lang.AssertionError: [2009-9월-03 21:57:16 KST] does not match regex [\d{4}-.{3,12}-\d{2} \d{2}:\d{2}:\d{2} .*]
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.assertTrue(Assert.java:43)
    at ch.qos.logback.core.util.DatePatternToRegexTest.verify(DatePatternToRegexTest.java:105)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:89)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:93)
    at ch.qos.logback.core.util.DatePatternToRegexTest.timeZone(DatePatternToRegexTest.java:68)
...

dayInWeek(ch.qos.logback.core.util.DatePatternToRegexTest)  Time elapsed: 0 sec  <<< FAILURE!
java.lang.AssertionError: [2009-9월-목] does not match regex [\d{4}-.{2,4}-.{2,12}]
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.assertTrue(Assert.java:43)
    at ch.qos.logback.core.util.DatePatternToRegexTest.verify(DatePatternToRegexTest.java:105)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:89)
    at ch.qos.logback.core.util.DatePatternToRegexTest.doTest(DatePatternToRegexTest.java:93)
    at ch.qos.logback.core.util.DatePatternToRegexTest.dayInWeek(DatePatternToRegexTest.java:74)
...

Some of Country have Different size of Month Regex.

E.g. Korean.

Calendar cal = Calendar.getInstance();
cal.set(2009, 8, 3, 21, 57, 16);

SimpleDateFormat sdf = new SimpleDateFormat("MMM", locale.KOREAN);
String sMonth = sdf.format(cal.getTime());
sMonth is "9월" , sMonth.lenth() is 2

getMonthRegexByLocale() return valid Regex (Each country).

And

Week(E) is some.

so I edited.

```
case 'E':
  if (occurrences <= 3) {
    return ".{1,8}";
  }
  return ".{3,12}";
```

check Jira's http://jira.qos.ch/browse/LOGBACK-969 sampleFiles....
