### PR TITLE
Add XML support to en/disable stacktrace package detail

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
@@ -45,6 +45,9 @@ import ch.qos.logback.core.status.WarnStatus;
 public class LoggerContext extends ContextBase implements ILoggerFactory,
         LifeCycle {
 
+  /** Default setting of stacktrace packaging detail */
+  public static final boolean DEFAULT_PACKAGING_STATE = false;
+
   final Logger root;
   private int size;
   private int noAppenderWarning = 0;
@@ -54,7 +57,7 @@ public class LoggerContext extends ContextBase implements ILoggerFactory,
 
   private LoggerContextVO loggerContextRemoteView;
   private final TurboFilterList turboFilterList = new TurboFilterList();
-  private boolean packagingDataEnabled = true;
+  private boolean packagingDataEnabled = DEFAULT_PACKAGING_STATE;
 
   private int maxCallerDataDepth = ClassicConstants.DEFAULT_MAX_CALLEDER_DATA_DEPTH;
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/ConfigurationAction.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/ConfigurationAction.java
@@ -27,6 +27,7 @@ import ch.qos.logback.core.util.OptionHelper;
 
 public class ConfigurationAction extends Action {
   static final String INTERNAL_DEBUG_ATTR = "debug";
+  static final String PACKAGING_INFO_ATTR = "packageTrace";
   static final String SCAN_ATTR = "scan";
   static final String SCAN_PERIOD_ATTR = "scanPeriod";
   static final String DEBUG_SYSTEM_PROPERTY_KEY = "logback.debug";
@@ -56,8 +57,13 @@ public class ConfigurationAction extends Action {
     ContextUtil contextUtil = new ContextUtil(context);
     contextUtil.addHostNameAsProperty();
 
-    if(EnvUtil.isGroovyAvailable()) {
-      LoggerContext lc = (LoggerContext) context;
+    LoggerContext lc = (LoggerContext) context;
+    boolean packageTraceEnabled = OptionHelper.toBoolean(
+                                    ic.subst(attributes.getValue(PACKAGING_INFO_ATTR)),
+                                    LoggerContext.DEFAULT_PACKAGING_STATE);
+    lc.setPackagingDataEnabled(packageTraceEnabled);
+
+    if (EnvUtil.isGroovyAvailable()) {
       contextUtil.addGroovyPackages(lc.getFrameworkPackages());
     }
 

--- a/logback-classic/src/test/input/joran/packageDataDisabled.xml
+++ b/logback-classic/src/test/input/joran/packageDataDisabled.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration debug="true" packageTrace="false">
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <param name="Pattern"  value="%d - %m%n"/>
+    </layout>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="CONSOLE" />
+  </root>
+
+</configuration>

--- a/logback-classic/src/test/input/joran/packageDataEnabled.xml
+++ b/logback-classic/src/test/input/joran/packageDataEnabled.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration debug="true" packageTrace="true">
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <param name="Pattern"  value="%d - %m%n"/>
+    </layout>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="CONSOLE" />
+  </root>
+
+</configuration>

--- a/logback-classic/src/test/java/ch/qos/logback/classic/joran/JoranConfiguratorTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/joran/JoranConfiguratorTest.java
@@ -462,4 +462,20 @@ public class JoranConfiguratorTest {
 
     checker.assertIsErrorFree();
   }
+
+  @Test
+  public void packageDataDisabledByConfigAttribute() throws JoranException {
+    String configFileAsStr = ClassicTestConstants.JORAN_INPUT_PREFIX
+              + "packageDataDisabled.xml";
+    configure(configFileAsStr);
+    assertFalse(loggerContext.isPackagingDataEnabled());
+  }
+
+  @Test
+  public void packageDataEnabledByConfigAttribute() throws JoranException {
+    String configFileAsStr = ClassicTestConstants.JORAN_INPUT_PREFIX
+            + "packageDataEnabled.xml";
+    configure(configFileAsStr);
+    assertTrue(loggerContext.isPackagingDataEnabled());
+  }
 }

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -268,6 +268,51 @@ public class Foo {
    directory accessible from the class path. Running the <em>MyApp1</em>
    application should give identical results to its previous run.</p>
 
+   <h4 class="doAnchor" name="packageTrace">Enabling packaging
+   detail in stacktraces</h4>
+
+   <p>logback can include packaging data in stacktraces to help track
+   down the culprit JAR(s) of an exception, as shown in the following
+   example:</p>
+
+   <pre>14:28:48.835 [btpool0-7] INFO  c.q.l.demo.prime.PrimeAction - 99 is not a valid value
+java.lang.Exception: 99 is invalid
+  at ch.qos.logback.demo.prime.PrimeAction.execute(PrimeAction.java:28) [classes/:na]
+  at org.apache.struts.action.RequestProcessor.processActionPerform(RequestProcessor.java:431) [struts-1.2.9.jar:1.2.9]
+  at org.apache.struts.action.RequestProcessor.process(RequestProcessor.java:236) [struts-1.2.9.jar:1.2.9]
+  at org.apache.struts.action.ActionServlet.doPost(ActionServlet.java:432) [struts-1.2.9.jar:1.2.9]
+  at javax.servlet.http.HttpServlet.service(HttpServlet.java:820) [servlet-api-2.5-6.1.12.jar:6.1.12]
+  at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:502) [jetty-6.1.12.jar:6.1.12]
+  at ch.qos.logback.demo.UserServletFilter.doFilter(UserServletFilter.java:44) [classes/:na]
+  at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1115) [jetty-6.1.12.jar:6.1.12]
+  at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:361) [jetty-6.1.12.jar:6.1.12]
+  at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:417) [jetty-6.1.12.jar:6.1.12]
+  at org.mortbay.jetty.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:230) [jetty-6.1.12.jar:6.1.12]</pre>
+
+  <p class="highlight">While stacktrace packaging detail can be helpful in
+  many situations, it is rather expensive to compute, especially for
+  deep stacktraces. Consider avoiding this option in performance-critical
+  code.</p>
+
+   <p>To enable this lookup programmatically, set the context's
+   <a href="http://logback.qos.ch/apidocs/ch/qos/logback/classic/LoggerContext.html#setPackagingDataEnabled(boolean)">
+   <code>setPackagingDataEnabled(boolean)</code></a>:<p>
+
+<pre class="prettyprint lang-java source">
+public static void main(String[] args) {
+  <b>LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();</b>
+  // enable packaging detail for stacktraces
+  <b>lc.setPackagingDataEnabled(true);</b>
+  ...
+}</pre>
+
+   <p>This can also be enabled from <code>logback.xml</code> with:</p>
+
+<pre class="prettyprint source">
+&lt;configuration <span class="big bold">packageTrace="true"</span>>
+  ...
+&lt;/configuration></pre>
+
    <h4 class="doAnchor" name="automaticStatusPrinting">Automatic
    printing of status messages in case of warning or errors</h4>
 
@@ -294,13 +339,13 @@ public class Foo {
 
   
 <pre class="prettyprint lang-java source">
-  public static void main(String[] args) {
-    // assume SLF4J is bound to logback in the current environment
-    <b>LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();</b>
-    // print logback's internal status
-    <b>StatusPrinter.print(lc);</b>
-    ...
-  }</pre>
+public static void main(String[] args) {
+  // assume SLF4J is bound to logback in the current environment
+  <b>LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();</b>
+  // print logback's internal status
+  <b>StatusPrinter.print(lc);</b>
+  ...
+}</pre>
 
   <p>If everything goes well, you should see the following output on the console</p>
 


### PR DESCRIPTION
Changed the default enable status of packaging info in stacktraces
to be disabled to avoid the expensive lookup unless requested.

Added an XML attribute "packageTrace" to <configuration> in order to
allow enabling or disabling the packaging info in stacktraces. When
the attribute is omitted, the default setting is assumed (disabled).

To enable package detail in logback.xml:

```xml
  <configuration packageTrace="true">
    ...
  </configuration>
```

LOGBACK-730
LOGBACK-966