### PR TITLE
Fix NPE on JMX reloadDefaultConfiguration when no configuration file is used

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/jmx/JMXConfigurator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/jmx/JMXConfigurator.java
@@ -1,6 +1,6 @@
 /**
  * Logback: the reliable, generic, fast and flexible logging framework.
- * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ * Copyright (C) 1999-2016, QOS.ch. All rights reserved.
  *
  * This program and the accompanying materials are dual-licensed under
  * either the terms of the Eclipse Public License v1.0 as published by
@@ -140,18 +140,22 @@ public class JMXConfigurator extends ContextAwareBase implements
     addStatusListener(statusListenerAsList);
     addInfo("Resetting context: " + loggerContext.getName());
     loggerContext.reset();
-    // after a reset the statusListenerAsList gets removed as a listener
-    addStatusListener(statusListenerAsList);
 
-    try {
-      JoranConfigurator configurator = new JoranConfigurator();
-      configurator.setContext(loggerContext);
-      configurator.doConfigure(url);
-      addInfo("Context: " + loggerContext.getName() + " reloaded.");
-    } finally {
-      removeStatusListener(statusListenerAsList);
-      if (debug) {
-        StatusPrinter.print(statusListenerAsList.getStatusList());
+    // use configurator only if a url is defined
+    if (url != null) {
+      // after a reset the statusListenerAsList gets removed as a listener
+      addStatusListener(statusListenerAsList);
+
+      try {
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(loggerContext);
+        configurator.doConfigure(url);
+        addInfo("Context: " + loggerContext.getName() + " reloaded.");
+      } finally {
+        removeStatusListener(statusListenerAsList);
+        if (debug) {
+          StatusPrinter.print(statusListenerAsList.getStatusList());
+        }
       }
     }
   }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/jmx/JMXConfiguratorTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/jmx/JMXConfiguratorTest.java
@@ -1,6 +1,6 @@
 /**
  * Logback: the reliable, generic, fast and flexible logging framework.
- * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ * Copyright (C) 1999-2016, QOS.ch. All rights reserved.
  *
  * This program and the accompanying materials are dual-licensed under
  * either the terms of the Eclipse Public License v1.0 as published by
@@ -152,6 +152,22 @@ public class JMXConfiguratorTest {
     configurator.setLoggerLevel(testLogger.getName(), "null");
     assertNull(testLogger.getLevel());
        
+    MBeanUtil.unregister(lc, mbs, on, this);
+  }
+
+  @Test
+  public void testReloadDefaultConfiguration() throws Exception {
+    String objectNameAsStr = "ch.qos"+diff + ":Name=" + lc.getName()
+            + ",Type=" + this.getClass().getName();
+
+    ObjectName on = MBeanUtil.string2ObjectName(lc, this, objectNameAsStr);
+    JMXConfigurator configurator = new JMXConfigurator(lc, mbs, on);
+    configurator.setLoggerLevel(testLogger.getName(), "DEBUG");
+    assertEquals(Level.DEBUG,  testLogger.getLevel());
+
+    configurator.reloadDefaultConfiguration();
+    assertNull(testLogger.getLevel());
+
     MBeanUtil.unregister(lc, mbs, on, this);
   }
 


### PR DESCRIPTION
NPE occurs in use cases where Logback configuration is done programmatically. For example, Spring Boot uses Logback as default logging implementation and provides various means of customizing its default configuration. Enabling JMX configurator in such setup causes reloadDefaultConfiguration JMX operation to throw NPE.

This PR adds check to conditionally run configurator if the configuration file URL is indeed available.

PR includes a test case which reproduces the issue with current implementation. If needed, I can also provide a simple Spring Boot project to reproduce the issue.

Do I need to sign the CLA for this PR?