### PR TITLE
fix LOGBACK-551: create a DelegateAppender which delegates all events to multiple child appenders

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/DelegateAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/DelegateAppender.java
@@ -30,7 +30,7 @@ import ch.qos.logback.core.spi.AppenderAttachableImpl;
  */
 public class DelegateAppender extends AppenderBase<ILoggingEvent> implements AppenderAttachable<ILoggingEvent> {
 
-  AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<ILoggingEvent>();
+  private AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<ILoggingEvent>();
 
   /**
    * {@inheritDoc}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/DelegateAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/DelegateAppender.java
@@ -1,0 +1,119 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) <year>, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic;
+
+import java.util.Iterator;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.spi.AppenderAttachable;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+
+
+/**
+ * Appender which delegates all events to child appenders.
+ *
+ * @author Juan Pablo Santos Rodríguez
+ * @see http://jira.qos.ch/browse/LOGBACK-551
+ */
+public class DelegateAppender extends AppenderBase<ILoggingEvent> implements AppenderAttachable<ILoggingEvent> {
+
+  AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<ILoggingEvent>();
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.AppenderBase#append(java.lang.Object)
+   */
+  @Override
+  protected void append(ILoggingEvent eventObject) {
+    Iterator<Appender<ILoggingEvent>> appenders = iteratorForAppenders();
+    while(appenders.hasNext()) {
+      appenders.next().doAppend(eventObject);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#addAppender(ch.qos.logback.core.Appender)
+   */
+  @Override
+  public void addAppender(Appender< ILoggingEvent > newAppender) {
+    addInfo("Attaching appender named [" + newAppender.getName() + "] to DelegateAppender.");
+    aai.addAppender(newAppender);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#iteratorForAppenders()
+   */
+  @Override
+  public Iterator<Appender<ILoggingEvent>> iteratorForAppenders() {
+    return aai.iteratorForAppenders();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#getAppender(java.lang.String)
+   */
+  @Override
+  public Appender< ILoggingEvent > getAppender(String name) {
+    return aai.getAppender(name);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#isAttached(ch.qos.logback.core.Appender)
+   */
+  @Override
+  public boolean isAttached(Appender<ILoggingEvent> appender) {
+    return aai.isAttached(appender);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#detachAndStopAllAppenders()
+   */
+  @Override
+  public void detachAndStopAllAppenders() {
+    aai.detachAndStopAllAppenders();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#detachAppender(ch.qos.logback.core.Appender)
+   */
+  @Override
+  public boolean detachAppender(Appender<ILoggingEvent> appender) {
+    return aai.detachAppender(appender);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see ch.qos.logback.core.spi.AppenderAttachable#detachAppender(java.lang.String)
+   */
+  @Override
+  public boolean detachAppender(String name) {
+    return aai.detachAppender(name);
+  }
+
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/DelegateAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/DelegateAppenderTest.java
@@ -1,0 +1,66 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) <year>, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import ch.qos.logback.classic.net.testObjectBuilders.LoggingEventBuilderInContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.read.ListAppender;
+
+
+/**
+ * Unit tests associated to {@link DelegateAppender}.
+ *
+ * @author Juan Pablo Santos Rodríguez
+ */
+public class DelegateAppenderTest {
+
+  @Test
+  public void testDelegatesToChildAppendersOnDoAppend() {
+    // given
+    LoggerContext lc = new LoggerContext();
+
+    ListAppender<ILoggingEvent> listApp1 = new ListAppender<ILoggingEvent>();
+    listApp1.setContext(lc);
+    listApp1.setName("list1");
+    listApp1.start();
+
+    ListAppender<ILoggingEvent> listApp2 = new ListAppender<ILoggingEvent>();
+    listApp2.setContext(lc);
+    listApp2.setName("list2");
+    listApp2.start();
+
+    DelegateAppender delegateApp = new DelegateAppender();
+    delegateApp.addAppender(listApp1);
+    delegateApp.addAppender(listApp2);
+    delegateApp.setContext(lc);
+    delegateApp.setName("delegate");
+    delegateApp.start();
+
+    LoggingEventBuilderInContext builder = new LoggingEventBuilderInContext(lc, DelegateAppenderTest.class.getName(), UnsynchronizedAppenderBase.class.getName());
+
+    // when
+    delegateApp.doAppend(builder.build(66));
+    delegateApp.stop();
+
+    // then
+    assertEquals(1, listApp1.list.size());
+    assertEquals(1, listApp2.list.size());
+  }
+
+}

--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -4077,6 +4077,41 @@ import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
   &lt;/root>
 &lt;/configuration></pre>
   
+    <h3 class="doAnchor" name="DelegateAppender">DelegateAppender</h3>
+    
+    <p>DelegateAppender, as its name suggests, delegates <a
+    href="../apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html">ILoggingEvent</a>s
+    to underlying appenders. It acts solely as an event dispatcher and must
+    therefore reference one or more appenders in order to do anything
+    useful.</p>
+    
+    <p class="example">Example: <code>DelegateAppender</code> configuration</p>
+
+    <span class="asGroovy" onclick="return asGroovy('delegateAppender');">View as .groovy</span>
+
+    <pre id="delegateAppender" class="prettyprint source">&lt;configuration>
+  &lt;appender name="<b>FILE</b>" class="ch.qos.logback.core.FileAppender">
+    &lt;file>myapp.log&lt;/file>
+    &lt;encoder>
+      &lt;pattern>%logger{35} - %msg%n&lt;/pattern>
+    &lt;/encoder>
+  &lt;/appender>
+  
+  &lt;appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    &lt;encoder>
+      &lt;pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n&lt;/pattern>
+    &lt;/encoder>
+  &lt;/appender>
+
+  <b>&lt;appender name="DELEGATE" class="ch.qos.logback.classic.DelegateAppender"></b>
+    <b>&lt;appender-ref ref="FILE" /></b>
+    <b>&lt;appender-ref ref="STDOUT" /></b>
+  <b>&lt;/appender></b>
+
+  &lt;root level="DEBUG">
+    &lt;appender-ref ref="<b>DELEGATE</b>" />
+  &lt;/root>
+&lt;/configuration></pre>
 
 		<h3 class="doAnchor" name="WriteYourOwnAppender">Writing your own
 		Appender</h3>


### PR DESCRIPTION
Following P7 on https://github.com/qos-ch/logback/blob/master/CONTRIBUTING.md, 
tentative text to be added on release notes:

<p>New <code>DelegateAppender</code> which delegates all event to 
underlying appenders (<a href="http://jira.qos.ch/browse/LOGBACK-551">LOGBACK-511</a>). 
Patch provided by Juan Pablo Santos.</p>