### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/HLogger.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/HLogger.java
@@ -215,9 +215,9 @@ public class HLogger extends MarkerIgnoringBase {
    * Remove the appender passed as parameter form the list of appenders.
    */
   public synchronized void removeAppender(Appender<ILoggingEvent> appender) {
-    if ((appender == null) || (appenderList == null)) {
+    if (appender != null && appenderList != null) {
+      appenderList.remove(appender);
     }
-    appenderList.remove(appender);
   }
 
   /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - Null pointers should not be dereferenced
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2259
Please let me know if you have any questions.
Kirill Vlasov