### PR TITLE
LOGBACK-1092: Share GEventEvaluator with logback-access

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -65,6 +65,18 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/groovy</directory>
+        <includes>
+          <include>**/EvaluatorTemplate.groovy</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/logback-access/src/main/groovy/ch/qos/logback/access/boolex/EvaluatorTemplate.groovy
+++ b/logback-access/src/main/groovy/ch/qos/logback/access/boolex/EvaluatorTemplate.groovy
@@ -11,28 +11,19 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.boolex
+package ch.qos.logback.access.boolex
 
-import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.access.spi.IAccessEvent
 import ch.qos.logback.core.boolex.IEvaluator
-
-import static ch.qos.logback.classic.Level.TRACE;
-import static ch.qos.logback.classic.Level.DEBUG;
-import static ch.qos.logback.classic.Level.INFO;
-import static ch.qos.logback.classic.Level.WARN;
-import static ch.qos.logback.classic.Level.ERROR;
 
 // WARNING
 // If this file is renamed, this should be reflected in
 // logback-classic/pom.xml  resources section.
 
-/**
- * @author Ceki G&uuml;c&uuml;
- */
-public class EvaluatorTemplate implements IEvaluator<ILoggingEvent> {
+public class EvaluatorTemplate implements IEvaluator<IAccessEvent> {
 
-  boolean doEvaluate(ILoggingEvent event) {
-    ILoggingEvent e = event;
+  boolean doEvaluate(IAccessEvent event) {
+    IAccessEvent e = event;
     //EXPRESSION
   }
 

--- a/logback-access/src/main/java/ch/qos/logback/access/boolex/GEventEvaluator.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/boolex/GEventEvaluator.java
@@ -1,0 +1,6 @@
+package ch.qos.logback.access.boolex;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.boolex.GEventEvaluatorBase;
+
+public class GEventEvaluator extends GEventEvaluatorBase<IAccessEvent> {}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/boolex/GEventEvaluator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/boolex/GEventEvaluator.java
@@ -14,75 +14,9 @@
 package ch.qos.logback.classic.boolex;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.boolex.EvaluationException;
-import ch.qos.logback.core.boolex.EventEvaluatorBase;
-import ch.qos.logback.core.util.FileUtil;
-import groovy.lang.*;
-import org.codehaus.groovy.control.CompilationFailedException;
+import ch.qos.logback.core.boolex.GEventEvaluatorBase;
 
 /**
  * @author Ceki G&uuml;lc&uuml;
  */
-public class GEventEvaluator extends EventEvaluatorBase<ILoggingEvent> {
-
-    String expression;
-
-    IEvaluator delegateEvaluator;
-    Script script;
-
-    public String getExpression() {
-        return expression;
-    }
-
-    public void setExpression(String expression) {
-        this.expression = expression;
-    }
-
-    public void start() {
-        int errors = 0;
-        if (expression == null || expression.length() == 0) {
-            addError("Empty expression");
-            return;
-        } else {
-            addInfo("Expression to evaluate [" + expression + "]");
-        }
-
-        ClassLoader classLoader = getClass().getClassLoader();
-        String currentPackageName = this.getClass().getPackage().getName();
-        currentPackageName = currentPackageName.replace('.', '/');
-
-        FileUtil fileUtil = new FileUtil(getContext());
-        String scriptText = fileUtil.resourceAsString(classLoader, currentPackageName + "/EvaluatorTemplate.groovy");
-        if (scriptText == null) {
-            return;
-        }
-
-        // insert the expression into script text
-        scriptText = scriptText.replace("//EXPRESSION", expression);
-
-        GroovyClassLoader gLoader = new GroovyClassLoader(classLoader);
-        try {
-            Class scriptClass = gLoader.parseClass(scriptText);
-
-            GroovyObject goo = (GroovyObject) scriptClass.newInstance();
-            delegateEvaluator = (IEvaluator) goo;
-
-        } catch (CompilationFailedException cfe) {
-            addError("Failed to compile expression [" + expression + "]", cfe);
-            errors++;
-        } catch (Exception e) {
-            addError("Failed to compile expression [" + expression + "]", e);
-            errors++;
-        }
-        if (errors == 0)
-            super.start();
-    }
-
-    public boolean evaluate(ILoggingEvent event) throws NullPointerException, EvaluationException {
-        if (delegateEvaluator == null) {
-            return false;
-        }
-        return delegateEvaluator.doEvaluate(event);
-    }
-
-}
+public class GEventEvaluator extends GEventEvaluatorBase<ILoggingEvent> {}

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -23,6 +23,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
       <optional>true</optional>      

--- a/logback-core/src/main/java/ch/qos/logback/core/boolex/GEventEvaluatorBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/boolex/GEventEvaluatorBase.java
@@ -1,0 +1,85 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ * <p>
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ * <p>
+ * or (per the licensee's choosing)
+ * <p>
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.boolex;
+
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import ch.qos.logback.core.util.FileUtil;
+import groovy.lang.*;
+import org.codehaus.groovy.control.CompilationFailedException;
+
+public class GEventEvaluatorBase<E extends DeferredProcessingAware>
+    extends EventEvaluatorBase<E> {
+
+    String expression;
+
+    IEvaluator<E> delegateEvaluator;
+    Script script;
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+
+    @Override
+    public void start() {
+        int errors = 0;
+        if (expression == null || expression.length() == 0) {
+            addError("Empty expression");
+            return;
+        } else {
+            addInfo("Expresssion to evaluate [" + expression + "]");
+        }
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        String currentPackageName = this.getClass().getPackage().getName();
+        currentPackageName = currentPackageName.replace('.', '/');
+
+        FileUtil fileUtil = new FileUtil(getContext());
+        String scriptText = fileUtil.resourceAsString(classLoader, currentPackageName + "/EvaluatorTemplate.groovy");
+        if (scriptText == null) {
+            return;
+        }
+
+        // insert the expression into script text
+        scriptText = scriptText.replace("//EXPRESSION", expression);
+
+        GroovyClassLoader gLoader = new GroovyClassLoader(classLoader);
+        try {
+            Class scriptClass = gLoader.parseClass(scriptText);
+
+            GroovyObject goo = (GroovyObject) scriptClass.newInstance();
+            delegateEvaluator = (IEvaluator) goo;
+        } catch (CompilationFailedException cfe) {
+            addError("Failed to compile expression [" + expression + "]", cfe);
+            errors++;
+        } catch (Exception e) {
+            addError("Failed to compile expression [" + expression + "]", e);
+            errors++;
+        }
+        if (errors == 0)
+            super.start();
+    }
+
+    @Override
+    public boolean evaluate(E event) throws NullPointerException, EvaluationException {
+        if (delegateEvaluator == null) {
+            return false;
+        }
+        return delegateEvaluator.doEvaluate(event);
+    }
+
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/boolex/IEvaluator.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/boolex/IEvaluator.java
@@ -11,15 +11,15 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.boolex;
+package ch.qos.logback.core.boolex;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
 
 /**
  * An <b>internal</b> interface used by the GEventEvaluator.
- * 
+ *
  * @author Ceki G&uuml;lc&uuml;
  */
-public interface IEvaluator {
-    boolean doEvaluate(ILoggingEvent event);
+public interface IEvaluator<E extends DeferredProcessingAware> {
+  boolean doEvaluate(E event);
 }


### PR DESCRIPTION
create a GEventEvaluatorBase in core which is extended in classic and access
http://jira.qos.ch/browse/LOGBACK-1092
