### PR TITLE
Fix for  http://jira.qos.ch/browse/LOGBACK-905

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketAppender.java
@@ -14,8 +14,6 @@
 // Contributors: Dan MacDonald <dan@redknee.com>
 package ch.qos.logback.classic.net;
 
-import java.net.InetAddress;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.net.AbstractSocketAppender;
 import ch.qos.logback.core.spi.PreSerializationTransformer;
@@ -43,10 +41,19 @@ public class SocketAppender extends AbstractSocketAppender<ILoggingEvent> {
 
 
   @Override
-  protected void postProcessEvent(ILoggingEvent event) {
-    if (includeCallerData) {
+  protected void append(ILoggingEvent event) {
+    if (event == null || !isStarted()) return;
+    //To have right stacktrace, need to call getCollectData in append method.
+    // posProcessEvent() is called in other thread
+    if (includeCallerData){
       event.getCallerData();
     }
+    super.append(event);
+  }
+
+  @Override
+  protected void postProcessEvent(ILoggingEvent event) {
+    //Do nothing
   }
 
   public void setIncludeCallerData(boolean includeCallerData) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SocketAppender.java
@@ -27,6 +27,7 @@ import ch.qos.logback.core.spi.PreSerializationTransformer;
  * 
  * @author Ceki G&uuml;lc&uuml;
  * @author S&eacute;bastien Pennec
+ * @author Krzysztof Otrebski
  */
 
 public class SocketAppender extends AbstractSocketAppender<ILoggingEvent> {


### PR DESCRIPTION
Fix for http://jira.qos.ch/browse/LOGBACK-905
postProcessEvent method is called in async appender thread. Logback creates new Throwable to get stacktrace and current class, method and line. But this is in another thread, so it can't get true data.
Details are in my comment to bug: http://jira.qos.ch/browse/LOGBACK-905?focusedCommentId=16597&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16597