### PR TITLE
LOGBACK-1098:  Filters shuld be able to lower level of LoggingEvents

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
@@ -239,10 +239,6 @@ public class LoggingEvent implements ILoggingEvent {
   }
 
   public void setLevel(Level level) {
-    if (this.level != null) {
-      throw new IllegalStateException(
-              "The level has been already set for this event.");
-    }
     this.level = level;
   }
 


### PR DESCRIPTION
This pull request is to allow changes to the level of a LoggingEvent after it has been set.
Currently, changing the level of a logging event is prevented (an exception is raised), but sometimes one may need to change it, e.g. in a filter.
This modification doesn't affect any unit test.