### PR TITLE
replaces <span> with <b> so the viewAsGroovy Link works again

### DIFF
--- a/logback-site/src/site/pages/js/dsl.js
+++ b/logback-site/src/site/pages/js/dsl.js
@@ -15,7 +15,7 @@ function asGroovy(id) {
   inner = inner.replace(/&lt;/gi, '<');
   inner = inner.replace(/&gt;/gi, '>');
 
-  inner = inner.replace(/<span class="?\w{3,5}"?>/gi, '');
+  inner = inner.replace(/<span class="[^"]*"?>/gi, '');
   inner = inner.replace(/<\/span>/gi, '');
   inner = inner.replace(/<br>/gi, '');
   inner = inner.replace(/&nbsp;/gi, '');


### PR DESCRIPTION
With this commit the viewAsGroovy link works again. Although I'm not sure the generated groovy config is correct because the debug() statement is missing.