### PR TITLE
LOGBACK-941 - MDC properties are not set to LoggingEvent with SocketAppender

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
 
 import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
 import ch.qos.logback.core.spi.PreSerializationTransformer;
 import ch.qos.logback.core.util.CloseUtil;
 import ch.qos.logback.core.util.Duration;
@@ -174,6 +175,11 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   @Override
   protected void append(E event) {
     if (event == null || !isStarted()) return;
+
+    //Adding MDC, Thread and FormattedMessage data to the LoggingEvent
+    if (event instanceof DeferredProcessingAware) {
+       ((DeferredProcessingAware) event).prepareForDeferredProcessing();
+    }
 
     try {
       final boolean inserted = deque.offer(event, eventDelayLimit.getMilliseconds(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
The fix for this is quite straight forward, adapted from Guillaume St-Michel's comment in Jira. The slightly more complicated part was testing it, since AbstractSocketAppenderTest was using an event type of String. The majority of the changes to AbstractSocketAppenderTest are around changing the event type to extend DeferredProcessingAware. If those changes are undesirable, let me know, and I can take a look at how to isolate the changes to the one new test.