### PR TITLE
LOGBACK-1046 fix suggestion

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -201,7 +201,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
       resilientFOS.postIOFailure(e);
     }
     finally {
-      if (fileLock != null) {
+      if (fileLock != null && fileLock.isValid()) {
         fileLock.release();
       }
 


### PR DESCRIPTION
as described in Jira, releasing the lock on a closed channel results in an Exception that renders the appender non-started for the rest of the application's life.
checking that the channel is still open before releasing it mitigates this problem.