### PR TITLE
Improve lookup of logger name abbreviation with cache

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
@@ -13,28 +13,32 @@
  */
 package ch.qos.logback.classic.pattern;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.MDC;
-import org.slf4j.MarkerFactory;
-
 import ch.qos.logback.classic.ClassicConstants;
+import ch.qos.logback.classic.ClassicTestConstants;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.ClassicTestConstants;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.net.SyslogConstants;
 import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.core.pattern.FormatInfo;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.MDC;
+import org.slf4j.MarkerFactory;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ConverterTest {
 
@@ -397,5 +401,24 @@ public class ConverterTest {
 
     String result = converter.convert(event);
     assertEquals("v", result);
+  }
+
+  @Test
+  @Ignore
+  public void performanceTest() {
+    final LoggerConverter converter = new LoggerConverter();
+    converter.setOptionList(Collections.singletonList("0"));
+    converter.start();
+    final LoggingEvent event = makeLoggingEvent(null);
+    for (int i = 0; i < 100000; i++) {
+      converter.convert(event);
+    }
+    for (int run = 0; run < 10; run++) {
+      long startTime = System.nanoTime();
+      for (int i = 0; i < 200000000; i++) {
+        converter.convert(event);
+      }
+      System.out.println("Time: " + (System.nanoTime() - startTime) / 1000000);
+    }
   }
 }


### PR DESCRIPTION
We could add a cache for the abbreviations of the FQN logger names to increase the performance. It's just an idea, but maybe this PR is a contribution you like.
I know some software projects with several thousand classes but not all of them have log statements inside. So why don't create a cache between the logger name / class name and the generated abbreviation?

We could restrict the cache size to 25000 entries (for example) and reuse the abbreviation for every log statement that is written. This PR uses a `ConcurrentHashMap` as cache. It is filled until the cache size exhausted.

I've added a small benchmark method (I know, microbenchmarking is hard / bad) to compare the current approach with the cached one. It converts the same loggername 200000000 times into the abbreviation. Here are the average values out of 10 runs (without reforming the JVM) and the nanoseconds per operation.:

| description | average in ms | ns per op |
| --- | --- | --- |
| cur. impl. length 15 | 46963,8 | 234,82 |
| cur. impl. length 255 | 2951,4 | 14,76 |
| cur. impl. length 0 | 13625,7 | 68,13 |
| cached length 15 | 731,5 | 3,66 |
| cached length 255 | 725 | 3,63 |
| cached length 0 | 674 | 3,37 |

A length of 0 uses the `ClassNameOnlyAbbraviator`. 
(To compare the values with your own machine: Quad i7, 2,3ghz)

But the cache solution have also some drawbacks:
- Memory is used to hold the cache. On the other hand the garbage collection is slightly reduced due less generated String objects.
- This is no LRU-Cache. Really big projects may not benefit from this patch because they have so many logging classes. Yes, maybe we can make the class cache bigger or configurable. Same for dynamic logger names. On the other hand: If the cache is full and the searched loggername is not in the cache, the implementation is only slightly slower.
- Why not using a LRU-Cache? Java5 doesn't have a thread safe LRU cache. The `LinkedHashMap` in combination with `Collections.synchronizedMap(..)` is approximately 10 times slower.
- The `size()`-method on a `ConcurrentHashMap` could take some time on heavy write operations along the map. This is optimized in Java8 but nevertheless: If all classes are in the cache noone would write in the cache again. So I think it's not a problem at all but we may investigate / test this behavior with Java < 8.
- Your benchmark is only with one entry in the map. Right! But first I want to here opinion about caching this stuff.
