### PR TITLE
Make prepareForDeferredProcessing on AccessEvent idempotent

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -481,9 +481,9 @@ public class AccessEvent implements Serializable, IAccessEvent {
   }
 
   public void prepareForDeferredProcessing() {
-    buildRequestHeaderMap();
-    buildRequestParameterMap();
-    buildResponseHeaderMap();
+    getRequestHeaderMap();
+    getRequestParameterMap();
+    getResponseHeaderMap();
     getLocalPort();
     getMethod();
     getProtocol();

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -31,6 +31,10 @@
     
     <h3>Version 1.1.3</h3>
 
+    <p>Fixed a bug in <code>AccessEvent</code> which could cause any
+    <code>AsyncAppender</code> based appender to corrupt the request
+    headers, request parameters, or response headers, before logging.</p>
+
     <div class="breaking">
       <h4>All logback modules now require JDK 1.6 instead of
       previously JDK 1.5. This change was put to consultation on the


### PR DESCRIPTION
Otherwise the OutputStreamAppender overwrites valid properties with now invalid properties when using an async appender.
