### PR TITLE
"private" methods that don't access instance data should be "static"

### DIFF
--- a/logback-access/src/test/java/ch/qos/logback/access/db/DBAppenderHSQLTestFixture.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/db/DBAppenderHSQLTestFixture.java
@@ -114,7 +114,7 @@ public class DBAppenderHSQLTestFixture {
     query(conn, buf.toString());
   }
 
-  private  void query(Connection conn, String expression) throws SQLException {
+  private static void query(Connection conn, String expression) throws SQLException {
     Statement st = null;
     st = conn.createStatement();
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
@@ -171,14 +171,14 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     stmt.setString(CALLER_LINE_INDEX, Integer.toString(caller.getLineNumber()));
   }
 
-  private StackTraceElement extractFirstCaller(StackTraceElement[] callerDataArray) {
+  private static StackTraceElement extractFirstCaller(StackTraceElement[] callerDataArray) {
     StackTraceElement caller = EMPTY_CALLER_DATA;
     if(hasAtLeastOneNonNullElement(callerDataArray))
       caller = callerDataArray[0];
     return caller;
   }
 
-  private boolean hasAtLeastOneNonNullElement(StackTraceElement[] callerDataArray) {
+  private static boolean hasAtLeastOneNonNullElement(StackTraceElement[] callerDataArray) {
     return callerDataArray != null && callerDataArray.length > 0 && callerDataArray[0] != null;
   }
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
@@ -64,7 +64,7 @@ public class MDCConverter extends ClassicConverter {
   /**
    * if no key is specified, return all the values present in the MDC, in the format "k1=v1, k2=v2, ..."
    */
-  private String outputMDCForAllKeys(Map<String, String> mdcPropertyMap) {
+  private static String outputMDCForAllKeys(Map<String, String> mdcPropertyMap) {
     StringBuilder buf = new StringBuilder();
     boolean first = true;
     for (Map.Entry<String, String> entry : mdcPropertyMap.entrySet()) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
@@ -232,7 +232,7 @@ public class ThrowableProxyConverter extends ThrowableHandlingConverter {
     }
   }
 
-  private void printIgnoredCount(StringBuilder buf, int ignoredCount) {
+  private static void printIgnoredCount(StringBuilder buf, int ignoredCount) {
     buf.append(" [").append(ignoredCount).append(" skipped]");
   }
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/selector/ContextJNDISelector.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/selector/ContextJNDISelector.java
@@ -118,7 +118,7 @@ public class ContextJNDISelector implements ContextSelector {
     }
   }
 
-  private String conventionalConfigFileName(String contextName) {
+  private static String conventionalConfigFileName(String contextName) {
     return "logback-" + contextName + ".xml";
   }
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/PackagingDataCalculator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/PackagingDataCalculator.java
@@ -143,7 +143,7 @@ public class PackagingDataCalculator {
     return cpd;
   }
 
-  String getImplementationVersion(Class type) {
+  static String getImplementationVersion(Class type) {
     if (type == null) {
       return "na";
     }
@@ -184,7 +184,7 @@ public class PackagingDataCalculator {
     return "na";
   }
 
-  private String getCodeLocation(String locationStr, char separator) {
+  private static String getCodeLocation(String locationStr, char separator) {
     int idx = locationStr.lastIndexOf(separator);
     if (isFolder(idx, locationStr)) {
       idx = locationStr.lastIndexOf(separator, idx - 1);
@@ -195,11 +195,11 @@ public class PackagingDataCalculator {
     return null;
   }
 
-  private boolean isFolder(int idx, String text) {
+  private static boolean isFolder(int idx, String text) {
     return (idx != -1 && idx + 1 == text.length());
   }
 
-  private Class loadClass(ClassLoader cl, String className) {
+  private static Class loadClass(ClassLoader cl, String className) {
     if (cl == null) {
       return null;
     }
@@ -221,8 +221,8 @@ public class PackagingDataCalculator {
    * @param className
    * @return
    */
-  private Class bestEffortLoadClass(ClassLoader lastGuaranteedClassLoader,
-                                    String className) {
+  private static Class bestEffortLoadClass(ClassLoader lastGuaranteedClassLoader,
+                                           String className) {
     Class result = loadClass(lastGuaranteedClassLoader, className);
     if (result != null) {
       return result;

--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
@@ -65,7 +65,7 @@ public final class LogbackMDCAdapter implements MDCAdapter {
     return lastOp;
   }
 
-  private boolean wasLastOpReadOrNull(Integer lastOp) {
+  private static boolean wasLastOpReadOrNull(Integer lastOp) {
     return lastOp == null || lastOp.intValue() == READ_OPERATION;
   }
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/LoggerSerializationTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/LoggerSerializationTest.java
@@ -120,11 +120,11 @@ public class LoggerSerializationTest {
   Foo readFooObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
     return (Foo) readObject(inputStream);
   }
-  private Object readObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+  private static Object readObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
     return inputStream.readObject();
   }
 
-  private void writeObject(ObjectOutputStream oos, Object o) throws IOException {
+  private static void writeObject(ObjectOutputStream oos, Object o) throws IOException {
     oos.writeObject(o);
     oos.flush();
     oos.close();

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderH2TestFixture.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderH2TestFixture.java
@@ -128,7 +128,7 @@ public class DBAppenderH2TestFixture  {
     executeQuery(connection, buf.toString());
   }
 
-  private  void executeQuery(Connection conn, String expression) throws SQLException {
+  private static void executeQuery(Connection conn, String expression) throws SQLException {
     Statement st = null;
     st = conn.createStatement();
     int i = st.executeUpdate(expression);

--- a/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderHSQLTestFixture.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/db/DBAppenderHSQLTestFixture.java
@@ -160,7 +160,7 @@ public class DBAppenderHSQLTestFixture  {
     query(conn, buf.toString());
   }
 
-  private  void query(Connection conn, String expression) throws SQLException {
+  private static void query(Connection conn, String expression) throws SQLException {
 
     Statement st = null;
     st = conn.createStatement();

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SMTPAppender_GreenTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SMTPAppender_GreenTest.java
@@ -247,7 +247,7 @@ public class SMTPAppender_GreenTest {
     }
   }
 
-  private byte[] getAsByteArray(InputStream inputStream) throws IOException {
+  private static byte[] getAsByteArray(InputStream inputStream) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
     byte[] buffer = new byte[1024];

--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
@@ -155,7 +155,7 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
     }
   }
 
-  private void appendIfNotNull(StringBuilder sb, String s) {
+  private static void appendIfNotNull(StringBuilder sb, String s) {
     if (s != null) {
       sb.append(s);
     }

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ElementPath.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ElementPath.java
@@ -84,7 +84,7 @@ public class ElementPath {
     return true;
   }
 
-  private boolean equalityCheck(String x, String y) {
+  private static boolean equalityCheck(String x, String y) {
     return x.equalsIgnoreCase(y);
   }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ElementSelector.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ElementSelector.java
@@ -13,7 +13,6 @@
  */
 package ch.qos.logback.core.joran.spi;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -138,7 +137,7 @@ public class ElementSelector extends ElementPath {
     return match;
   }
 
-  private boolean equalityCheck(String x, String y) {
+  private static boolean equalityCheck(String x, String y) {
     return x.equalsIgnoreCase(y);
   }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/spi/SimpleRuleStore.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/spi/SimpleRuleStore.java
@@ -154,7 +154,7 @@ public class SimpleRuleStore extends ContextAwareBase implements RuleStore {
     }
   }
 
-  private boolean isKleeneStar(String last) {
+  private static boolean isKleeneStar(String last) {
     return KLEENE_STAR.equals(last);
   }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/util/PropertySetter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/util/PropertySetter.java
@@ -213,7 +213,7 @@ public class PropertySetter extends ContextAwareBase {
     }
   }
 
-  private Class<?> getParameterClassForMethod(Method method) {
+  private static Class<?> getParameterClassForMethod(Method method) {
     if (method == null) {
       return null;
     }
@@ -244,7 +244,7 @@ public class PropertySetter extends ContextAwareBase {
    *          The class to test for instantiability
    * @return true if clazz can be instantiated, and false otherwise.
    */
-  private boolean isUnequivocallyInstantiable(Class<?> clazz) {
+  private static boolean isUnequivocallyInstantiable(Class<?> clazz) {
     if (clazz.isInterface()) {
       return false;
     }
@@ -384,7 +384,7 @@ public class PropertySetter extends ContextAwareBase {
     return true;
   }
 
-  private String capitalizeFirstLetter(String name) {
+  private static String capitalizeFirstLetter(String name) {
     return name.substring(0, 1).toUpperCase() + name.substring(1);
   }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLContextFactoryBean.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLContextFactoryBean.java
@@ -228,7 +228,7 @@ public class SSLContextFactoryBean {
    * @return URL for the location specified in the property or {@code null}
    *    if no value is defined for the property
    */
-  private String locationFromSystemProperty(String name) {
+  private static String locationFromSystemProperty(String name) {
     String location = System.getProperty(name);
     if (location != null && !location.startsWith("file:")) {
       location = "file:" + location;

--- a/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.java
@@ -141,7 +141,7 @@ public class SSLParametersConfiguration extends ContextAwareBase {
    * @param s the subject string
    * @return array of values contained in {@code s}
    */
-  private String[] stringToArray(String s) {
+  private static String[] stringToArray(String s) {
     return s.split("\\s*,\\s*");
   }
   

--- a/logback-core/src/main/java/ch/qos/logback/core/util/CharSequenceToRegexMapper.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/CharSequenceToRegexMapper.java
@@ -81,7 +81,7 @@ class CharSequenceToRegexMapper {
     }
   }
 
-  private String number(int occurrences) {
+  private static String number(int occurrences) {
     return "\\d{" + occurrences + "}";
   }
 
@@ -105,7 +105,7 @@ class CharSequenceToRegexMapper {
     return symbolArrayToRegex(symbols.getShortMonths());
   }
 
-  private String symbolArrayToRegex(String[] symbolArray) {
+  private static String symbolArrayToRegex(String[] symbolArray) {
     int[] minMax = findMinMaxLengthsInSymbols(symbolArray);
     return ".{" + minMax[0] + "," + minMax[1] + "}";
   }

--- a/logback-core/src/test/java/ch/qos/logback/core/encoder/DummyEncoder.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/encoder/DummyEncoder.java
@@ -45,7 +45,7 @@ public class DummyEncoder<E> extends EncoderBase<E> {
     writeOut(val);
   }
 
-  private void appendIfNotNull(StringBuilder sb, String s) {
+  private static void appendIfNotNull(StringBuilder sb, String s) {
     if (s != null) {
       sb.append(s);
     }

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/TrivialConfiguratorTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/TrivialConfiguratorTest.java
@@ -150,13 +150,13 @@ public class TrivialConfiguratorTest {
             + ".jar");
   }
 
-  private void fillInJarFile(File jarFile, String jarEntryName)
+  private static void fillInJarFile(File jarFile, String jarEntryName)
           throws IOException {
     fillInJarFile(jarFile, jarEntryName, null);
   }
 
-  private void fillInJarFile(File jarFile, String jarEntryName1,
-                             String jarEntryName2) throws IOException {
+  private static void fillInJarFile(File jarFile, String jarEntryName1,
+                                    String jarEntryName2) throws IOException {
     JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile));
     jos.putNextEntry(new ZipEntry(jarEntryName1));
     jos.write("<x/>".getBytes());

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/spi/CaseCombinator.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/spi/CaseCombinator.java
@@ -42,7 +42,7 @@ public class CaseCombinator {
 
   }
 
-  private char permute(char c, int permutation, int position) {
+  private static char permute(char c, int permutation, int position) {
     int mask = 1 << position;
     boolean shouldBeInUpperCase = (permutation & mask) != 0;
     boolean isEffectivelyUpperCase = isUpperCase(c);
@@ -53,7 +53,7 @@ public class CaseCombinator {
     return c;
   }
 
-  private int computeTotalNumerOfCombinations(String in, int length) {
+  private static int computeTotalNumerOfCombinations(String in, int length) {
     int count = 0;
     for (int i = 0; i < length; i++) {
       char c = in.charAt(i);
@@ -64,7 +64,7 @@ public class CaseCombinator {
     return (1 << count);
   }
 
-  private char toUpperCase(char c) {
+  private static char toUpperCase(char c) {
     if ('A' <= c && c <= 'Z') {
       return c;
     }
@@ -75,7 +75,7 @@ public class CaseCombinator {
     return c;
   }
 
-  private char toLowerCase(char c) {
+  private static char toLowerCase(char c) {
     if ('a' <= c && c <= 'z') {
       return c;
     }
@@ -86,7 +86,7 @@ public class CaseCombinator {
     return c;
   }
 
-  private boolean isEnglishLetter(char c) {
+  private static boolean isEnglishLetter(char c) {
     if ('a' <= c && c <= 'z')
       return true;
 
@@ -95,7 +95,7 @@ public class CaseCombinator {
     return false;
   }
 
-  private boolean isUpperCase(char c) {
+  private static boolean isUpperCase(char c) {
     return ('A' <= c && c <= 'Z');
   }
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/net/ssl/mock/MockContextAware.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/net/ssl/mock/MockContextAware.java
@@ -58,7 +58,7 @@ public class MockContextAware extends ContextAwareBase
     return hasMatching(info, regex);
   }
   
-  private boolean hasMatching(List<String> messages, String regex) {
+  private static boolean hasMatching(List<String> messages, String regex) {
     for (String message : messages) {
       if (message.matches(regex)) return true;
     }

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/TimeBasedRollingWithArchiveRemoval_Test.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/TimeBasedRollingWithArchiveRemoval_Test.java
@@ -13,12 +13,7 @@
  */
 package ch.qos.logback.core.rolling;
 
-import ch.qos.logback.core.Context;
-import ch.qos.logback.core.ContextBase;
-import ch.qos.logback.core.encoder.EchoEncoder;
 import ch.qos.logback.core.rolling.helper.RollingCalendar;
-import ch.qos.logback.core.testUtil.RandomUtil;
-import ch.qos.logback.core.util.CoreTestConstants;
 import ch.qos.logback.core.util.StatusPrinter;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +21,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,7 +54,7 @@ public class TimeBasedRollingWithArchiveRemoval_Test extends ScaffoldingForRolli
   }
 
 
-  private int computeSlashCount(String datePattern) {
+  private static int computeSlashCount(String datePattern) {
     if (datePattern == null)
       return 0;
     else {

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/CompressTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/CompressTest.java
@@ -125,7 +125,7 @@ public class CompressTest {
     // + "witness/compress3.txt.zip"));
   }
 
-  private void copy(File src, File dst) throws IOException {
+  private static void copy(File src, File dst) throws IOException {
     InputStream in = new FileInputStream(src);
     OutputStream out = new FileOutputStream(dst);
     byte[] buf = new byte[1024];

--- a/logback-core/src/test/java/ch/qos/logback/core/util/StringCollectionUtilTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/util/StringCollectionUtilTest.java
@@ -73,7 +73,7 @@ public class StringCollectionUtilTest {
   }
 
   @SuppressWarnings("unchecked")
-  private List<String> stringToList(String... values) {
+  private static List<String> stringToList(String... values) {
     List<String> result = new ArrayList<String>(values.length);
     result.addAll(Arrays.asList(values));
     return result;

--- a/logback-core/src/test/java/ch/qos/logback/core/util/TimeUtilTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/util/TimeUtilTest.java
@@ -115,7 +115,7 @@ public class TimeUtilTest  {
     assertEquals(expected, computed);
   }
   
-  private long correctBasedOnTimeZone(long gmtLong) {
+  private static long correctBasedOnTimeZone(long gmtLong) {
     int offset = TimeZone.getDefault().getRawOffset();
     return gmtLong - offset;
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
Please let me know if you have any questions.
Kirill Vlasov