### PR TITLE
LOGBACK-878: logback-access - Added support for multiple request/response headers with the same name

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/jetty/JettyServerAdapter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/jetty/JettyServerAdapter.java
@@ -14,14 +14,11 @@
 package ch.qos.logback.access.jetty;
 
 import ch.qos.logback.access.spi.ServerAdapter;
-
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A jetty specific implementation of the {@link ServerAdapter} interface.
@@ -55,14 +52,18 @@ public class JettyServerAdapter implements ServerAdapter {
     }
 
     @Override
-    public Map<String, String> buildResponseHeaderMap() {
-        Map<String, String> responseHeaderMap = new HashMap<String, String>();
+    public Map<String, String[]> buildResponseHeaderMap() {
+        Map<String, String[]> responseHeaderMap = new HashMap<String, String[]>();
         HttpFields httpFields = response.getHttpFields();
         Enumeration e = httpFields.getFieldNames();
         while (e.hasMoreElements()) {
             String key = (String) e.nextElement();
-            String value = response.getHeader(key);
-            responseHeaderMap.put(key, value);
+            Enumeration<String> headers = response.getHeaders(key);
+            if (headers != null) {
+                ArrayList<String> list = Collections.list(headers);
+                String[] values = list.toArray(new String[list.size()]);
+                responseHeaderMap.put(key, values);
+            }
         }
         return responseHeaderMap;
     }

--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/FullRequestConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/FullRequestConverter.java
@@ -13,10 +13,10 @@
  */
 package ch.qos.logback.access.pattern;
 
-import java.util.Enumeration;
-
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.CoreConstants;
+
+import java.util.Enumeration;
 
 /**
  * This class is tied to the <code>fullRequest</code> conversion word.
@@ -38,10 +38,13 @@ public class FullRequestConverter extends AccessConverter {
         Enumeration headerNames = ae.getRequestHeaderNames();
         while (headerNames.hasMoreElements()) {
             String name = (String) headerNames.nextElement();
-            buf.append(name);
-            buf.append(": ");
-            buf.append(ae.getRequestHeader(name));
-            buf.append(CoreConstants.LINE_SEPARATOR);
+            String[] values = ae.getRequestHeaderMap().get(name);
+            for (String value : values) {
+                buf.append(name);
+                buf.append(": ");
+                buf.append(value);
+                buf.append(CoreConstants.LINE_SEPARATOR);
+            }
         }
         buf.append(CoreConstants.LINE_SEPARATOR);
         buf.append(ae.getRequestContent());

--- a/logback-access/src/main/java/ch/qos/logback/access/pattern/FullResponseConverter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/pattern/FullResponseConverter.java
@@ -13,10 +13,10 @@
  */
 package ch.qos.logback.access.pattern;
 
-import java.util.List;
-
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.CoreConstants;
+
+import java.util.List;
 
 public class FullResponseConverter extends AccessConverter {
 
@@ -33,10 +33,13 @@ public class FullResponseConverter extends AccessConverter {
 
         List<String> hnList = ae.getResponseHeaderNameList();
         for (String headerName : hnList) {
-            buf.append(headerName);
-            buf.append(": ");
-            buf.append(ae.getResponseHeader(headerName));
-            buf.append(CoreConstants.LINE_SEPARATOR);
+            String[] values = ae.getResponseHeaderMap().get(headerName);
+            for (String value : values) {
+                buf.append(headerName);
+                buf.append(": ");
+                buf.append(value);
+                buf.append(CoreConstants.LINE_SEPARATOR);
+            }
         }
         buf.append(CoreConstants.LINE_SEPARATOR);
         buf.append(ae.getResponseContent());

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
@@ -66,8 +66,8 @@ public interface IAccessEvent extends DeferredProcessingAware {
     long getElapsedTime();
 
     /**
-    * The number of seconds elapsed between receiving the request and logging it.
-    */
+     * The number of seconds elapsed between receiving the request and logging it.
+     */
     long getElapsedSeconds();
 
     String getRequestURI();
@@ -90,17 +90,18 @@ public interface IAccessEvent extends DeferredProcessingAware {
     String getSessionID();
 
     void setThreadName(String threadName);
+
     String getThreadName();
-    
+
     String getQueryString();
-    
+
     String getRemoteAddr();
 
     String getRequestHeader(String key);
 
-    Enumeration getRequestHeaderNames();
+    Enumeration<String> getRequestHeaderNames();
 
-    Map<String, String> getRequestHeaderMap();
+    Map<String, String[]> getRequestHeaderMap();
 
     Map<String, String[]> getRequestParameterMap();
 
@@ -124,7 +125,7 @@ public interface IAccessEvent extends DeferredProcessingAware {
 
     String getResponseHeader(String key);
 
-    Map<String, String> getResponseHeaderMap();
+    Map<String, String[]> getResponseHeaderMap();
 
     List<String> getResponseHeaderNameList();
 }

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/ServerAdapter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/ServerAdapter.java
@@ -30,5 +30,5 @@ public interface ServerAdapter {
 
     int getStatusCode();
 
-    Map<String, String> buildResponseHeaderMap();
+    Map<String, String[]> buildResponseHeaderMap();
 }

--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/TomcatServerAdapter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/TomcatServerAdapter.java
@@ -14,10 +14,10 @@
 package ch.qos.logback.access.tomcat;
 
 import ch.qos.logback.access.spi.ServerAdapter;
-
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,11 +52,13 @@ public class TomcatServerAdapter implements ServerAdapter {
     }
 
     @Override
-    public Map<String, String> buildResponseHeaderMap() {
-        Map<String, String> responseHeaderMap = new HashMap<String, String>();
+    public Map<String, String[]> buildResponseHeaderMap() {
+        Map<String, String[]> responseHeaderMap = new HashMap<String, String[]>();
         for (String key : response.getHeaderNames()) {
-            String value = response.getHeader(key);
-            responseHeaderMap.put(key, value);
+            Collection<String> values = response.getHeaders(key);
+            if (values != null) {
+                responseHeaderMap.put(key, (String[]) values.toArray());
+            }
         }
         return responseHeaderMap;
     }

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyRequest.java
@@ -33,7 +33,7 @@ public class DummyRequest implements HttpServletRequest {
     public static final String DUMMY_RESPONSE_CONTENT_STRING = "response contents";
     public static final byte[] DUMMY_RESPONSE_CONTENT_BYTES = DUMMY_RESPONSE_CONTENT_STRING.getBytes();
 
-    Hashtable<String, String> headerNames;
+    Hashtable<String, String[]> headerNames;
     String uri;
     Map<String, Object> attributes;
 
@@ -44,9 +44,9 @@ public class DummyRequest implements HttpServletRequest {
     }
 
     public DummyRequest() {
-        headerNames = new Hashtable<String, String>();
-        headerNames.put("headerName1", "headerValue1");
-        headerNames.put("headerName2", "headerValue2");
+        headerNames = new Hashtable<String, String[]>();
+        headerNames.put("headerName1", new String[]{"headerValue11", "headerValue12"});
+        headerNames.put("headerName2", new String[]{"headerValue2"});
 
         attributes = new HashMap<String, Object>(DUMMY_DEFAULT_ATTR_MAP);
     }
@@ -61,7 +61,7 @@ public class DummyRequest implements HttpServletRequest {
 
     public Cookie[] getCookies() {
         Cookie cookie = new Cookie("testName", "testCookie");
-        return new Cookie[] { cookie };
+        return new Cookie[]{cookie};
     }
 
     public long getDateHeader(String arg0) {
@@ -69,7 +69,7 @@ public class DummyRequest implements HttpServletRequest {
     }
 
     public String getHeader(String key) {
-        return headerNames.get(key);
+        return headerNames.get(key)[0];
     }
 
     public Enumeration getHeaderNames() {
@@ -77,7 +77,7 @@ public class DummyRequest implements HttpServletRequest {
     }
 
     public Enumeration getHeaders(String arg0) {
-        return null;
+        return Collections.enumeration(Arrays.asList(headerNames.get(arg0)));
     }
 
     public int getIntHeader(String arg0) {

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyResponse.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyResponse.java
@@ -13,33 +13,32 @@
  */
 package ch.qos.logback.access.dummy;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.*;
-
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.*;
 
 public class DummyResponse implements HttpServletResponse {
 
     public static final int DUMMY_DEFAULT_STATUS = 200;
     public static final int DUMMY_DEFAULT_CONTENT_COUNT = 1000;
-    public static final Map<String, String> DUMMY_DEFAULT_HDEADER_MAP = new HashMap<String, String>();;
+    public static final Map<String, String[]> DUMMY_DEFAULT_HEADER_MAP = new HashMap<String, String[]>();
 
     static {
-        DUMMY_DEFAULT_HDEADER_MAP.put("headerName1", "headerValue1");
-        DUMMY_DEFAULT_HDEADER_MAP.put("headerName2", "headerValue2");
+        DUMMY_DEFAULT_HEADER_MAP.put("headerName1", new String[]{"headerValue1"});
+        DUMMY_DEFAULT_HEADER_MAP.put("headerName2", new String[]{"headerValue21", "headerValue22"});
     }
 
     int status = DUMMY_DEFAULT_STATUS;
-    public Map<String, String> headerMap;
+    public Map<String, String[]> headerMap;
 
     String characterEncoding = null;
     ServletOutputStream outputStream = null;
 
     public DummyResponse() {
-        headerMap = DUMMY_DEFAULT_HDEADER_MAP;
+        headerMap = DUMMY_DEFAULT_HEADER_MAP;
     }
 
     public void addCookie(Cookie arg0) {
@@ -153,15 +152,20 @@ public class DummyResponse implements HttpServletResponse {
     }
 
     public String getHeader(String key) {
-        return headerMap.get(key);
+        return headerMap.get(key) == null || headerMap.get(key).length == 0 ?
+                null :
+                headerMap.get(key)[0];
     }
 
     public Collection<String> getHeaders(String name) {
-        String val = headerMap.get(name);
-        List list = new ArrayList();
-        if (val != null)
-            list.add(val);
-        return list;
+        String[] values = headerMap.get(name);
+        if (values == null) {
+            return Collections.emptyList();
+        } else {
+            List<String> result = new ArrayList<String>(values.length);
+            Collections.addAll(result, values);
+            return result;
+        }
     }
 
     public Collection<String> getHeaderNames() {

--- a/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyServerAdapter.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/dummy/DummyServerAdapter.java
@@ -39,7 +39,7 @@ public class DummyServerAdapter implements ServerAdapter {
         return -1;
     }
 
-    public Map<String, String> buildResponseHeaderMap() {
+    public Map<String, String[]> buildResponseHeaderMap() {
         return response.headerMap;
     }
 

--- a/logback-access/src/test/java/ch/qos/logback/access/pattern/ConverterTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/pattern/ConverterTest.java
@@ -13,22 +13,21 @@
  */
 package ch.qos.logback.access.pattern;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.servlet.http.Cookie;
-
+import ch.qos.logback.access.dummy.DummyRequest;
+import ch.qos.logback.access.dummy.DummyResponse;
+import ch.qos.logback.access.dummy.DummyServerAdapter;
+import ch.qos.logback.access.spi.AccessEvent;
 import ch.qos.logback.access.spi.IAccessEvent;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import ch.qos.logback.access.dummy.DummyRequest;
-import ch.qos.logback.access.dummy.DummyResponse;
-import ch.qos.logback.access.dummy.DummyServerAdapter;
-import ch.qos.logback.access.spi.AccessEvent;
+import javax.servlet.http.Cookie;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ConverterTest {
 
@@ -172,7 +171,7 @@ public class ConverterTest {
         converter.setOptionList(optionList);
         converter.start();
         String result = converter.convert(event);
-        assertEquals(request.getHeader("headerName1"), result);
+        assertEquals(response.getHeader("headerName1"), result);
     }
 
     @Test
@@ -189,6 +188,26 @@ public class ConverterTest {
         converter.start();
         String result = converter.convert(event);
         assertEquals(Integer.toString(event.getServerAdapter().getStatusCode()), result);
+    }
+
+    @Test
+    public void testFullRequestConverter() {
+        FullRequestConverter converter = new FullRequestConverter();
+        converter.start();
+        String result = converter.convert(event);
+        assertTrue(result.contains("headerName1: headerValue11"));
+        assertTrue(result.contains("headerName1: headerValue12"));
+        assertTrue(result.contains("headerName2: headerValue2"));
+    }
+
+    @Test
+    public void testFullResponseConverter() {
+        FullResponseConverter converter = new FullResponseConverter();
+        converter.start();
+        String result = converter.convert(event);
+        assertTrue(result.contains("headerName1: headerValue1"));
+        assertTrue(result.contains("headerName2: headerValue21"));
+        assertTrue(result.contains("headerName2: headerValue22"));
     }
 
     private IAccessEvent createEvent() {

--- a/logback-access/src/test/java/ch/qos/logback/access/spi/AccessEventSerializationTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/spi/AccessEventSerializationTest.java
@@ -1,13 +1,13 @@
 /**
  * Logback: the reliable, generic, fast and flexible logging framework.
  * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
- *
+ * <p>
  * This program and the accompanying materials are dual-licensed under
  * either the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation
- *
- *   or (per the licensee's choosing)
- *
+ * <p>
+ * or (per the licensee's choosing)
+ * <p>
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
@@ -21,8 +21,7 @@ import org.junit.Test;
 
 import java.io.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class AccessEventSerializationTest {
 
@@ -47,10 +46,11 @@ public class AccessEventSerializationTest {
         assertNotNull(o);
         IAccessEvent aeBack = (IAccessEvent) o;
 
-        assertEquals(DummyResponse.DUMMY_DEFAULT_HDEADER_MAP, aeBack.getResponseHeaderMap());
-        assertEquals(DummyResponse.DUMMY_DEFAULT_HDEADER_MAP.get("x"), aeBack.getResponseHeader("x"));
-        assertEquals(DummyResponse.DUMMY_DEFAULT_HDEADER_MAP.get("headerName1"), aeBack.getResponseHeader("headerName1"));
-        assertEquals(DummyResponse.DUMMY_DEFAULT_HDEADER_MAP.size(), aeBack.getResponseHeaderNameList().size());
+        assertEquals(DummyResponse.DUMMY_DEFAULT_HEADER_MAP.size(), aeBack.getResponseHeaderMap().size());
+        assertNull(aeBack.getResponseHeader("x"));
+        assertEquals(DummyResponse.DUMMY_DEFAULT_HEADER_MAP.get("headerName1")[0], aeBack.getResponseHeader("headerName1"));
+        assertEquals(DummyResponse.DUMMY_DEFAULT_HEADER_MAP.get("headerName2")[0], aeBack.getResponseHeader("headerName2"));
+        assertEquals(DummyResponse.DUMMY_DEFAULT_HEADER_MAP.size(), aeBack.getResponseHeaderNameList().size());
         assertEquals(DummyResponse.DUMMY_DEFAULT_CONTENT_COUNT, aeBack.getContentLength());
         assertEquals(DummyResponse.DUMMY_DEFAULT_STATUS, aeBack.getStatusCode());
 


### PR DESCRIPTION
Release notes:
```
<p><code>IAccessEvent</code> now provides an API to correctly handle multiple 
request/response headers with the same name. <code>FullRequestConverter</code> 
and <code>FullResponseConverter</code> were updated to output those headers,
one per line.
This issue was reported in <a href="http://jira.qos.ch/browse/LOGBACK-878">LOGBACK-878</a>
</p>
```