### PR TITLE
Fix Janino-related NPE in bootstrap class loader

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/EnvUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/EnvUtil.java
@@ -56,7 +56,7 @@ public class EnvUtil {
   static public boolean isJaninoAvailable() {
     ClassLoader classLoader = EnvUtil.class.getClassLoader();
     try {
-      Class<?> bindingClass = classLoader.loadClass("org.codehaus.janino.ScriptEvaluator");
+      Class<?> bindingClass = Class.forName("org.codehaus.janino.ScriptEvaluator", false, classLoader);
       return (bindingClass != null);
     } catch (ClassNotFoundException e) {
       return false;


### PR DESCRIPTION
I have been using SLF4J/Logback successfully inside the bootstrap class loader for a while now, but recently tried to add conditional processing (Janino) in the logback.xml and ran into a NullPointerException:

```
        at java.lang.NullPointerException
        at      at ch.qos.logback.core.util.EnvUtil.isJaninoAvailable(EnvUtil.java:59)
        at      at ch.qos.logback.core.joran.conditional.IfAction.begin(IfAction.java:51)
        at      at ch.qos.logback.core.joran.spi.Interpreter.callBeginAction(Interpreter.java:275)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:147)
        at      at ch.qos.logback.core.joran.spi.Interpreter.startElement(Interpreter.java:129)
        at      at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:50)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:149)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:135)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:99)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:49)
        at      at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:77)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:152)
        at      at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:85)
        at      at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:140)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:119)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:328)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:280)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:301)
```

I hope you will accept this one-line fix to resolve the issue.

Thanks,
Trask
