### PR TITLE
LOGBACK-116: RollingCalendarTest fails when user.timezone is not CEST

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/RollingCalendarTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/RollingCalendarTest.java
@@ -87,7 +87,7 @@ public class RollingCalendarTest extends TestCase {
       Date result = rc.getRelativeDate(nowDate, p);
       long offset = rc.getTimeZone().getRawOffset()+rc.getTimeZone().getDSTSavings();
     
-      long origin = now - (now % (MILLIS_IN_DAY)) - offset;      
+      long origin = now - ((now + offset) % (MILLIS_IN_DAY));      
       long expected = origin + p * MILLIS_IN_DAY;
       assertEquals("p="+p, expected, result.getTime());
     }


### PR DESCRIPTION
Correct time-zone offset handling.

I caught this error at 2014/7/14 23:07 JST.
You'll reproduce by setting this: mvn test -DargLine="-Duser.timezone=Asia/Tokyo"
Test will pass when mvn test -DargLine="-Duser.timezone=CEST"

```
Running ch.qos.logback.core.rolling.helper.RollingCalendarTest
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.082 sec <<< FAILURE! - in ch.qos.logback.core.rolling.helper.RollingCalendarTest
testPeriodicity(ch.qos.logback.core.rolling.helper.RollingCalendarTest)  Time elapsed: 0.019 sec
testVaryingNumberOfHourlyPeriods(ch.qos.logback.core.rolling.helper.RollingCalendarTest)  Time elapsed: 0.006 sec
testVaryingNumberOfDailyPeriods(ch.qos.logback.core.rolling.helper.RollingCalendarTest)  Time elapsed: 0.008 sec  <<< FAILURE!
junit.framework.AssertionFailedError: p=20 expected:<1224946800000> but was:<1225033200000>
    at junit.framework.Assert.fail(Assert.java:50)
    at junit.framework.Assert.failNotEquals(Assert.java:287)
    at junit.framework.Assert.assertEquals(Assert.java:67)
    at junit.framework.Assert.assertEquals(Assert.java:134)
    at ch.qos.logback.core.rolling.helper.RollingCalendarTest.testVaryingNumberOfDailyPeriods(RollingCalendarTest.java:92)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at junit.framework.TestCase.runTest(TestCase.java:168)
    at junit.framework.TestCase.runBare(TestCase.java:134)
    at junit.framework.TestResult$1.protect(TestResult.java:110)
    at junit.framework.TestResult.runProtected(TestResult.java:128)
    at junit.framework.TestResult.run(TestResult.java:113)
    at junit.framework.TestCase.run(TestCase.java:124)
    at junit.framework.TestSuite.runTest(TestSuite.java:243)
    at junit.framework.TestSuite.run(TestSuite.java:238)
    at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:83)
    at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
    at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
    at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
    at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)


Results :

Failed tests: 
  RollingCalendarTest.testVaryingNumberOfDailyPeriods:92 p=20 expected:<1224946800000> but was:<1225033200000>
```
