### PR TITLE
LOGBACK-909 Fix race condition in SMTPAppenderBase

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/DilutedSMTPAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/DilutedSMTPAppenderTest.java
@@ -73,23 +73,11 @@ public class DilutedSMTPAppenderTest {
 
   @Test
   public void testStart() {
-    try {
-      Address[] addressArray = appender.getMessage().getFrom();
-      Address address = addressArray[0];
-      assertEquals("user@host.dom", address.toString());
+    assertEquals("sebastien.nospam@qos.ch%nopex", appender.getToAsListOfString().get(0));
 
-      addressArray = null;
-      address = null;
+    assertEquals("logging report", appender.getSubject());
 
-      assertEquals("sebastien.nospam@qos.ch%nopex", appender.getToAsListOfString().get(0));
-
-      assertEquals("logging report", appender.getSubject());
-
-      assertTrue(appender.isStarted());
-
-    } catch (MessagingException ex) {
-      fail("Unexpected exception.");
-    }
+    assertTrue(appender.isStarted());
   }
 
   @Test
@@ -105,13 +93,6 @@ public class DilutedSMTPAppenderTest {
   public void testEntryConditionsCheck() {
     appender.checkEntryConditions();
     assertEquals(0, appender.getContext().getStatusManager().getCount());
-  }
-
-  @Test
-  public void testEntryConditionsCheckNoMessage() {
-    appender.setMessage(null);
-    appender.checkEntryConditions();
-    assertEquals(1, appender.getContext().getStatusManager().getCount());
   }
 
   @Test


### PR DESCRIPTION
This is a fix for http://jira.qos.ch/browse/LOGBACK-909 (SMTPAppender synchronization problem in Asynchronous mode).

SMTPAppenderBase re-uses a single MimeMessage instance for all mails, which caused various problems in asynchronous mode, as MimeMessage is not thread safe. This patch modifies SMTPAppenderBase to create a new MimeMessage instance for each outgoing mail.
