### PR TITLE
Resolve DNS (respecting InetAddress caching rules) for each UDP packet.

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -43,7 +43,6 @@ public class SyslogOutputStream extends OutputStream {
   public SyslogOutputStream(String syslogHost, int port) throws UnknownHostException,
       SocketException {
     this.syslogHost = syslogHost;
-    this.address = InetAddress.getByName(syslogHost);
     this.port = port;
     this.ds = new DatagramSocket();
   }

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -35,12 +35,14 @@ public class SyslogOutputStream extends OutputStream {
   private static final int MAX_LEN = 1024;
 
   private InetAddress address;
+  private String syslogHost;
   private DatagramSocket ds;
   private ByteArrayOutputStream baos = new ByteArrayOutputStream();
   final private int port;
 
   public SyslogOutputStream(String syslogHost, int port) throws UnknownHostException,
       SocketException {
+    this.syslogHost = syslogHost;
     this.address = InetAddress.getByName(syslogHost);
     this.port = port;
     this.ds = new DatagramSocket();
@@ -52,7 +54,7 @@ public class SyslogOutputStream extends OutputStream {
 
   public void flush() throws IOException {
     byte[] bytes = baos.toByteArray();
-    DatagramPacket packet = new DatagramPacket(bytes, bytes.length, address,
+    DatagramPacket packet = new DatagramPacket(bytes, bytes.length, InetAddress.getByName(this.syslogHost),
         port);
 
     // clean up for next round
@@ -61,7 +63,7 @@ public class SyslogOutputStream extends OutputStream {
     } else {
       baos.reset();
     }
-    
+
     // after a failure, it can happen that bytes.length is zero
     // in that case, there is no point in sending out an empty message/
     if(bytes.length == 0) {
@@ -70,7 +72,7 @@ public class SyslogOutputStream extends OutputStream {
     if (this.ds != null) {
       ds.send(packet);
     }
-  
+
   }
 
   public void close() {


### PR DESCRIPTION
When using the SyslogOutputStream (noting that it's also used by LogstashSocketAppender) the InetAddress DNS lookup result is cached at initialization. The resulting effect is that if the upstream syslog host changes IP (such as in a cloud environment where the instance is relaunched) logs are silently dropped (as they're sent using UDP) until logging is re-initialized (typically a service restart). Additionally, it blocks horizontal scaling of upstream syslog servers using a DNS round robin approach.

The submitted change uses the standard InetAddress DNS caching mechanism and so (DNS configuration dependent, but by default) does not result in a large overhead on DNS servers or the local JVM.