### PR TITLE
Documentation: Fix <h3> tag issue

### DIFF
--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -2782,7 +2782,7 @@ logger.error(<b>notifyAdmin</b>,
     connection is encrypted right from the start.
     </p>
 
-    <h3> class="doAnchor" name="gmailSSL">SMTPAppender configuration
+    <h3 class="doAnchor" name="gmailSSL">SMTPAppender configuration
     for Gmail (SSL)</h3>
 
     <p>The next example shows you how to configure


### PR DESCRIPTION
The Appenders manual page had some markup being rendered on the page due to a premature close tag.

![doc-gmail](https://cloud.githubusercontent.com/assets/4712580/6431703/402ef94a-bfed-11e4-8a18-aea89a6e0824.png)


This pull request fixes that.

I've signed the CLA.