### PR TITLE
Fix ISO-8601 date format to conform to the spec by replacing ' ' with 'T'

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/ClassicTestConstants.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/ClassicTestConstants.java
@@ -16,7 +16,7 @@ package ch.qos.logback.classic;
 import ch.qos.logback.core.util.CoreTestConstants;
 
 public class ClassicTestConstants {
-  final static public String ISO_REGEX = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}";
+  final static public String ISO_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}";
   //pool-1-thread-47
   final static public String NAKED_MAIN_REGEX = "([mM]ain|pool-\\d-)([Tt]hread)?(-\\d{1,3})?";
 

--- a/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -50,7 +50,7 @@ public class CoreConstants {
   public static final String PATTERN_RULE_REGISTRY = "PATTERN_RULE_REGISTRY";
 
   public static final String ISO8601_STR = "ISO8601";
-  public static final String ISO8601_PATTERN = "yyyy-MM-dd HH:mm:ss,SSS";
+  public static final String ISO8601_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
   public static final String DAILY_DATE_PATTERN = "yyyy-MM-dd";
 
   /**


### PR DESCRIPTION
Unfortunately it should also really append the timezone as well (e.g. with
an 'XX' at the end of the pattern) but that is not supported until Java 7...
