### PR TITLE
Moving access request log configuration in to its own method to allow extension

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
@@ -14,8 +14,6 @@
 package ch.qos.logback.access.jetty;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -43,7 +41,6 @@ import ch.qos.logback.core.spi.FilterAttachable;
 import ch.qos.logback.core.spi.FilterAttachableImpl;
 import ch.qos.logback.core.spi.FilterReply;
 import ch.qos.logback.core.status.ErrorStatus;
-import ch.qos.logback.core.status.WarnStatus;
 import ch.qos.logback.core.util.OptionHelper;
 
 /**
@@ -151,19 +148,23 @@ public class RequestLogImpl extends ContextBase implements RequestLog,
   }
 
   public void start() {
-    URL configURL = getConfigurationFileURL();
-    if (configURL != null) {
-      runJoranOnFile(configURL);
-    } else {
-      addError("Could not find configuration file for logback-access");
-    }
+    configure();
     if (!isQuiet()) {
       StatusPrinter.print(getStatusManager());
     }
     started = true;
   }
 
-  URL getConfigurationFileURL() {
+  protected void configure() {
+    URL configURL = getConfigurationFileURL();
+    if (configURL != null) {
+        runJoranOnFile(configURL);
+    } else {
+        addError("Could not find configuration file for logback-access");
+    }
+  }
+
+  protected URL getConfigurationFileURL() {
     if (fileName != null) {
       addInfo("Will use configuration file [" + fileName + "]");
       File file = new File(fileName);
@@ -266,7 +267,6 @@ public class RequestLogImpl extends ContextBase implements RequestLog,
 
   public void detachAndStopAllAppenders() {
     aai.detachAndStopAllAppenders();
-
   }
 
   public boolean detachAppender(Appender<IAccessEvent> appender) {

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -31,6 +31,10 @@
     
     <h3>Version 1.1.3</h3>
 
+    <p><code>RequestLogImpl</code> now has an overridable <code>configure</code>
+    method to allow extending implementations to configure it via methods
+    other than the <code>logback-access.xml</code> file.</p>
+
     <div class="breaking">
       <h4>All logback modules now require JDK 1.6 instead of
       previously JDK 1.5. This change was put to consultation on the


### PR DESCRIPTION
Motivation is the use of logback-access within Dropwizard, which provides its own tightly coupled configuration.
