### PR TITLE
Update gmaven to gmavenplus plugin

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -159,25 +159,15 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
-          </dependency>
-        </dependencies>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.1</version>
         <executions>
           <execution>
-            <configuration>
-              <providerSelection>1.8</providerSelection>
-            </configuration>
             <goals>
               <goal>generateStubs</goal>
               <goal>compile</goal>
-              <goal>generateTestStubs</goal>
+              <goal>testGenerateStubs</goal>
               <goal>testCompile</goal>
             </goals>
           </execution>
@@ -228,12 +218,12 @@
             <id>ant-osgi-test</id>
             <phase>package</phase>
             <configuration>
-              <tasks>
+              <target>
                 <property name="currentVersion" value="${project.version}"/>
                 <property name="slf4j.version" value="${slf4j.version}"/>
                 <property name="basedir" value="${basedir}"/>
                 <ant antfile="${basedir}/osgi-build.xml"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>
@@ -244,10 +234,10 @@
             <id>ant-integration-test</id>
             <phase>package</phase>
             <configuration>
-              <tasks>
+              <target>
                 <property name="slf4j.version" value="${slf4j.version}"/>
                 <ant antfile="${basedir}/integration.xml"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>
@@ -327,12 +317,14 @@
               <pluginExecutions>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>gmaven-plugin</artifactId>
-                    <versionRange>[1.4,)</versionRange>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <versionRange>[1.1,)</versionRange>
                     <goals>
-                      <goal>generateTestStubs</goal>
+                      <goal>testGenerateStubs</goal>
                       <goal>generateStubs</goal>
+                      <goal>testCompile</goal>
+                      <goal>compile</goal>
                     </goals>
                   </pluginExecutionFilter>
                   <action>


### PR DESCRIPTION
Updated to newer groovy maven plus plugin
Switch from deprecated ant 'tasks' to ant 'target' maven xml tags
