### PR TITLE
[LOGBACK-1114] Migrate from fest-assert to assertj

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/SQLBuilderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/SQLBuilderTest.java
@@ -13,7 +13,7 @@
  */
 package ch.qos.logback.classic.db;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/names/DefaultDBNameResolverTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/names/DefaultDBNameResolverTest.java
@@ -16,7 +16,7 @@ package ch.qos.logback.classic.db.names;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Tomasz Nurkiewicz

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/names/SimpleDBNameResolverTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/names/SimpleDBNameResolverTest.java
@@ -16,7 +16,7 @@ package ch.qos.logback.classic.db.names;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Tomasz Nurkiewicz

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ExtendedThrowableProxyConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ExtendedThrowableProxyConverterTest.java
@@ -13,8 +13,8 @@
  */
 package ch.qos.logback.classic.pattern;
 
-import static org.junit.Assert.*;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/RootCauseFirstThrowableProxyConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/RootCauseFirstThrowableProxyConverterTest.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 import static ch.qos.logback.classic.util.TestHelper.makeNestedException;
 import static ch.qos.logback.classic.util.TestHelper.positionOf;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Tomasz Nurkiewicz

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ThrowableProxyConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ThrowableProxyConverterTest.java
@@ -34,7 +34,7 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.classic.util.TestHelper;
 
 import static ch.qos.logback.classic.util.TestHelper.addSuppressed;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
@@ -171,7 +171,7 @@ public class ThrowableProxyConverterTest {
         final String result = tpc.convert(le);
 
         // then
-        assertThat(result).excludes("skipSelectedLines");
+        assertThat(result).doesNotContain("skipSelectedLines");
     }
 
     @Test
@@ -187,7 +187,7 @@ public class ThrowableProxyConverterTest {
         final String result = tpc.convert(le);
 
         // then
-        assertThat(result).excludes("skipSelectedLines").excludes("junit");
+        assertThat(result).doesNotContain("skipSelectedLines").doesNotContain("junit");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert</artifactId>
-      <version>1.2</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.7.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
fest-assert is a defunct library which was replaced by assertj.

migration notes here.

http://joel-costigliola.github.io/assertj/assertj-core-migrating-from-fest.html#fest-1.4

Using version 1.7.1 as that is last to support java 6.  Assertj 2.x is for java 7 building which is possible and still targetting java 6.  Assertj 3.x is for java 8 building which again is possible to still target java 6.  In order to not make such changes, will stick to version 1.7.1.