### PR TITLE
Tokenizer: allow '$' at the end of string

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/subst/Tokenizer.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/subst/Tokenizer.java
@@ -60,7 +60,8 @@ public class Tokenizer {
         addLiteralToken(tokenList, buf);
         break;
       case START_STATE:
-        throw new ScanException("Unexpected end of pattern string");
+        buf.append(CoreConstants.DOLLAR);
+        addLiteralToken(tokenList, buf);
     }
     return tokenList;
   }

--- a/logback-core/src/test/java/ch/qos/logback/core/subst/TokenizerTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/subst/TokenizerTest.java
@@ -56,16 +56,13 @@ public class TokenizerTest {
   public void scalaObjectLogger() {
     /*
      * logger name of scala object is like "a.b.o$" which
-     * should make dollar sign at tail a valid token.
+     * should make trailing dollar sign valid.
      */
     try {
-      String input0 = "package.object";
-      String input1 = "$";
-      String input = input0 + input1;
+      String input = "package.object$";
       Tokenizer tokenizer = new Tokenizer(input);
       List<Token> tokenList = tokenizer.tokenize();
-      witnessList.add(new Token(Token.Type.LITERAL, input0));
-      witnessList.add(new Token(Token.Type.LITERAL, input1));
+      witnessList.add(new Token(Token.Type.LITERAL, input));
       assertEquals(witnessList, tokenList);
     } catch (ScanException e) {
       fail("This should be a valid token");

--- a/logback-core/src/test/java/ch/qos/logback/core/subst/TokenizerTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/subst/TokenizerTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TokenizerTest {
 
@@ -51,6 +52,25 @@ public class TokenizerTest {
     assertEquals(witnessList, tokenList);
   }
 
+  @Test
+  public void scalaObjectLogger() {
+    /*
+     * logger name of scala object is like "a.b.o$" which
+     * should make dollar sign at tail a valid token.
+     */
+    try {
+      String input0 = "package.object";
+      String input1 = "$";
+      String input = input0 + input1;
+      Tokenizer tokenizer = new Tokenizer(input);
+      List<Token> tokenList = tokenizer.tokenize();
+      witnessList.add(new Token(Token.Type.LITERAL, input0));
+      witnessList.add(new Token(Token.Type.LITERAL, input1));
+      assertEquals(witnessList, tokenList);
+    } catch (ScanException e) {
+      fail("This should be a valid token");
+    }
+  }
 
   @Test
   public void simleVariable() throws ScanException {


### PR DESCRIPTION
For scala object, `object SomeObject {}` for example, the logger name will be `a.b.SomeObject$`. Let the Tokenizer class accept the dollar sign at the end of string in order to allow xml file to config it.

```
<logger name="a.b.SomeObject$" level="INFO" />
```
