### PR TITLE
AppenderBase started variable made volatile

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AppenderBase.java
@@ -32,7 +32,7 @@ import ch.qos.logback.core.status.WarnStatus;
 abstract public class AppenderBase<E> extends ContextAwareBase implements
     Appender<E> {
 
-  protected boolean started = false;
+  protected volatile boolean started = false;
 
   /**
    * The guard prevents an appender from repeatedly calling its own doAppend


### PR DESCRIPTION
 It is mutable, access to it is not synchronized and it is shared between threads, so it must be volatile for threads to be guaranteed to see the change in state.

Fix for http://jira.qos.ch/browse/LOGBACK-1037
