### PR TITLE
LOGBACK-1130 Add support for %I, %S, %T and %q in access log PatternLayout

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/PatternLayout.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/PatternLayout.java
@@ -15,6 +15,7 @@ package ch.qos.logback.access;
 
 import ch.qos.logback.access.pattern.ContentLengthConverter;
 import ch.qos.logback.access.pattern.DateConverter;
+import ch.qos.logback.access.pattern.ElapsedSecondsConverter;
 import ch.qos.logback.access.pattern.ElapsedTimeConverter;
 import ch.qos.logback.access.pattern.EnsureLineSeparation;
 import ch.qos.logback.access.pattern.FullRequestConverter;
@@ -23,6 +24,7 @@ import ch.qos.logback.access.pattern.LineSeparatorConverter;
 import ch.qos.logback.access.pattern.LocalIPAddressConverter;
 import ch.qos.logback.access.pattern.LocalPortConverter;
 import ch.qos.logback.access.pattern.NAConverter;
+import ch.qos.logback.access.pattern.QueryStringConverter;
 import ch.qos.logback.access.pattern.RemoteHostConverter;
 import ch.qos.logback.access.pattern.RemoteIPAddressConverter;
 import ch.qos.logback.access.pattern.RemoteUserConverter;
@@ -37,8 +39,10 @@ import ch.qos.logback.access.pattern.RequestURIConverter;
 import ch.qos.logback.access.pattern.RequestURLConverter;
 import ch.qos.logback.access.pattern.ResponseContentConverter;
 import ch.qos.logback.access.pattern.ResponseHeaderConverter;
+import ch.qos.logback.access.pattern.SessionIDConverter;
 import ch.qos.logback.access.pattern.ServerNameConverter;
 import ch.qos.logback.access.pattern.StatusCodeConverter;
+import ch.qos.logback.access.pattern.ThreadNameConverter;
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.pattern.color.*;
@@ -98,17 +102,26 @@ public class PatternLayout extends PatternLayoutBase<IAccessEvent> {
     defaultConverterMap.put("i", RequestHeaderConverter.class.getName());
     defaultConverterMap.put("header", RequestHeaderConverter.class.getName());
 
+    defaultConverterMap.put("I", ThreadNameConverter.class.getName());
+    defaultConverterMap.put("threadName", ThreadNameConverter.class.getName());
+
     defaultConverterMap.put("l", NAConverter.class.getName());
 
     defaultConverterMap.put("m", RequestMethodConverter.class.getName());
     defaultConverterMap.put("requestMethod", RequestMethodConverter.class
         .getName());
 
+    defaultConverterMap.put("q", QueryStringConverter.class.getName());
+    defaultConverterMap.put("queryString", QueryStringConverter.class.getName());
+
     defaultConverterMap.put("r", RequestURLConverter.class.getName());
     defaultConverterMap.put("requestURL", RequestURLConverter.class.getName());
 
     defaultConverterMap.put("s", StatusCodeConverter.class.getName());
     defaultConverterMap.put("statusCode", StatusCodeConverter.class.getName());
+
+    defaultConverterMap.put("S", SessionIDConverter.class.getName());
+    defaultConverterMap.put("sessionID", SessionIDConverter.class.getName());
 
     defaultConverterMap.put("t", DateConverter.class.getName());
     defaultConverterMap.put("date", DateConverter.class.getName());
@@ -150,6 +163,9 @@ public class PatternLayout extends PatternLayoutBase<IAccessEvent> {
 
     defaultConverterMap.put("fullRequest", FullRequestConverter.class.getName());
     defaultConverterMap.put("fullResponse", FullResponseConverter.class.getName());
+
+    defaultConverterMap.put("elapsedSeconds", ElapsedSecondsConverter.class.getName());
+    defaultConverterMap.put("T", ElapsedSecondsConverter.class.getName());
 
     defaultConverterMap.put("elapsedTime", ElapsedTimeConverter.class.getName());
     defaultConverterMap.put("D", ElapsedTimeConverter.class.getName());

--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/ElapsedSecondsConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/ElapsedSecondsConverter.java
@@ -1,0 +1,24 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.access.pattern;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+
+public class ElapsedSecondsConverter extends AccessConverter {
+
+  public String convert(IAccessEvent accessEvent) {
+    return Long.toString(accessEvent.getElapsedSeconds());
+  }
+
+}

--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/QueryStringConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/QueryStringConverter.java
@@ -1,0 +1,23 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.access.pattern;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+
+public class QueryStringConverter extends AccessConverter {
+
+  public String convert(IAccessEvent accessEvent) {
+    return accessEvent.getQueryString();
+  }
+}

--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/SessionIDConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/SessionIDConverter.java
@@ -1,0 +1,23 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.access.pattern;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+
+public class SessionIDConverter extends AccessConverter {
+
+  public String convert(IAccessEvent accessEvent) {
+    return accessEvent.getSessionID();
+  }
+}

--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/ThreadNameConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/ThreadNameConverter.java
@@ -1,0 +1,24 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.access.pattern;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+
+public class ThreadNameConverter extends AccessConverter {
+
+  public String convert(IAccessEvent accessEvent) {
+    return accessEvent.getThreadName();
+  }
+
+}

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -20,6 +20,7 @@ import ch.qos.logback.access.servlet.Util;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -51,14 +52,17 @@ public class AccessEvent implements Serializable, IAccessEvent {
   private transient final HttpServletRequest httpRequest;
   private transient final HttpServletResponse httpResponse;
 
+  String queryString;
   String requestURI;
   String requestURL;
   String remoteHost;
   String remoteUser;
   String remoteAddr;
+  String threadName;
   String protocol;
   String method;
   String serverName;
+  String sessionID;
   String requestContent;
   String responseContent;
   long elapsedTime;
@@ -125,6 +129,18 @@ public class AccessEvent implements Serializable, IAccessEvent {
     }
   }
 
+  /**
+   * @param threadName The threadName to set.
+   */
+  public void setThreadName(String threadName) {
+    this.threadName = threadName;
+  }
+
+  @Override
+  public String getThreadName() {
+    return threadName == null ? NA : threadName;
+  }
+
   @Override
   public String getRequestURI() {
     if (requestURI == null) {
@@ -135,6 +151,24 @@ public class AccessEvent implements Serializable, IAccessEvent {
       }
     }
     return requestURI;
+  }
+
+  @Override
+  public String getQueryString() {
+    if (queryString == null) {
+      if (httpRequest != null) {
+        StringBuilder buf = new StringBuilder();
+        final String qStr = httpRequest.getQueryString();
+        if (qStr != null) {
+          buf.append(AccessConverter.QUESTION_CHAR);
+          buf.append(qStr);
+        }
+        queryString = buf.toString();
+      } else {
+        queryString = NA;
+      }
+    }
+    return queryString;
   }
 
   /**
@@ -148,11 +182,7 @@ public class AccessEvent implements Serializable, IAccessEvent {
         buf.append(httpRequest.getMethod());
         buf.append(AccessConverter.SPACE_CHAR);
         buf.append(httpRequest.getRequestURI());
-        final String qStr = httpRequest.getQueryString();
-        if (qStr != null) {
-          buf.append(AccessConverter.QUESTION_CHAR);
-          buf.append(qStr);
-        }
+        buf.append(getQueryString());
         buf.append(AccessConverter.SPACE_CHAR);
         buf.append(httpRequest.getProtocol());
         requestURL = buf.toString();
@@ -211,6 +241,21 @@ public class AccessEvent implements Serializable, IAccessEvent {
       }
     }
     return method;
+  }
+
+  @Override
+  public String getSessionID() {
+    if (sessionID == null) {
+      if (httpRequest != null) {
+        final HttpSession session = httpRequest.getSession();
+        if (session != null) {
+          sessionID = session.getId();
+        }
+      } else {
+        sessionID = NA;
+      }
+    }
+    return sessionID;
   }
 
   @Override
@@ -406,6 +451,10 @@ public class AccessEvent implements Serializable, IAccessEvent {
       }
     }
     return statusCode;
+  }
+
+  public long getElapsedSeconds() {
+    return elapsedTime < 0 ? elapsedTime : elapsedTime / 1000;
   }
 
   public long getElapsedTime() {

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
@@ -61,9 +61,20 @@ public interface IAccessEvent extends DeferredProcessingAware {
   long getTimeStamp();
 
   /**
-   * The time elapsed between receiving the request and logging it.
+   * The number of seconds elapsed between receiving the request and logging it.
+   */
+  long getElapsedSeconds();
+
+  /**
+   * The time elapsed in ms between receiving the request and logging it.
    */
   long getElapsedTime();
+
+  void setThreadName(String threadName);
+
+  String getThreadName();
+
+  String getQueryString();
 
   String getRequestURI();
 
@@ -79,6 +90,8 @@ public interface IAccessEvent extends DeferredProcessingAware {
   String getProtocol();
 
   String getMethod();
+
+  String getSessionID();
 
   String getServerName();
 

--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
@@ -193,6 +193,13 @@ public class LogbackValve extends ValveBase implements Lifecycle, Context,
       TomcatServerAdapter adapter = new TomcatServerAdapter(request, response);
       IAccessEvent accessEvent = new AccessEvent(request, response, adapter);
 
+      try {
+        final String threadName = Thread.currentThread().getName();
+        if (threadName != null) {
+          accessEvent.setThreadName(threadName);
+        }
+      } catch (Exception ignored) { }
+
       if (getFilterChainDecision(accessEvent) == FilterReply.DENY) {
         return;
       }

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -2083,6 +2083,14 @@ java.lang.Exception: display
           </td>
       </tr>
       <tr>
+        <td class="word" name="elapsedSeconds"><b>T / elapsedSeconds</b></td>
+        <td>
+          <p>
+            The time taken to serve the request, in seconds.
+          </p>
+        </td>
+      </tr>
+      <tr>
         <td class="word" name="dateAccess"><b>t / date</b></td>
         <td>
           <p>Outputs the date of the logging event.  The date
@@ -2107,6 +2115,14 @@ java.lang.Exception: display
         </td>
       </tr>		
       <tr>
+        <td class="word" name="queryString"><b>q / queryString</b></td>
+        <td>
+          <p>
+            Request query string, prepended with a '?'.
+          </p>
+        </td>
+      </tr>
+      <tr>
         <td class="word" name="requestURI"><b>U / requestURI</b></td>
         <td>
           <p>
@@ -2114,10 +2130,22 @@ java.lang.Exception: display
           </p>
         </td>
       </tr>		
+      <tr>
+        <td class="word" name="sessionID"><b>S / sessionID</b></td>
+        <td>
+          <p>Session ID.</p>
+        </td>
+      </tr>
       <tr >
         <td class="word" name="server"><b>v / server</b></td>
         <td>
           <p>Server name.</p>
+        </td>
+      </tr>
+      <tr>
+        <td class="word" name="threadName"><b>I / threadName</b></td>
+        <td>
+          <p>Name of the thread which processed the request.</p>
         </td>
       </tr>
       <tr class="b">


### PR DESCRIPTION
Release Notes:

<p>Add new format strings to logback-access <code>PatternLayout</code>: <code>%I</code> (thread name), <code>%S</code> (HTTP session ID), <code>%T</code> (request time in seconds), <code>%q</code> (query string).</p>

Other (non-release)notes of interest:

* This is just a rebased/cleaned up (according to the contribution guidelines) version of @wodify's original `access_pattern_conversions` (#205) which has been languishing and was unmergable. I'm pretty sure this is bad form, but better than the alternatives (and gives proper credit since wodify did almost all of the work)
* If this is merged, #205 should be closed
* I have not signed the CLA, though I am happy to if necessary