### PR TITLE
Change default PatternLayout to %ex (LOGBACK-966)

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/EnsureExceptionHandling.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/EnsureExceptionHandling.java
@@ -24,7 +24,7 @@ public class EnsureExceptionHandling implements
   /**
    * This implementation checks if any of the converters in the chain handles
    * exceptions. If not, then this method adds a
-   * {@link ExtendedThrowableProxyConverter} instance to the end of the chain.
+   * {@link ThrowableProxyConverter} instance to the end of the chain.
    * <p>
    * This allows appenders using this layout to output exception information
    * event if the user forgets to add %ex to the pattern. Note that the
@@ -43,7 +43,7 @@ public class EnsureExceptionHandling implements
     }
     if (!chainHandlesThrowable(head)) {
       Converter<ILoggingEvent> tail = ConverterUtil.findTail(head);
-      Converter<ILoggingEvent> exConverter = new ExtendedThrowableProxyConverter();
+      Converter<ILoggingEvent> exConverter = new ThrowableProxyConverter();
       tail.setNext(exConverter);
     }
   }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ExtendedThrowableProxyConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ExtendedThrowableProxyConverterTest.java
@@ -55,11 +55,11 @@ public class ExtendedThrowableProxyConverterTest {
         null);
   }
 
-  @Test
+ @Test
   public void integration() {
     PatternLayout pl = new PatternLayout();
     pl.setContext(lc);
-    pl.setPattern("%m%n");
+    pl.setPattern("%m%n%xEx");
     pl.start();
     ILoggingEvent e = createLoggingEvent(new Exception("x"));
     String res = pl.doLayout(e);


### PR DESCRIPTION
Set the default PatternLayout to use exception tracing without calculating packaging data when no Converter capable of handling exceptions is specified ([LOGBACK-966](http://jira.qos.ch/browse/LOGBACK-966)).

I changed the ExtendedThrowableProxyConverterTest because it was failing as it was, but I don't know if further changes are needed to it or ThrowableProxyConverterTest due to the fact that the default converter was altered. Please tell me if anything is missing.