### PR TITLE
Fix for LOGBACK-732, make charset configurable in SyslogAppender

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SyslogAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SyslogAppenderTest.java
@@ -33,6 +33,8 @@ import ch.qos.logback.core.recovery.RecoveryCoordinator;
 import ch.qos.logback.core.testUtil.RandomUtil;
 import ch.qos.logback.core.util.StatusPrinter;
 
+import java.nio.charset.Charset;
+
 public class SyslogAppenderTest {
 
   private static final String SYSLOG_PREFIX_REGEX = "<\\d{2}>\\w{3} [\\d ]\\d \\d{2}(:\\d{2}){2} [\\w.-]* ";
@@ -95,7 +97,7 @@ public class SyslogAppenderTest {
 
     assertTrue(mockServer.isFinished());
     assertEquals(1, mockServer.getMessageList().size());
-    String msg = mockServer.getMessageList().get(0);
+    String msg = new String(mockServer.getMessageList().get(0));
 
     String threadName = Thread.currentThread().getName();
 
@@ -120,7 +122,7 @@ public class SyslogAppenderTest {
 
     assertTrue(mockServer.isFinished());
     assertEquals(1, mockServer.getMessageList().size());
-    String msg = mockServer.getMessageList().get(0);
+    String msg = new String(mockServer.getMessageList().get(0));
 
     String threadName = Thread.currentThread().getName();
 
@@ -155,7 +157,7 @@ public class SyslogAppenderTest {
     // System.out.println(i++ + ": " + line);
     // }
 
-    String msg = mockServer.getMessageList().get(0);
+    String msg = new String(mockServer.getMessageList().get(0));
     String expected = "<"
         + (SyslogConstants.LOG_MAIL + SyslogConstants.DEBUG_SEVERITY) + ">";
     assertTrue(msg.startsWith(expected));
@@ -165,11 +167,11 @@ public class SyslogAppenderTest {
         + " " + logMsg;
     checkRegexMatch(msg, regex);
 
-    msg = mockServer.getMessageList().get(1);
+    msg = new String(mockServer.getMessageList().get(1));
     assertTrue(msg.contains(ex.getClass().getName()));
     assertTrue(msg.contains(ex.getMessage()));
 
-    msg = mockServer.getMessageList().get(2);
+    msg = new String(mockServer.getMessageList().get(2));
     assertTrue(msg.startsWith(expected));
     regex = SYSLOG_PREFIX_REGEX + "\\[" + threadName + "\\] " +  "foo "+CoreConstants.TAB + "at ch\\.qos.*";
     checkRegexMatch(msg, regex);
@@ -206,13 +208,13 @@ public class SyslogAppenderTest {
 
     // large message is truncated
     final int maxMessageSize = sa.getMaxMessageSize();
-    String largeMsg = mockServer.getMessageList().get(0);
+    String largeMsg = new String(mockServer.getMessageList().get(0));
     assertTrue(largeMsg.startsWith(expected));
     String largeRegex = SYSLOG_PREFIX_REGEX + "\\[" + threadName + "\\] " + loggerName
         + " " + "a{" + (maxMessageSize - 2000) + "," + maxMessageSize + "}";
     checkRegexMatch(largeMsg, largeRegex);
 
-    String msg = mockServer.getMessageList().get(1);
+    String msg = new String(mockServer.getMessageList().get(1));
     assertTrue(msg.startsWith(expected));
     String regex = SYSLOG_PREFIX_REGEX + "\\[" + threadName + "\\] " + loggerName
         + " " + logMsg;
@@ -241,5 +243,36 @@ public class SyslogAppenderTest {
     sa.setFacility("MAIL");
     sa.start();
     sa.stop();
+  }
+
+  @Test
+  public void nonAsciiMessageEncoding() throws Exception {
+    // See LOGBACK-732
+    setMockServerAndConfigure(1);
+
+    // Use a string that can be encoded in a somewhat odd encoding (ISO-8859-4) to minimize
+    // the probability of the encoding test to work by accident
+    String logMsg = "Rīga";
+
+    Charset ISO_8859_4 = Charset.forName("ISO-8859-4");
+    sa.setCharset(ISO_8859_4);
+    logger.debug(logMsg);
+
+    // wait max 8 seconds for mock server to finish. However, it should
+    // be done much sooner than that.
+    mockServer.join(8000);
+
+    assertTrue(mockServer.isFinished());
+    assertEquals(1, mockServer.getMessageList().size());
+    String msg = new String(mockServer.getMessageList().get(0), ISO_8859_4);
+    String threadName = Thread.currentThread().getName();
+
+    String expected = "<"
+        + (SyslogConstants.LOG_MAIL + SyslogConstants.DEBUG_SEVERITY) + ">";
+    assertTrue(msg.startsWith(expected));
+
+    checkRegexMatch(msg, SYSLOG_PREFIX_REGEX + "\\[" + threadName + "\\] " + loggerName + " "
+        + logMsg);
+
   }
 }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/mock/MockSyslogServer.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/mock/MockSyslogServer.java
@@ -27,7 +27,7 @@ public class MockSyslogServer extends Thread {
   final int loopLen;
   final int port;
   
-  List<String> msgList = new ArrayList<String>();
+  List<byte[]> msgList = new ArrayList<byte[]>();
   boolean finished = false;
   
   public MockSyslogServer(int loopLen, int port) {
@@ -48,8 +48,9 @@ public class MockSyslogServer extends Thread {
         DatagramPacket packet = new DatagramPacket(buf, buf.length);
         //System.out.println("Waiting for message");
         socket.receive(packet);
-        String msg = new String(buf, 0, packet.getLength());
-        msgList.add(msg);
+        byte[] out = new byte[packet.getLength()];
+        System.arraycopy(buf, 0, out, 0, out.length);
+        msgList.add(out);
       }
     } catch (Exception se) {
       se.printStackTrace();
@@ -65,7 +66,7 @@ public class MockSyslogServer extends Thread {
     return finished;
   }
   
-  public List<String> getMessageList() {
+  public List<byte[]> getMessageList() {
     return msgList;
   }
 }

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -66,6 +66,12 @@
     href="http://jira.qos.ch/browse/LOGBACK-611">LOGBACK-611</a>)
     </p>
 
+    <p>It is now possible to configure the character encoding used by
+    <code>SyslogAppender</code> to encode messages using the
+    <code>setCharset()</code> method. This fixes <a
+    href="http://jira.qos.ch/browse/LOGBACK-732">LOGBACK-732</a>
+    </p>
+
     <h3>2nd of April, 2014 - Release of version 1.1.2</h3>
 
     <p>Create an abstract method, createOutputStream, as an extension point


### PR DESCRIPTION
The SyslogAppenderBase encodes message strings into byte sequences using the platform default charset, which is sometimes not what you want. This change adds the ability to configure which charset to use. The change is backwards compatible so that not calling setCharset() will result in the same behavior as before.
