### PR TITLE
LOGBACK-898 never blocking async appender

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
@@ -123,6 +123,24 @@ public class AsyncAppenderBaseTest {
 	}
 
 	@Test(timeout = 2000)
+	public void eventLossIfNeverBlock() {
+		int bufferSize = 10;
+		int loopLen = bufferSize * 2;
+		delayingListAppender.setDelay(5000); // something greater than the test timeout
+		asyncAppenderBase.addAppender(delayingListAppender);
+		asyncAppenderBase.setQueueSize(bufferSize);
+		asyncAppenderBase.setNeverBlock(true);
+		asyncAppenderBase.start();
+		for (int i = 0; i < loopLen; i++) {
+			asyncAppenderBase.doAppend(i);
+		}
+		asyncAppenderBase.stop();
+		// ListAppender size isn't a reliable test here, so just make sure we didn't
+		// have any errors, and that we could complete the test in time.
+		statusChecker.assertIsErrorFree();
+	}
+
+	@Test(timeout = 2000)
 	public void lossyAppenderShouldOnlyLooseCertainEvents() {
 		int bufferSize = 5;
 		int loopLen = bufferSize * 2;

--- a/logback-core/src/test/java/ch/qos/logback/core/testUtil/DelayingListAppender.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/testUtil/DelayingListAppender.java
@@ -20,6 +20,10 @@ public class DelayingListAppender<E> extends ListAppender<E> {
   public int delay = 5;
   public boolean interrupted = false;
 
+  public void setDelay(int ms) {
+    delay = ms;
+  }
+
   @Override
   public void append(E e) {
     try {

--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -4009,6 +4009,14 @@ import static ch.qos.logback.classic.ClassicConstants.FINALIZE_SESSION_MARKER;
         <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html#join(long)">Thread.join(long)</a>.
         </td>
       </tr>
+      <tr>
+        <td><span class="prop" container="async">neverBlock</span></td>
+        <td><code>boolean</code></td>
+        <td>If <code>false</code> (the default) the appender will block on
+        appending to a full queue rather than losing the message. Set to
+        <code>true</code> and the appender will just drop the message and
+        will not block your application.</td>
+      </tr>
     </table>
 
     <p>By default, event queue is configured with a maximum capacity


### PR DESCRIPTION
Allows the AsyncAppender to be configured to be never block on
a full queue.

This is taken from Jeff Wartes original patch:

http://jira.qos.ch/browse/LOGBACK-898

I submitted a signed CLA some months ago.