### PR TITLE
Rotate log if the underlying file was removed

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -14,6 +14,9 @@
 package ch.qos.logback.core.rolling;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
 
 import ch.qos.logback.core.joran.spi.NoAutoStart;
@@ -105,7 +108,15 @@ public class SizeAndTimeBasedFNATP<E> extends
       invocationMask = (invocationMask << 1) + 1;
     }
 
-    if (activeFile.length() >= maxFileSize.getSize()) {
+    long activeLength;
+    try {
+      activeLength = Files
+          .readAttributes(activeFile.toPath(), BasicFileAttributes.class)
+          .size();
+    } catch (IOException ignored) {
+      activeLength = maxFileSize.getSize();
+    }
+    if (activeLength >= maxFileSize.getSize()) {
       elapsedPeriodsFileName = tbrp.fileNamePatternWCS
               .convertMultipleArguments(dateInCurrentPeriod, currentPeriodsCounter);
       currentPeriodsCounter++;


### PR DESCRIPTION
<p>Fixed <code>SizeAndTimeBasedFNATP</code> so that it will trigger a rotation when it is unable to get the size of the current log. Previously, when the log file was deleted, <code>SizeAndTimeBasedFNATP</code> would allow the disconnected inode unbounded growth.</p>