### PR TITLE
SSL hostname verification

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurable.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurable.java
@@ -83,4 +83,5 @@ public interface SSLConfigurable {
      */
     void setWantClientAuth(boolean state);
 
+    void setDisableHostnameVerification(boolean disableHostnameVerification);
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableServerSocket.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableServerSocket.java
@@ -60,4 +60,7 @@ public class SSLConfigurableServerSocket implements SSLConfigurable {
         delegate.setWantClientAuth(state);
     }
 
+    public void setDisableHostnameVerification(boolean disableHostnameVerification) {
+        // This is not relevant for a server socket.
+    }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableSocket.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableSocket.java
@@ -13,6 +13,7 @@
  */
 package ch.qos.logback.core.net.ssl;
 
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 
 /**
@@ -60,4 +61,12 @@ public class SSLConfigurableSocket implements SSLConfigurable {
         delegate.setWantClientAuth(state);
     }
 
+    public void setDisableHostnameVerification(boolean disableHostnameVerification) {
+        if (disableHostnameVerification) {
+            return;
+        }
+        SSLParameters sslParameters = delegate.getSSLParameters();
+        sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+        delegate.setSSLParameters(sslParameters);
+    }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.java
@@ -40,6 +40,7 @@ public class SSLParametersConfiguration extends ContextAwareBase {
     private Boolean wantClientAuth;
     private String[] enabledProtocols;
     private String[] enabledCipherSuites;
+    private Boolean disableHostnameVerification;
 
     /**
      * Configures SSL parameters on an {@link SSLConfigurable}.
@@ -54,6 +55,7 @@ public class SSLParametersConfiguration extends ContextAwareBase {
         if (isWantClientAuth() != null) {
             socket.setWantClientAuth(isWantClientAuth());
         }
+        socket.setDisableHostnameVerification(disableHostnameVerification != null ? disableHostnameVerification : false);
     }
 
     /**
@@ -239,4 +241,11 @@ public class SSLParametersConfiguration extends ContextAwareBase {
         this.wantClientAuth = wantClientAuth;
     }
 
+    public void setDisableHostnameVerification(Boolean disableHostnameVerification) {
+        this.disableHostnameVerification = disableHostnameVerification;
+    }
+
+    public Boolean isDisableHostnameVerification() {
+        return disableHostnameVerification;
+    }
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/net/ssl/mock/MockSSLConfigurable.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/net/ssl/mock/MockSSLConfigurable.java
@@ -27,6 +27,7 @@ public class MockSSLConfigurable implements SSLConfigurable {
     private String[] enabledCipherSuites = EMPTY;
     private boolean needClientAuth;
     private boolean wantClientAuth;
+    private Boolean disableHostnameVerification;
 
     public String[] getDefaultProtocols() {
         return defaultProtocols;
@@ -92,4 +93,11 @@ public class MockSSLConfigurable implements SSLConfigurable {
         this.wantClientAuth = wantClientAuth;
     }
 
+    public boolean isDisableHostnameVerification() {
+        return disableHostnameVerification;
+    }
+
+    public void setDisableHostnameVerification(boolean disableHostnameVerification) {
+        this.disableHostnameVerification = disableHostnameVerification;
+    }
 }


### PR DESCRIPTION
When [using SSL](http://logback.qos.ch/manual/usingSSL.html), there currently is no hostname verification: distinct servers with certificates issued by trusted CAs could impersonate each other.

This small patch implements hostname verification (using Java 7's "HTTPS" endpoint identification algorithm rules), and turns it on by default. It also adds a configuration to turn it off (`dontVerifyHostname`):

```
    <ssl>
        <trustStore>
            <location>classpath:/democa.jks</location>
            <password>demodemo</password>
        </trustStore>
        <parameters>
            <dontVerifyHostname>true</dontVerifyHostname>
        </parameters>
    </ssl>
```

(I realise this may break some existing configurations, but security by default is generally the right choice.)

This uses Java's [`SSLParameters.setEndpointIdentificationAlgorithm(String)`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLParameters.html#setEndpointIdentificationAlgorithm-java.lang.String-), which is only available from Java 7. I have therefore implemented it using reflection, which rather unsatisfactory, but works. (I have also silenced the potential reflection exceptions, which is not great, but I wasn't sure how to handle this w.r.t. the rest of the code base.)
Hostname verification will still be missing when using Java 6.

Please note that Java's hostname matching rules follow RFC 2818 quite strictly. In particular, when using an IP address, that IP address MUST be in a Subject Alternative Name (of type IP address), not just in the CN. The documentation should probably reflect this. When using an IP address, instead of using:

```
keytool -genkey -alias server -dname "CN=my-logging-server" \
    -keyalg RSA -validity 365 -keystore server.keystore
```

the `-ext san=ip:<THE.IP.ADDRESS>` option should be used. For example (assuming the server address is `10.0.0.1`):

```
keytool -genkey -alias server -dname "CN=10.0.0.1" \
    -ext san=ip:10.0.0.1 \
    -keyalg RSA -validity 365 -keystore server.keystore
```

This requires `keytool` from Java 7 or above, but it can produce keystores usable with Java 6.

Feedback welcome, I don't mind modifying this patch if the pull request cannot be merged as it is.
