### PR TITLE
introduced method GafferConfigurator.run(binding, dslText)

### DIFF
--- a/logback-classic/src/main/groovy/ch/qos/logback/classic/gaffer/GafferConfigurator.groovy
+++ b/logback-classic/src/main/groovy/ch/qos/logback/classic/gaffer/GafferConfigurator.groovy
@@ -50,7 +50,12 @@ class GafferConfigurator {
   }
 
   void run(String dslText) {
-    Binding binding = new Binding();
+    Binding binding = new Binding()
+    run(binding, dslText)
+  }
+
+  void run(Binding binding, String dslText) {
+
     binding.setProperty("hostname", ContextUtil.localHostName);
 
     def configuration = new CompilerConfiguration()


### PR DESCRIPTION
I need to pass Binding to GafferConfigurator for more flexible configuration in logback.groovy. Probably, others would need it as well.