### PR TITLE
Fix for LOGBACK-840

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/DefaultArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/DefaultArchiveRemover.java
@@ -44,7 +44,7 @@ abstract public class DefaultArchiveRemover extends ContextAwareBase implements
 
 
   int computeElapsedPeriodsSinceLastClean(long nowInMillis) {
-    long periodsElapsed = 0;
+    long periodsElapsed;
     if (lastHeartBeat == UNINITIALIZED) {
       addInfo("first clean up after appender initialization");
       periodsElapsed = rc.periodsElapsed(nowInMillis, nowInMillis + INACTIVITY_TOLERANCE_IN_MILLIS);
@@ -53,8 +53,10 @@ abstract public class DefaultArchiveRemover extends ContextAwareBase implements
     } else {
       periodsElapsed = rc.periodsElapsed(lastHeartBeat, nowInMillis);
       if (periodsElapsed < 1) {
-        addWarn("Unexpected periodsElapsed value " + periodsElapsed);
         periodsElapsed = 1;
+        if(this instanceof TimeBasedArchiveRemover) {
+          addWarn("Unexpected periodsElapsed value " + periodsElapsed);
+        }
       }
     }
     return (int) periodsElapsed;

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemover.java
@@ -28,8 +28,7 @@ public class SizeAndTimeBasedArchiveRemover extends DefaultArchiveRemover {
 
     String regex = fileNamePattern.toRegexForFixedDate(dateOfPeriodToClean);
     String stemRegex = FileFilterUtil.afterLastSlash(regex);
-    File archive0 = new File(fileNamePattern.convertMultipleArguments(
-        dateOfPeriodToClean, 0));
+    File archive0 = new File(fileNamePattern.convertMultipleArguments(dateOfPeriodToClean, 0));
     // in case the file has no directory part, i.e. if it's written into the
     // user's current directory.
     archive0 = archive0.getAbsoluteFile();
@@ -38,9 +37,14 @@ public class SizeAndTimeBasedArchiveRemover extends DefaultArchiveRemover {
     File[] matchingFileArray = FileFilterUtil.filesInFolderMatchingStemRegex(
         parentDir, stemRegex);
 
-    for (File f : matchingFileArray) {
-      f.delete();
-    }
+    for (File file2Delete : matchingFileArray) {
+      boolean deleted = file2Delete.delete();
+      if(deleted) {
+        addInfo("deleting " + file2Delete);
+      } else {
+        addWarn("failed to delete " + file2Delete);
+      }
+	}
 
     if (parentClean) {
       removeFolderIfEmpty(parentDir);

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -28,8 +28,12 @@ public class TimeBasedArchiveRemover extends DefaultArchiveRemover {
     String filename = fileNamePattern.convert(date2delete);
     File file2Delete = new File(filename);
     if (file2Delete.exists() && file2Delete.isFile()) {
-      file2Delete.delete();
-      addInfo("deleting " + file2Delete);
+      boolean deleted = file2Delete.delete();
+      if(deleted) {
+        addInfo("deleting " + file2Delete);
+      } else {
+        addWarn("failed to delete " + file2Delete);
+      }
       if (parentClean) {
         removeFolderIfEmpty(file2Delete.getParentFile());
       }


### PR DESCRIPTION
Should not log warn for SizeAndTimeBasedArchiveRemover when the periodsElapsed is less than 1, as it is expected behavior. If the log is set to roll once per day, but is rolled because of size in between, the periodsElapsed will be less than 1.
