### PR TITLE
Exposing lengthOption and evaluatorList to extended classes

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
@@ -36,8 +36,8 @@ public class ThrowableProxyConverter extends ThrowableHandlingConverter {
 
   protected static final int BUILDER_CAPACITY = 2048;
 
-  int lengthOption;
-  List<EventEvaluator<ILoggingEvent>> evaluatorList = null;
+  protected int lengthOption;
+  protected List<EventEvaluator<ILoggingEvent>> evaluatorList = null;
 
   int errorCount = 0;
 


### PR DESCRIPTION
These methods make it easier to extend the `ThrowableProxyConverter`. 

For example, I extended the `ThrowableProxyConverter` to implement Nurkiewicz's stack trace filtering functionality (LBCLASSIC-325) here: https://github.com/mrietveld/jbpm/commit/6ee0481ce21c7eade8be23a6153ab21fffe2442c