### PR TITLE
Log root cause of the SQLException.

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxy.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxy.java
@@ -17,6 +17,7 @@ import ch.qos.logback.core.CoreConstants;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 
 public class ThrowableProxy implements IThrowableProxy {
 
@@ -54,7 +55,7 @@ public class ThrowableProxy implements IThrowableProxy {
         this.message = throwable.getMessage();
         this.stackTraceElementProxyArray = ThrowableProxyUtil.steArrayToStepArray(throwable.getStackTrace());
 
-        Throwable nested = throwable.getCause();
+        Throwable nested = getNested(throwable);
 
         if (nested != null) {
             this.cause = new ThrowableProxy(nested);
@@ -82,6 +83,16 @@ public class ThrowableProxy implements IThrowableProxy {
             }
         }
 
+    }
+
+    private Throwable getNested(Throwable throwable) {
+        if (throwable instanceof SQLException) {
+            return ((SQLException) throwable).getNextException();
+        }
+        if (throwable instanceof InvocationTargetException) {
+            return ((InvocationTargetException) throwable).getTargetException();
+        }
+        return throwable.getCause();
     }
 
     public Throwable getThrowable() {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/TestHelper.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/TestHelper.java
@@ -15,6 +15,7 @@ package ch.qos.logback.classic.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 
 public class TestHelper {
 
@@ -30,14 +31,33 @@ public class TestHelper {
         ADD_SUPPRESSED_METHOD = method;
     }
 
-    public static boolean suppressedSupported() {
-        return ADD_SUPPRESSED_METHOD != null;
-    }
-
     public static void addSuppressed(Throwable outer, Throwable suppressed) throws InvocationTargetException, IllegalAccessException {
         if (suppressedSupported()) {
             ADD_SUPPRESSED_METHOD.invoke(outer, suppressed);
         }
+    }
+
+    private static final Method GET_SUPPRESSED_METHOD;
+
+    static {
+        Method method = null;
+        try {
+            method = Throwable.class.getMethod("getSuppressed");
+        } catch (NoSuchMethodException e) {
+            // ignore, will get thrown in Java < 7
+        }
+        GET_SUPPRESSED_METHOD = method;
+    }
+
+    public static Throwable[] getSuppressed(Throwable outer) throws InvocationTargetException, IllegalAccessException {
+        if (suppressedSupported()) {
+            return (Throwable[]) GET_SUPPRESSED_METHOD.invoke(outer);
+        }
+        return new Throwable[0];
+    }
+
+    public static boolean suppressedSupported() {
+        return ADD_SUPPRESSED_METHOD != null;
     }
 
     static public Throwable makeNestedException(int level) {


### PR DESCRIPTION
Now stack trace of the batched SQL exception looks

```
 c.g.c.u.c.UncheckedExecutionException: org.jooq.exception.DataAccessException: SQL [null]; Batch entry 1 insert into "audience" ("type", "source", "country", "partner", "account_id", "level", "level_id", "task_id", "status") select 'RTG', 'EMAIL', 'US', 'FACEBOOK', '<audience_id>', 'DEAL', '<deal_id>', '<task_id>', 'PENDING' where not exists (select "audience"."id", "audience"."source", "audience"."country", "audience"."partner", "audience"."partner_audience_id", "audience"."partner_seed_audience_id", "audience"."account_id", "audience"."level", "audience"."level_id", "audience"."task_id", "audience"."status", "audience"."created_at", "audience"."updated_at", "audience"."type" from "audience" where ("audience"."type" = 'RTG' and "audience"."source" = 'EMAIL' and "audience"."country" = 'US' and "audience"."partner" = 'FACEBOOK' and "audience"."level" = 'DEAL' and "audience"."level_id" = 'you-and-the-mat-1-1')) was aborted.  Call getNextException to see the cause.
    at c.g.c.c.LocalCache$Segment.get(LocalCache.java:2203) ~[da-audience-service-57c5d7b.jar:na]
    at c.g.c.c.LocalCache.get(LocalCache.java:3937)
    at c.g.c.c.LocalCache.getOrLoad(LocalCache.java:3941)
    at c.g.c.c.LocalCache$LocalLoadingCache.get(LocalCache.java:4824)
    at c.g.d.a.a.c.AudienceCache.lambda$startAudienceCreation$19(AudienceCache.java:77)
    at c.g.d.a.a.c.AudienceCache$$Lambda$27/515789015.run(Unknown Source) [da-audience-service-57c5d7b.jar:na]
    at j.u.c.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1386) [na:1.8.0_40]
    at j.u.c.ForkJoinTask.doExec(ForkJoinTask.java:289)
    at j.u.c.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
    at j.u.c.ForkJoinPool.runWorker(ForkJoinPool.java:1689)
    at j.u.c.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: o.j.e.DataAccessException: SQL [null]; Batch entry 1 insert into "audience" ("type", "source", "country", "partner", "account_id", "level", "level_id", "task_id", "status") select 'RTG', 'EMAIL', 'US', 'FACEBOOK', '<audience_id>', 'DEAL', '<deal_id>', '<task_id>', 'PENDING' where not exists (select "audience"."id", "audience"."source", "audience"."country", "audience"."partner", "audience"."partner_audience_id", "audience"."partner_seed_audience_id", "audience"."account_id", "audience"."level", "audience"."level_id", "audience"."task_id", "audience"."status", "audience"."created_at", "audience"."updated_at", "audience"."type" from "audience" where ("audience"."type" = 'RTG' and "audience"."source" = 'EMAIL' and "audience"."country" = 'US' and "audience"."partner" = 'FACEBOOK' and "audience"."level" = 'DEAL' and "audience"."level_id" = 'you-and-the-mat-1-1')) was aborted.  Call getNextException to see the cause.
    at org.jooq.impl.Utils.translate(Utils.java:1645) ~[da-audience-service-57c5d7b.jar:na]
    at o.j.i.DefaultExecuteContext.sqlException(DefaultExecuteContext.java:661)
    at o.j.i.BatchMultiple.execute(BatchMultiple.java:121)
    at c.g.d.a.a.AudienceDao.upsert(AudienceDao.java:56)
    at c.g.d.a.a.AudienceController.createAudiences(AudienceController.java:100)
    at c.g.d.a.a.AudienceController.getOrCreateAudiences(AudienceController.java:64)
    at c.g.d.a.a.c.AudienceCache.loadInternal(AudienceCache.java:89)
    at c.g.d.a.a.c.AudienceCache.access$000(AudienceCache.java:31)
    at c.g.d.a.a.c.AudienceCache$1.load(AudienceCache.java:47)
    at c.g.d.a.a.c.AudienceCache$1.load(AudienceCache.java:44)
    at c.g.c.c.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3527)
    at c.g.c.c.LocalCache$Segment.loadSync(LocalCache.java:2319)
    at c.g.c.c.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2282)
    at c.g.c.c.LocalCache$Segment.get(LocalCache.java:2197)
    ... 10 common frames omitted
Caused by: j.s.BatchUpdateException: Batch entry 1 insert into "audience" ("type", "source", "country", "partner", "account_id", "level", "level_id", "task_id", "status") select 'RTG', 'EMAIL', 'US', 'FACEBOOK', '<audience_id>', 'DEAL', '<deal_id>', '<task_id>', 'PENDING' where not exists (se... 
```

This patch allows to print root cause of SQLException.
Code borrowed from the `org.apache.commons.lang.exception.ExceptionUtils` class

Please, let me know if I need to make any changes, so this patch will be merged.
Maybe there is a better way to achieve the same result?
