### PR TITLE
Logback 929

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
@@ -38,8 +38,8 @@ public class ExecutorServiceUtil {
 
     public Thread newThread(Runnable r) {
       Thread thread = defaultFactory.newThread(r);
-      if(!thread.isDaemon()){
-        thread.setDaemon( true );
+      if (!thread.isDaemon()) {
+        thread.setDaemon(true);
       }
       thread.setName("logback-" + threadNumber.getAndIncrement());
       return thread;

--- a/logback-core/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
@@ -38,6 +38,9 @@ public class ExecutorServiceUtil {
 
     public Thread newThread(Runnable r) {
       Thread thread = defaultFactory.newThread(r);
+      if(!thread.isDaemon()){
+        thread.setDaemon( true );
+      }
       thread.setName("logback-" + threadNumber.getAndIncrement());
       return thread;
     }


### PR DESCRIPTION
attempt to fix http://jira.qos.ch/browse/LOGBACK-929
basically daemonize threads created by logback's execution context.