### PR TITLE
Make AccessEvent.prepareForDeferredProcessing() to create a copy of the ...

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -295,11 +295,12 @@ public class AccessEvent implements Serializable, IAccessEvent {
 
   public String getAttribute(String key) {
     Object value = null;
-    if (httpRequest != null) {
-      value = httpRequest.getAttribute(key);
-    } else if (attributeMap != null) {
-      // Event was prepared for deferred processing so we have a copy of attribute map
+    if (attributeMap != null) {
+      // Event was prepared for deferred processing so we have a copy of attribute map and must use that copy
       value = attributeMap.get(key);
+    } else if (httpRequest != null) {
+      // We have original request so take attribute from it
+      value = httpRequest.getAttribute(key);
     }
 
     return value != null ? value.toString() : NA;

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
@@ -92,11 +92,6 @@ public interface IAccessEvent extends DeferredProcessingAware {
 
   Map<String, String[]> getRequestParameterMap();
 
-  /**
-   * Attributes are not serialized
-   *
-   * @param key
-   */
   String getAttribute(String key);
 
   String[] getRequestParameter(String key);

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
@@ -35,6 +35,7 @@ public class DummyRequest implements HttpServletRequest {
   
   Hashtable<String, String> headerNames;
   String uri;
+  Map<String, Object> attributes;
 
   static {
     DUMMY_DEFAULT_ATTR_MAP.put("testKey", "testKey");
@@ -46,6 +47,8 @@ public class DummyRequest implements HttpServletRequest {
     headerNames = new Hashtable<String, String>();
     headerNames.put("headerName1", "headerValue1");
     headerNames.put("headerName2", "headerValue2");
+
+    attributes = new HashMap<String, Object>(DUMMY_DEFAULT_ATTR_MAP);
   }
 
   public String getAuthType() {
@@ -170,11 +173,11 @@ public class DummyRequest implements HttpServletRequest {
   }
 
   public Object getAttribute(String key) {
-    return DUMMY_DEFAULT_ATTR_MAP.get(key);
+    return attributes.get(key);
   }
 
   public Enumeration getAttributeNames() {
-    return Collections.enumeration(DUMMY_DEFAULT_ATTR_MAP.keySet());
+    return Collections.enumeration(attributes.keySet());
   }
 
   public String getCharacterEncoding() {
@@ -304,7 +307,8 @@ public class DummyRequest implements HttpServletRequest {
   public void removeAttribute(String arg0) {
   }
 
-  public void setAttribute(String arg0, Object arg1) {
+  public void setAttribute(String name, Object value) {
+    attributes.put(name, value);
   }
 
   public void setCharacterEncoding(String arg0)

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
@@ -13,28 +13,34 @@
  */
 package ch.qos.logback.access.dummy;
 
+import ch.qos.logback.access.AccessConstants;
+
+import javax.servlet.*;
+import javax.servlet.http.*;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.*;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
-
-import ch.qos.logback.access.AccessConstants;
-
 public class DummyRequest implements HttpServletRequest {
 
   public final static String  DUMMY_CONTENT_STRING = "request contents";
-  public final static byte[] DUMMY_CONTENT_BYTES = DUMMY_CONTENT_STRING.getBytes(); 
+  public final static byte[] DUMMY_CONTENT_BYTES = DUMMY_CONTENT_STRING.getBytes();
 
-  
+  public static final Map<String, Object> DUMMY_DEFAULT_ATTR_MAP = new HashMap<String, Object>();
+
   public static final String DUMMY_RESPONSE_CONTENT_STRING = "response contents";
   public static final byte[] DUMMY_RESPONSE_CONTENT_BYTES =DUMMY_RESPONSE_CONTENT_STRING.getBytes();
   
   Hashtable<String, String> headerNames;
   String uri;
+
+  static {
+    DUMMY_DEFAULT_ATTR_MAP.put("testKey", "testKey");
+    DUMMY_DEFAULT_ATTR_MAP.put(AccessConstants.LB_INPUT_BUFFER, DUMMY_CONTENT_BYTES);
+    DUMMY_DEFAULT_ATTR_MAP.put(AccessConstants.LB_OUTPUT_BUFFER, DUMMY_RESPONSE_CONTENT_BYTES);
+  }
 
   public DummyRequest() {
     headerNames = new Hashtable<String, String>();
@@ -164,19 +170,11 @@ public class DummyRequest implements HttpServletRequest {
   }
 
   public Object getAttribute(String key) {
-    if (key.equals("testKey")) {
-      return "testKey";
-    } else if (AccessConstants.LB_INPUT_BUFFER.equals(key)) {
-      return DUMMY_CONTENT_BYTES;
-    } else if (AccessConstants.LB_OUTPUT_BUFFER.equals(key)) {
-      return DUMMY_RESPONSE_CONTENT_BYTES;
-    } else {
-      return null;
-    }
+    return DUMMY_DEFAULT_ATTR_MAP.get(key);
   }
 
   public Enumeration getAttributeNames() {
-    return null;
+    return Collections.enumeration(DUMMY_DEFAULT_ATTR_MAP.keySet());
   }
 
   public String getCharacterEncoding() {

--- a/logback-access/src/test/java/ch/qos/logback/access/spi/AccessEventSerializationTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/spi/AccessEventSerializationTest.java
@@ -13,20 +13,15 @@
  */
 package ch.qos.logback.access.spi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
-import org.junit.Test;
-
 import ch.qos.logback.access.dummy.DummyAccessEventBuilder;
 import ch.qos.logback.access.dummy.DummyRequest;
 import ch.qos.logback.access.dummy.DummyResponse;
+import org.junit.Test;
+
+import java.io.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class AccessEventSerializationTest  {
 
@@ -70,7 +65,9 @@ public class AccessEventSerializationTest  {
     
     assertEquals(DummyRequest.DUMMY_RESPONSE_CONTENT_STRING, aeBack
         .getResponseContent());
-    
+
+    assertEquals(DummyRequest.DUMMY_DEFAULT_ATTR_MAP.get("testKey"), aeBack
+        .getAttribute("testKey"));
   }
 
 }


### PR DESCRIPTION
...request attributes map so attributes are available later even if processing is done in a background thread.

Only Serializable attributes are copied to be on a safe side. Also, do not copy attributes set by Logback's TeeFilter as the very same information is already serialised as request/response content.

@tony19. this PR closes LOGBACK-1033 and superceedes the PR #238. How it is different:
* implementation changed to be more on the safe side and use the old logic (of getting request attribute directly from httpRequest) as long as httpRequest is available. Only if event was actually serialised and deserialised and transient httpRequest is lost, the copy of the attribute map will be used
* it only copied objects that are Serializable - again, to be on a safe side in case event is not just passed to a background thread  but serialised into file or something
* unit test is added

Release notes:
<p>AccessEvent now creates a copy of request attributes when its prepareForDeferredProcessing() method is called. This makes attributes visible even if appender uses a background thread to process events.
(<a href="http://jira.qos.ch/browse/LOGBACK-1033">LOGBACK-1033</a>).</p>
