### PR TITLE
LOGBACK-910: Set the interrupt flag when we catch InterruptException to ...

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -134,6 +134,7 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
       
     } catch (InterruptedException e) {
       addError("Failed to join worker thread. " + blockingQueue.size() + " queued events may be discarded.", e);
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -155,6 +156,7 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
     try {
       blockingQueue.put(eventObject);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
@@ -216,6 +216,20 @@ public class AsyncAppenderBaseTest {
     verify(la, loopLen);
   }
 
+  @Test
+  public void appendShouldNotClearInterruptFlag() throws Exception {
+    Thread.currentThread().interrupt();
+
+    asyncAppenderBase.addAppender(listAppender);
+    asyncAppenderBase.start();
+    asyncAppenderBase.doAppend(0);
+    asyncAppenderBase.stop();
+
+    assertTrue(Thread.currentThread().isInterrupted());
+    // clear flag for next test
+    Thread.interrupted();
+  }
+
   private void verify(ListAppender la, int expectedSize) {
     assertFalse(la.isStarted());
     assertEquals(expectedSize, la.list.size());


### PR DESCRIPTION
...avoid swallowing it.
We are currently using a library which uses the interrupt flag to abort the current job. If we log at the wrong time we currently lose that notification, and carry on like nothing happened. This can lead to critical errors in our case.