### PR TITLE
LOGBACK-488 Enable 'hostname' variable to be accessible from nested scope when using Groovy DSL

### DIFF
--- a/logback-classic/src/main/groovy/ch/qos/logback/classic/gaffer/ComponentDelegate.groovy
+++ b/logback-classic/src/main/groovy/ch/qos/logback/classic/gaffer/ComponentDelegate.groovy
@@ -85,7 +85,7 @@ class ComponentDelegate extends ContextAwareBase {
     }
   }
 
-  void propertyMissing(String name, def value) {
+  void set(String name, def value) {
     NestingType nestingType = PropertyUtil.nestingType(component, name);
     if (nestingType == NestingType.NA) {
       addError("${getLabelFistLetterInUpperCase()} ${getComponentName()} of type [${component.getClass().canonicalName}] has no appplicable [${name}] property ")

--- a/logback-classic/src/test/groovy/ch/qos/logback/classic/gaffer/GafferConfiguratorTest.groovy
+++ b/logback-classic/src/test/groovy/ch/qos/logback/classic/gaffer/GafferConfiguratorTest.groovy
@@ -161,6 +161,16 @@ class GafferConfiguratorTest {
         assertEquals("HELLO %m%n", ca.encoder.getLayout().pattern)
     }
 
+    @Test
+    public void hostnameCascading() {
+        File file = new File(ClassicTestConstants.GAFFER_INPUT_PREFIX + "hostnameCascading.groovy")
+        String dslText = file.text
+        configurator.run dslText
+
+        ConsoleAppender ca = (ConsoleAppender) root.getAppender("STDOUT");
+        assertTrue ca.isStarted()
+        assertEquals("%m%n", ca.encoder.getLayout().pattern)
+    }
 
     @Test
     @Ignore

--- a/logback-classic/src/test/input/gaffer/appenderRefWithNonAppenderAttachable.groovy
+++ b/logback-classic/src/test/input/gaffer/appenderRefWithNonAppenderAttachable.groovy
@@ -18,7 +18,7 @@ import ch.qos.logback.core.encoder.LayoutWrappingEncoder
 appender("STDOUT", ConsoleAppender) {
   encoder(LayoutWrappingEncoder) {
     layout(PatternLayout) {
-      pattern = "${p} %m%n"
+      pattern = "%m%n"
     }
   }
 }

--- a/logback-classic/src/test/input/gaffer/hostnameCascading.groovy
+++ b/logback-classic/src/test/input/gaffer/hostnameCascading.groovy
@@ -11,20 +11,32 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-import ch.qos.logback.classic.AsyncAppender
-import ch.qos.logback.classic.PatternLayout
+//
+// Built on Wed May 19 20:51:44 CEST 2010 by logback-translator
+// For more information on configuration files in Groovy
+// please see http://logback.qos.ch/manual/groovy.html
+//
+
 import ch.qos.logback.core.ConsoleAppender
+
+import static ch.qos.logback.classic.Level.DEBUG
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder
+import ch.qos.logback.classic.PatternLayout
+
+def HOSTNAME = hostname
+assert HOSTNAME != null
 
 appender("STDOUT", ConsoleAppender) {
+  assert hostname == HOSTNAME
+
   encoder(LayoutWrappingEncoder) {
+    assert hostname == HOSTNAME
+
     layout(PatternLayout) {
+      assert hostname == HOSTNAME
+
       pattern = "%m%n"
     }
   }
 }
-appender("STDOUT-ASYNC", AsyncAppender) {
-  appenderRef('STDOUT')
-}
-root(DEBUG, ["STDOUT-ASYNC"])
-
+root(DEBUG, ["STDOUT"])


### PR DESCRIPTION
Logback's Groovy doc [mentioned](http://logback.qos.ch/manual/groovy.html#hostname) that:
> ...due to scoping rules that the authors cannot fully explain, the 'hostname' variable is available only at the topmost scope but not in nested scopes.

The reason for this is because while `ComponentDelegate.propertyMissing(String, def)` was meant (I'm guessing) to _only_ resolve missing property **setter**, Groovy _also_ used it to resolve missing property **getter**.

The latter would silently fail, making Groovy thinks everything is OK.

### Documentation
Rule P8 of [CONTRIBUTING.md](https://github.com/qos-ch/logback/blob/master/CONTRIBUTING.md) says (the above) documentation must be updated, but I'm not sure how it should be written...

### Release note
```
<p>'hostname' variable is now accessible from nested scope when using Groovy DSL. (<a href="http://jira.qos.ch/browse/LOGBACK-488">LOGBACK-488</a>)</p>
```