### PR TITLE
LOGBACK-1087 fix (with test)

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/BasicStatusManager.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/BasicStatusManager.java
@@ -84,7 +84,10 @@ public class BasicStatusManager implements StatusManager {
 
   private void fireStatusAddEvent(Status status) {
     synchronized (statusListenerListLock) {
-      for (StatusListener sl : statusListenerList) {
+      // use copy instead of the original listenerList
+      // to avoid possible ConcurrentModificationException
+      // cfr. http://jira.qos.ch/browse/LOGBACK-1087
+      for (StatusListener sl : getCopyOfStatusListenerList()) {
         sl.addStatusEvent(status);
       }
     }

--- a/logback-core/src/test/java/ch/qos/logback/core/BasicStatusManagerTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/BasicStatusManagerTest.java
@@ -87,5 +87,14 @@ public class BasicStatusManagerTest {
     }
   }
 
-
+  @Test
+  public void testFireStatusAddEventConcurrentModificationException() {
+    bsm.add(new StatusListener(){
+      @Override
+      public void addStatusEvent(Status status) {
+        bsm.remove(this);
+      }
+    });
+    bsm.add(new ErrorStatus("testFireStatusAddEvent", this));
+  }
 }


### PR DESCRIPTION
Uses a (shallow) copy of the statusListenerList to invoke addStatusEvent, so there are no concurrency issues if the original list gets modified at the same time (a somehow convoluted but legitimate usage).