### PR TITLE
LOGBACK-397: make Logger.childrenList thread-safe

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/Logger.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/Logger.java
@@ -362,7 +362,7 @@ public final class Logger implements org.slf4j.Logger, LocationAwareLogger,
     }
 
     if (childrenList == null) {
-      childrenList = new ArrayList<Logger>(DEFAULT_CHILD_ARRAY_SIZE);
+      childrenList = Collections.synchronizedList(new ArrayList<Logger>(DEFAULT_CHILD_ARRAY_SIZE));
     }
     Logger childLogger;
     childLogger = new Logger(childName, this, this.loggerContext);


### PR DESCRIPTION
Here's my take on a fix for http://jira.qos.ch/browse/LOGBACK-397.  Without it, I saw:
```
Caused by: java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)
	at java.util.ArrayList$Itr.next(ArrayList.java:851)
	at ch.qos.logback.classic.Logger.recursiveReset(Logger.java:344)
	at ch.qos.logback.classic.Logger.recursiveReset(Logger.java:345)
	at ch.qos.logback.classic.LoggerContext.reset(LoggerContext.java:213)
...
```