### PR TITLE
LOGBACK-1052 Have RequestLogImpl implement Jetty's LifeCycle interface

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -46,6 +46,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
       <scope>compile</scope>

--- a/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
@@ -26,6 +26,7 @@ import ch.qos.logback.core.util.StatusPrinter;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.component.LifeCycle;
 
 import ch.qos.logback.access.joran.JoranConfigurator;
 import ch.qos.logback.access.spi.AccessEvent;
@@ -112,7 +113,7 @@ import ch.qos.logback.core.util.OptionHelper;
  * @author S&eacute;bastien Pennec
  */
 public class RequestLogImpl extends ContextBase implements RequestLog,
-        AppenderAttachable<IAccessEvent>, FilterAttachable<IAccessEvent> {
+        AppenderAttachable<IAccessEvent>, FilterAttachable<IAccessEvent>, LifeCycle {
 
   public final static String DEFAULT_CONFIG_FILE = "etc" + File.separatorChar
           + "logback-access.xml";

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-jms_1.1_spec</artifactId>
         <version>1.0</version>


### PR DESCRIPTION
Have RequestLogImpl implement Jetty's LifeCycle interface directly. This
allows logback access to work with Jetty 9.3.0M1 and newer, where the
Jetty API was changed in an incompatible way.