### PR TITLE
Fix StackOverflow in ThrowableProxy

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/ThrowableProxyTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/ThrowableProxyTest.java
@@ -112,6 +112,24 @@ public class ThrowableProxyTest {
   }
 
   @Test
+  public void suppressedCyclic() throws InvocationTargetException, IllegalAccessException
+  {
+    assumeTrue(TeztHelper.suppressedSupported()); // only execute on Java 7, would work anyway but doesn't make sense.
+    Exception ex = null;
+    try {
+      someMethod();
+    } catch (Exception e) {
+      addSuppressed(e, new Exception("foo", e));
+      ex = e;
+    }
+    // Disabled verification
+    // Java exception printing includes a [CIRCULAR REFERENCE] line in this case.
+    // Matching this output would require non-trivial changes to ThrowableProxy.
+    // For now I'm just happy that this doesn't cause a StackOverflow
+    //verify(ex);
+  }
+
+  @Test
   public void suppressedWithSuppressed() throws Exception
   {
     assumeTrue(TeztHelper.suppressedSupported()); // only execute on Java 7, would work anyway but doesn't make sense.


### PR DESCRIPTION
It is possible for the cause of a suppressed exception to be the
exception it is attached to. Gracefully handle that case by
unsetting the cause to break and avoid a StackOverflow.

Sample stack trace showing the issue:

javax.net.ssl.SSLException: SSL peer shut down incorrectly
        at sun.security.ssl.InputRecord.readV3Record(InputRecord.java:596)
        at sun.security.ssl.InputRecord.read(InputRecord.java:532)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:961)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:918)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
        at java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
        at sun.net.www.MeteredStream.read(MeteredStream.java:134)
        at java.io.FilterInputStream.read(FilterInputStream.java:133)
        at sun.net.www.protocol.http.HttpURLConnection.read(HttpURLConnection.java:3335)
        at sun.net.www.protocol.http.HttpURLConnection.read(HttpURLConnection.java:3328)
        ...
        Suppressed: javax.net.ssl.SSLException: Connection has been shutdown: javax.net.ssl.SSLException: SSL peer shut down incorrectly
                at sun.security.ssl.SSLSocketImpl.checkEOF(SSLSocketImpl.java:1529)
                at sun.security.ssl.AppInputStream.available(AppInputStream.java:60)
                at java.io.BufferedInputStream.available(BufferedInputStream.java:410)
                at sun.net.www.MeteredStream.available(MeteredStream.java:170)
                at sun.net.www.http.KeepAliveStream.close(KeepAliveStream.java:85)
                at java.io.FilterInputStream.close(FilterInputStream.java:181)
                at sun.net.www.protocol.http.HttpURLConnection.close(HttpURLConnection.java:3408)
                ...