### PR TITLE
[LOGBACK-827] restored solution https://github.com/qos-ch/logback/pul…

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/AsyncAppender.java
@@ -1,0 +1,7 @@
+package ch.qos.logback.access;
+
+/**
+ * Created by msiatkowski on 14.10.15.
+ */
+public class AsyncAppender {
+}

--- a/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/AsyncAppenderTest.java
@@ -1,0 +1,7 @@
+package ch.qos.logback.access;
+
+/**
+ * Created by msiatkowski on 14.10.15.
+ */
+public class AsyncAppenderTest {
+}


### PR DESCRIPTION
I have found an old solution by @kpavlov and tried to make it work for current version.

I have managed to move most of the changes from https://github.com/qos-ch/logback/pull/185

The only part left from `logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java`
```java

        public Object getAttribute(String key) {
            if (key.equals("testKey")) {
                return "testKey";
            } else if (AccessConstants.LB_INPUT_BUFFER.equals(key)) {
                return DUMMY_CONTENT_BYTES;
            } else if (AccessConstants.LB_OUTPUT_BUFFER.equals(key)) {
                return DUMMY_RESPONSE_CONTENT_BYTES;
            } else {
                return null;
            }
        }
```

But i do not see the reason for this code. I quickly tested the solution with Tomcat 7 and it seems to work.
