### PR TITLE
Use context Classloader first if it is defined

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/Loader.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/Loader.java
@@ -121,7 +121,10 @@ public class Loader {
 
   public static Class<?> loadClass(String clazz, Context context)
           throws ClassNotFoundException {
-    ClassLoader cl = getClassLoaderOfObject(context);
+    ClassLoader cl = getTCL();
+    if(cl == null){
+      cl = getClassLoaderOfObject(context);
+    }
     return cl.loadClass(clazz);
   }
 


### PR DESCRIPTION
This PR was initally motivated by an issue where logback was unable to resolve a
custom filter in a play 2.3 and 2.4 application in dev mode.
The issue is that for all dependencies, including logback, the classes are
loaded in a DependencyClassloader which is stable, while the project code is i
loaded in a ReloadableClassloader which is a child of the stable class loader
and is discarded whenever project source code changes.

Since logback doesn't allow to pass a custom classloader, nor does it lookup the
context classloader, it tries to resolve project classes in the stable
classloader and fails to find project classes.

This small change tries to use the context classloader first if it is set, and
then falls back to the original behaviour. This effectively fixes the problem
for play applications in dev mode (tried using maven install and depending on the patched version locally)

More background on the classloader architecture in Play applications can be found in https://github.com/playframework/playframework/issues/2847