### PR TITLE
[LOGBACK-1033] Enable serialization of HTTP request attributes

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -301,7 +301,7 @@ public class AccessEvent implements Serializable, IAccessEvent {
       if (names != null) {
         while (names.hasMoreElements()) {
           String name = names.nextElement();
-          attributeMap.put(name,httpRequest.getAttribute(name));
+          attributeMap.put(name, httpRequest.getAttribute(name));
         }
       }
     }

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -65,6 +65,7 @@ public class AccessEvent implements Serializable, IAccessEvent {
   Map<String, String> requestHeaderMap;
   Map<String, String[]> requestParameterMap;
   Map<String, String> responseHeaderMap;
+  Map<String, Object> attributeMap;
 
   long contentLength = SENTINEL;
   int statusCode = SENTINEL;
@@ -292,18 +293,28 @@ public class AccessEvent implements Serializable, IAccessEvent {
     return requestParameterMap;
   }
 
-  /**
-   * Attributes are not serialized
-   *
-   * @param key
-   */
+  private void copyAttributeMap() {
+    if (attributeMap == null && httpRequest != null) {
+      attributeMap = new HashMap<String, Object>();
+
+      Enumeration<String> names = httpRequest.getAttributeNames();
+      if (names != null) {
+        while (names.hasMoreElements()) {
+          String name = names.nextElement();
+          attributeMap.put(name,httpRequest.getAttribute(name));
+        }
+      }
+    }
+  }
+
   public String getAttribute(String key) {
-    if (httpRequest != null) {
-      Object value = httpRequest.getAttribute(key);
-      if (value == null) {
-        return NA;
-      } else {
+    copyAttributeMap();
+    if (attributeMap != null) {
+      Object value = attributeMap.get(key);
+      if (value != null) {
         return value.toString();
+      } else {
+        return NA;
       }
     } else {
       return NA;
@@ -500,5 +511,7 @@ public class AccessEvent implements Serializable, IAccessEvent {
     getContentLength();
     getRequestContent();
     getResponseContent();
+
+    copyAttributeMap();
   }
 }

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
@@ -92,11 +92,6 @@ public interface IAccessEvent extends DeferredProcessingAware {
 
   Map<String, String[]> getRequestParameterMap();
 
-  /**
-   * Attributes are not serialized
-   *
-   * @param key
-   */
   String getAttribute(String key);
 
   String[] getRequestParameter(String key);

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
@@ -176,7 +176,10 @@ public class DummyRequest implements HttpServletRequest {
   }
 
   public Enumeration getAttributeNames() {
-    return null;
+    return Collections.enumeration(Arrays.asList(
+            "testKey",
+            AccessConstants.LB_INPUT_BUFFER,
+            AccessConstants.LB_OUTPUT_BUFFER));
   }
 
   public String getCharacterEncoding() {


### PR DESCRIPTION
Added serialization to request attributes so they can be logged.