### PR TITLE
Fix DateConverter to conform w/ISO8601 (LOGBACK-262)

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -142,6 +142,12 @@
       <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/logback-classic/src/test/java/ch/qos/logback/classic/ClassicTestConstants.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/ClassicTestConstants.java
@@ -16,7 +16,7 @@ package ch.qos.logback.classic;
 import ch.qos.logback.core.util.CoreTestConstants;
 
 public class ClassicTestConstants {
-  final static public String ISO_REGEX = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}";
+  final static public String ISO_REGEX = "\\d{4}-\\d{2}-\\d{2}T?\\d{2}:\\d{2}:\\d{2}(,\\d{3})?(Z|(\\+-\\d\\d:\\d\\d))?";
   //pool-1-thread-47
   final static public String NAKED_MAIN_REGEX = "([mM]ain|pool-\\d-)([Tt]hread)?(-\\d{1,3})?";
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/DateConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/DateConverterTest.java
@@ -1,0 +1,82 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2014, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.junit.Test;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.CoreConstants;
+
+/**
+ * Tests the {@link DateConverter}
+ */
+public class DateConverterTest {
+
+  private final Calendar CAL = getCalendar(2014,1,1,14,28,30,456);
+  private final String DATE_ISO801_UTC_STR  = "2014-01-01T14:28:30,456";
+  private final String DATE_ISO801_AWST_STR = "2014-01-01T22:28:30,456"; // AWST = UTC+8:00
+  private final long DATE_MS = CAL.getTimeInMillis();
+  private ILoggingEvent EVENT = getLogEvent();
+
+  @Test
+  public void convertsCustomDateTimeFormat() {
+    final String dateFormat = "(MM/dd/yy HH:mm)";
+    SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+    assertEquals(sdf.format(CAL.getTime()), getConverter(dateFormat).convert(EVENT));
+  }
+
+  @Test
+  public void convertsIso8601WithUtcTzOption() {
+    assertEquals(DATE_ISO801_UTC_STR, getConverter(CoreConstants.ISO8601_STR, "UTC").convert(EVENT));
+  }
+
+  @Test
+  public void convertsIso8601WithTzOption() {
+    assertEquals(DATE_ISO801_AWST_STR, getConverter(CoreConstants.ISO8601_STR, "Australia/Perth").convert(EVENT));
+  }
+
+  private ILoggingEvent getLogEvent() {
+    ILoggingEvent event = mock(ILoggingEvent.class);
+    when(event.getTimeStamp()).thenReturn(DATE_MS);
+    return event;
+  }
+
+  private Calendar getCalendar(int year, int month, int dayOfMonth, int hour, int minute, int second, int millisecond) {
+    Calendar cal = Calendar.getInstance();
+    cal.set(Calendar.DAY_OF_MONTH, dayOfMonth);
+    cal.set(Calendar.MONTH, month - 1);
+    cal.set(Calendar.YEAR, year);
+    cal.set(Calendar.HOUR_OF_DAY, hour);
+    cal.set(Calendar.MINUTE, minute);
+    cal.set(Calendar.SECOND, second);
+    cal.set(Calendar.MILLISECOND, millisecond);
+    cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return cal;
+  }
+
+  private DateConverter getConverter(String... options) {
+    DateConverter converter = new DateConverter();
+    converter.setOptionList(Arrays.asList(options));
+    converter.start();
+    return converter;
+  }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -50,7 +50,7 @@ public class CoreConstants {
   public static final String PATTERN_RULE_REGISTRY = "PATTERN_RULE_REGISTRY";
 
   public static final String ISO8601_STR = "ISO8601";
-  public static final String ISO8601_PATTERN = "yyyy-MM-dd HH:mm:ss,SSS";
+  public static final String ISO8601_PATTERN = "yyyy-MM-dd'T'HH:mm:ss,SSS";
   public static final String DAILY_DATE_PATTERN = "yyyy-MM-dd";
 
   /**

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -561,15 +561,15 @@ WARN  [main]: Message 2</p>
            </tr>
            <tr>
              <td>%d</td>
-             <td>2006-10-20 14:06:49,812</td>
+             <td>2006-10-20T14:06:49,812</td>
            </tr>
            <tr>
              <td>%date</td>
-             <td>2006-10-20 14:06:49,812</td>
+             <td>2006-10-20T14:06:49,812</td>
            </tr>
            <tr>
              <td>%date{ISO8601}</td>
-             <td>2006-10-20 14:06:49,812</td>
+             <td>2006-10-20T14:06:49,812</td>
            </tr>			
            <tr>
              <td>%date{HH:mm:ss.SSS}</td>
@@ -577,7 +577,7 @@ WARN  [main]: Message 2</p>
            </tr>
            <tr>
              <td>%date{dd&nbsp;MMM&nbsp;yyyy;HH:mm:ss.SSS}</td>
-             <td>20 oct. 2006;14:06:49.812	</td>
+             <td>20 Oct 2006;14:06:49.812	</td>
            </tr>
          </table>
          


### PR DESCRIPTION
ISO8601 requires the letter "T" as the delimiter between the date and
time fields, but we were incorrectly using a space.