### PR TITLE
[LOGBACK-1019] Added code to close the DatagramSocket

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -21,6 +21,7 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import ch.qos.logback.core.util.CloseUtil;
 
 /**
  * SyslogOutputStream is a wrapper around the {@link DatagramSocket} class so that it
@@ -75,6 +76,7 @@ public class SyslogOutputStream extends OutputStream {
 
   public void close() {
     address = null;
+	CloseUtil.closeQuietly(ds);
     ds = null;
   }
 


### PR DESCRIPTION
I am surprised to see there is no close method called on the DatagramSocket this may lead to a UDP leak.
Kindly let me know if there is anything wrong in my code.
