### PR TITLE
Redundant casts should not be used

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
@@ -273,7 +273,7 @@ public class LogbackValve extends ValveBase implements Lifecycle, Context,
 
   @Override
   public String getProperty(String key) {
-    return (String) this.propertyMap.get(key);
+    return this.propertyMap.get(key);
   }
 
   @Override

--- a/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
@@ -98,7 +98,7 @@ public class JettyBasicTest {
     // this line is necessary to make the stream aware of when the message is
     // over.
     connection.setFixedLengthStreamingMode(msg.getBytes().length);
-    ((HttpURLConnection) connection).setRequestMethod("POST");
+    connection.setRequestMethod("POST");
     connection.setDoOutput(true);
     connection.setDoInput(true);
     connection.setUseCaches(false);

--- a/logback-classic/src/main/java/ch/qos/logback/classic/Logger.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/Logger.java
@@ -134,7 +134,7 @@ public final class Logger implements org.slf4j.Logger, LocationAwareLogger,
     } else {
       int len = this.childrenList.size();
       for (int i = 0; i < len; i++) {
-        final Logger childLogger_i = (Logger) childrenList.get(i);
+        final Logger childLogger_i = childrenList.get(i);
         final String childName_i = childLogger_i.getName();
 
         if (childName.equals(childName_i)) {
@@ -167,7 +167,7 @@ public final class Logger implements org.slf4j.Logger, LocationAwareLogger,
     if (childrenList != null) {
       int len = childrenList.size();
       for (int i = 0; i < len; i++) {
-        Logger child = (Logger) childrenList.get(i);
+        Logger child = childrenList.get(i);
         // tell child to handle parent levelInt change
         child.handleParentLevelChange(effectiveLevelInt);
       }
@@ -192,7 +192,7 @@ public final class Logger implements org.slf4j.Logger, LocationAwareLogger,
       if (childrenList != null) {
         int len = childrenList.size();
         for (int i = 0; i < len; i++) {
-          Logger child = (Logger) childrenList.get(i);
+          Logger child = childrenList.get(i);
           child.handleParentLevelChange(newParentLevelInt);
         }
       }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/HLogger.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/HLogger.java
@@ -106,7 +106,7 @@ public class HLogger extends MarkerIgnoringBase {
     if (childrenMap == null) {
       return null;
     } else {
-      return (HLogger) childrenMap.get(suffix);
+      return childrenMap.get(suffix);
     }
   }
 
@@ -120,7 +120,7 @@ public class HLogger extends MarkerIgnoringBase {
     effectiveLevel = newLevel;
     if (childrenMap != null) {
       for (Iterator<HLogger> i = childrenMap.values().iterator(); i.hasNext();) {
-        HLogger child = (HLogger) i.next();
+        HLogger child = i.next();
 
         // tell child to handle parent levelInt change
         child.handleParentLevelChange(effectiveLevel);
@@ -143,7 +143,7 @@ public class HLogger extends MarkerIgnoringBase {
       // propagate the parent levelInt change to this logger's children
       if (childrenMap != null) {
         for (Iterator<HLogger> i = childrenMap.values().iterator(); i.hasNext();) {
-          HLogger child = (HLogger) i.next();
+          HLogger child = i.next();
           // tell child to handle parent levelInt change
           child.handleParentLevelChange(effectiveLevel);
         }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/control/ScenarioMaker.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/control/ScenarioMaker.java
@@ -61,7 +61,7 @@ public class ScenarioMaker {
         System.out.println("count=" + count);
       }
 
-      String loggerName = (String) queue.removeFirst();
+      String loggerName = queue.removeFirst();
       int randomChildrenCount = ScenarioRandomUtil
           .randomChildrenCount(loggerName);
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/html/XHTMLEntityResolver.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/html/XHTMLEntityResolver.java
@@ -38,7 +38,7 @@ public class XHTMLEntityResolver implements EntityResolver {
 
   public InputSource resolveEntity(String publicId, String systemId) {
     //System.out.println(publicId);
-    final String relativePath = (String)entityMap.get(publicId);
+    final String relativePath = entityMap.get(publicId);
 
     if (relativePath != null) {
       Class clazz = getClass();

--- a/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
@@ -83,7 +83,7 @@ public class ContextBase implements Context, LifeCycle {
     if (CONTEXT_NAME_KEY.equals(key))
       return getName();
 
-    return (String) this.propertyMap.get(key);
+    return this.propertyMap.get(key);
   }
 
   public Object getObject(String key) {

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ElementPath.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ElementPath.java
@@ -97,7 +97,7 @@ public class ElementPath {
   }
 
   public String get(int i) {
-    return (String) partList.get(i);
+    return partList.get(i);
   }
 
   public void pop() {
@@ -109,7 +109,7 @@ public class ElementPath {
   public String peekLast() {
     if (!partList.isEmpty()) {
       int size = partList.size();
-      return (String) partList.get(size - 1);
+      return partList.get(size - 1);
     } else {
       return null;
     }

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/spi/Interpreter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/spi/Interpreter.java
@@ -186,7 +186,7 @@ public class Interpreter {
     // given that an action list is always pushed for every startElement, we
     // need
     // to always pop for every endElement
-    List<Action> applicableActionList = (List<Action>) actionListStack.pop();
+    List<Action> applicableActionList = actionListStack.pop();
 
     if (skip != null) {
       if (skip.equals(elementPath)) {
@@ -232,7 +232,7 @@ public class Interpreter {
     int len = implicitActions.size();
 
     for (int i = 0; i < len; i++) {
-      ImplicitAction ia = (ImplicitAction) implicitActions.get(i);
+      ImplicitAction ia = implicitActions.get(i);
 
       if (ia.isApplicable(elementPath, attributes, ec)) {
         List<Action> actionList = new ArrayList<Action>(1);
@@ -268,7 +268,7 @@ public class Interpreter {
 
     Iterator<Action> i = applicableActionList.iterator();
     while (i.hasNext()) {
-      Action action = (Action) i.next();
+      Action action = i.next();
       // now let us invoke the action. We catch and report any eventual
       // exceptions
       try {

--- a/logback-core/src/test/java/ch/qos/logback/core/spi/CyclicBufferTrackerT.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/spi/CyclicBufferTrackerT.java
@@ -205,7 +205,7 @@ public class CyclicBufferTrackerT<E> implements ComponentTracker<CyclicBuffer<E>
         throw new IllegalArgumentException("arguments must be of type " + TEntry.class);
       }
 
-      TEntry<?> other = (TEntry<?>) o;
+      TEntry<?> other = o;
       if (timestamp > other.timestamp) {
         return 1;
       }

--- a/logback-examples/src/main/java/chapters/mdc/NumberCruncherServer.java
+++ b/logback-examples/src/main/java/chapters/mdc/NumberCruncherServer.java
@@ -101,7 +101,7 @@ public class NumberCruncherServer extends UnicastRemoteObject
     int[] result = new int[len];
 
     for (int i = 0; i < len; i++) {
-      result[i] = ((Integer) factors.elementAt(i)).intValue();
+      result[i] = factors.elementAt(i).intValue();
     }
 
     // clean up

--- a/logback-examples/src/main/java/chapters/onJoran/calculator/ComputationAction2.java
+++ b/logback-examples/src/main/java/chapters/onJoran/calculator/ComputationAction2.java
@@ -73,7 +73,7 @@ public class ComputationAction2 extends Action {
 
   public void end(InterpretationContext ec, String name) {
     // pop nameStr value from the special stack
-    String nameStr = (String) nameStrStack.pop();
+    String nameStr = nameStrStack.pop();
     
     if (OptionHelper.isEmpty(nameStr)) {
       // nothing to do


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1905 - Redundant casts should not be used
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905
Please let me know if you have any questions.
Kirill Vlasov