### PR TITLE
Use response encoding when creating the printwriter or you will run into...

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/servlet/TeeHttpServletResponse.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/servlet/TeeHttpServletResponse.java
@@ -41,8 +41,7 @@ public class TeeHttpServletResponse extends HttpServletResponseWrapper {
   @Override
   public PrintWriter getWriter() throws IOException {
     if (this.teeWriter == null) {
-      this.teeWriter = new PrintWriter(new OutputStreamWriter(getOutputStream()),
-          true);
+      this.teeWriter = new PrintWriter(new OutputStreamWriter(getOutputStream(), this.getResponse().getCharacterEncoding()), true);
     }
     return this.teeWriter;
   }

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyResponse.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyResponse.java
@@ -36,6 +36,9 @@ public class DummyResponse implements HttpServletResponse {
   int status = DUMMY_DEFAULT_STATUS;
   public Map<String, String> headerMap;
 
+  String characterEncoding = null;
+  ServletOutputStream outputStream = null;
+
   public DummyResponse() {
     headerMap = DUMMY_DEFAULT_HDEADER_MAP;
   }
@@ -101,7 +104,7 @@ public class DummyResponse implements HttpServletResponse {
   }
 
   public String getCharacterEncoding() {
-    return null;
+    return characterEncoding;
   }
 
   public String getContentType() {
@@ -113,7 +116,11 @@ public class DummyResponse implements HttpServletResponse {
   }
 
   public ServletOutputStream getOutputStream() throws IOException {
-    return null;
+    return outputStream;
+  }
+
+  public void setOutputStream(ServletOutputStream outputStream) {
+    this.outputStream = outputStream;
   }
 
   public PrintWriter getWriter() throws IOException {
@@ -133,7 +140,8 @@ public class DummyResponse implements HttpServletResponse {
   public void setBufferSize(int arg0) {
   }
 
-  public void setCharacterEncoding(String arg0) {
+  public void setCharacterEncoding(String characterEncoding) {
+    this.characterEncoding = characterEncoding;
   }
 
   public void setContentLength(int arg0) {

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyServletOutputStream.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyServletOutputStream.java
@@ -1,0 +1,29 @@
+package ch.qos.logback.access.dummy;
+
+import javax.servlet.ServletOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class DummyServletOutputStream extends ServletOutputStream {
+
+  private final OutputStream targetStream;
+
+  public DummyServletOutputStream(OutputStream targetStream) {
+    this.targetStream = targetStream;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    this.targetStream.write(b);
+  }
+
+  public void flush() throws IOException {
+    super.flush();
+    this.targetStream.flush();
+  }
+
+  public void close() throws IOException {
+    super.close();
+    this.targetStream.close();
+  }
+}

--- a/logback-access/src/test/java/ch/qos/logback/access/servlet/TeeHttpServletResponseTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/servlet/TeeHttpServletResponseTest.java
@@ -1,0 +1,55 @@
+package ch.qos.logback.access.servlet;
+
+import ch.qos.logback.access.dummy.DummyResponse;
+import ch.qos.logback.access.dummy.DummyServletOutputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertArrayEquals;
+
+@RunWith(Parameterized.class)
+public class TeeHttpServletResponseTest {
+
+  String characterEncoding;
+  String testString;
+  byte[] expectedBytes;
+
+  public TeeHttpServletResponseTest(String characterEncoding, String testString, byte[] expectedBytes) {
+    this.characterEncoding = characterEncoding;
+    this.testString = testString;
+    this.expectedBytes = expectedBytes;
+  }
+
+  @Parameterized.Parameters
+  public static Collection inputValues() {
+    return Arrays.asList(new Object[][]{
+      { "utf-8", "Gülcü", new byte[] { (byte) 0x47, (byte) 0xC3, (byte) 0xBC, (byte) 0x6C, (byte) 0x63, (byte) 0xC3, (byte) 0xBC }},
+      { "iso-8859-1", "Gülcü", new byte[] { (byte) 0x47, (byte) 0xFC, (byte) 0x6C, (byte) 0x63, (byte) 0xFC }}
+    });
+  }
+
+  @Test
+  public void testWriterEncoding() throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    DummyResponse dummyResponse = new DummyResponse();
+    dummyResponse.setCharacterEncoding(characterEncoding);
+    dummyResponse.setOutputStream(new DummyServletOutputStream(byteArrayOutputStream));
+
+    TeeHttpServletResponse teeServletResponse = new TeeHttpServletResponse(dummyResponse);
+
+    PrintWriter writer = teeServletResponse.getWriter();
+    writer.write(testString);
+    writer.flush();
+
+    assertArrayEquals(expectedBytes, byteArrayOutputStream.toByteArray());
+  }
+
+}


### PR DESCRIPTION
When configuring the Tee filter we ran into an issue where the wrong character encoding is used when writing to the response. The fix is to simply use the correct character encoding when constructing the printwriter
