### PR TITLE
Fixed a bug in TimeBasedFileNamingAndTriggeringPolicyBase

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
@@ -15,6 +15,7 @@ package ch.qos.logback.core.rolling;
 
 import java.io.File;
 import java.util.Date;
+import java.util.Locale;
 
 import ch.qos.logback.core.rolling.helper.ArchiveRemover;
 import ch.qos.logback.core.rolling.helper.DateTokenConverter;
@@ -48,7 +49,11 @@ abstract public class TimeBasedFileNamingAndTriggeringPolicyBase<E> extends
               + "] does not contain a valid DateToken");
     }
 
-    rc = new RollingCalendar();
+    if (dtc.getTimeZone() != null) {
+      rc = new RollingCalendar(dtc.getTimeZone(), Locale.getDefault());
+    } else {
+      rc = new RollingCalendar();
+    }
     rc.init(dtc.getDatePattern());
     addInfo("The date pattern is '" + dtc.getDatePattern()
             + "' from file name pattern '" + tbrp.fileNamePattern.getPattern()


### PR DESCRIPTION
Fixed a bug in TimeBasedFileNamingAndTriggeringPolicyBase causing the policy to always rollover according to the local system time and ignore the time zone passed in the file name pattern. LOGBACK-611 introduced the possibility to specify time zone in the file name pattern and the file names are now correctly created according to the specified time zone. However, rollover is still based on the old behaviour, e.g., if the pattern is set to /wombat/foo.{%d, UTC}, rollover will happen at midnight of the local system time, instead of midnight in UTC. If for example the log is created at 00:59+01:00 02/01/2015 (local system time), the rollover will happen at 00:00+01:00 03/01/2015 instead of 01:00+01:00 02/01/2015 (i.e., 00:00Z 02/01/2015). If the encoder is configured to use UTC timestamps, log file /wombat/foo.2015-01-01 will contain log entries starting at 23:59 01/01/2015 up to 22:59 02/01/2015.  