### PR TITLE
Add support for depth range to CallerDataConverter

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
@@ -13,10 +13,6 @@
  */
 package ch.qos.logback.classic.pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +32,9 @@ import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.net.SyslogConstants;
 import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.core.pattern.FormatInfo;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 public class ConverterTest {
 
@@ -74,7 +73,7 @@ public class ConverterTest {
       StringBuilder buf = new StringBuilder();
       converter.write(buf, le);
       // the number below should be the line number of the previous line
-      assertEquals("75", buf.toString());
+      assertEquals("74", buf.toString());
     }
   }
 
@@ -306,6 +305,21 @@ public class ConverterTest {
       // System.out.println(buf);
     }
 
+    {
+      DynamicConverter<ILoggingEvent> converter = new CallerDataConverter();
+      this.optionList.clear();
+      this.optionList.add("4..5");
+      converter.setOptionList(this.optionList);
+      converter.start();
+
+      StringBuilder buf = new StringBuilder();
+      converter.write(buf, le);
+      assertTrue("buf is too short", buf.length() >= 10);
+
+      String expected = "Caller+4\t at java.lang.reflect.Method.invoke(";
+      String actual = buf.toString().substring(0, expected.length());
+      assertThat(actual, is(expected));
+    }
   }
 
   @Test

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -624,7 +624,9 @@ WARN  [main]: Message 2</p>
 			<tr >
 				<td class="word" name="caller">
 					<b>caller{depth}</b>
+					<b>caller{depthStart..depthEnd}</b>
 					<b>caller{depth, evaluator-1, ... evaluator-n}</b>
+					<b>caller{depthStart..depthEnd, evaluator-1, ... evaluator-n}</b>
 				</td>
 
 				<td>
@@ -656,7 +658,16 @@ Caller+1   at mainPackage.sub.sample.Bar.createLoggingRequest(Bar.java:17)</pre>
 Caller+0   at mainPackage.sub.sample.Bar.sampleMethodName(Bar.java:22)
 Caller+1   at mainPackage.sub.sample.Bar.createLoggingRequest(Bar.java:17)
 Caller+2   at mainPackage.ConfigTester.main(ConfigTester.java:38)</pre>
-					
+
+                    <p>A range specifier can be added to the <em>caller</em> conversion specifier's
+                    options to configure the depth range of the information to be displayed.
+                    </p>
+
+                    <p>For example, <b>%caller{1..2}</b> would display the following excerpt:</p>
+
+<pre class="source white_bg">0    [main] DEBUG - logging statement
+Caller+0   at mainPackage.sub.sample.Bar.createLoggingRequest(Bar.java:17)</pre>
+
 					<p>This conversion word can also use evaluators to test
 					logging events against a given criterion before computing
 					caller data. For example, using <b>%caller{3,


### PR DESCRIPTION
The caller converter of the pattern layout supports specification
of depth which changes the number of levels it writes out
from the stack trace. If you need to skip some levels and write out
a range of stack trace elemens you cannot do so. This commit adds
support for ranges using the double dot ("..") notation. It can be useful
while using for example Scala traits to simplify logging which causes
the file and line number to be incorrect. This way the user can see
the actual place where logging was called.

**Documentation update (http://logback.qos.ch/manual/layouts.html#caller):**
A range specifier can be added to the caller conversion specifier's options to configure the depth range of the information to be displayed.
For example, `%caller{1..2}` would display the following excerpt:

```
0    [main] DEBUG - logging statement 
Caller+0   at mainPackage.sub.sample.Bar.createLoggingRequest(Bar.java:17)
```
