### PR TITLE
Fix links to SimpleDateFormat and Charset Javadoc

### DIFF
--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -597,7 +597,7 @@ public interface Appender&lt;E> extends LifeCycle, ContextAware, FilterAttachabl
    denotes the date pattern used to convert the current time (at which
    the configuration file is parsed) into a string. The date pattern
    should follow the conventions defined in <a
-   href="http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>. The
+   href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>. The
    <span class="attr">timeReference</span> attribute denotes the time
    reference for the time stamp. The default is the
    interpretation/parsing time of the configuration file, i.e. the
@@ -2364,7 +2364,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
         <td><code>String</code></td>
         <td>The outgoing email message will be encoded in the
         designated <a
-        href="http://java.sun.com/j2se/1.4.2/docs/api/java/nio/charset/Charset.html">charset</a>. The
+        href="https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html">charset</a>. The
         default charset encoding is "UTF-8" which works well for most
         purposes.
         </td>

--- a/logback-site/src/site/pages/manual/appenders_ja.html
+++ b/logback-site/src/site/pages/manual/appenders_ja.html
@@ -356,7 +356,7 @@ public interface Appender&lt;E&gt; extends LifeCycle, ContextAware, FilterAttach
 &lt;/configuration&gt;</pre>
 
 
-   <p>timestamp要素には、<span class="attr">key属性</span>および<span class="attr">datePattern属性</span>という2つの必須属性と、<span class="attr">timeReference属性</span>という任意属性があります。<span class="attr">key属性</span>には、<a href="./configuration.html#variableSubstitution">変数</a>と同じく、他の設定要素からタイムスタンプを参照するときの名前を指定します。<span class="attr">datePattern</span>属性には、設定ファイルを解釈した時点の日時を文字列に変換するための日付パターン文字列を指定します。日付パターン文字列に指定できるのは、<a href="http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>で利用できるものと同じです。<span class="attr">timeReference属性</span>には、タイムスタンプの基準時間を指定します。デフォルトでは、現在の日時、つまり、設定ファイルを解析、解釈した時点の日時になります。ですが、コンテキストを生成した時間を基準時間としたほうが便利な場合もあるでしょう。そういう場合は、<span class="attr">timeReference属性</span>に<code>"contextBirth"</code>を指定すればよいです。
+   <p>timestamp要素には、<span class="attr">key属性</span>および<span class="attr">datePattern属性</span>という2つの必須属性と、<span class="attr">timeReference属性</span>という任意属性があります。<span class="attr">key属性</span>には、<a href="./configuration.html#variableSubstitution">変数</a>と同じく、他の設定要素からタイムスタンプを参照するときの名前を指定します。<span class="attr">datePattern</span>属性には、設定ファイルを解釈した時点の日時を文字列に変換するための日付パターン文字列を指定します。日付パターン文字列に指定できるのは、<a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>で利用できるものと同じです。<span class="attr">timeReference属性</span>には、タイムスタンプの基準時間を指定します。デフォルトでは、現在の日時、つまり、設定ファイルを解析、解釈した時点の日時になります。ですが、コンテキストを生成した時間を基準時間としたほうが便利な場合もあるでしょう。そういう場合は、<span class="attr">timeReference属性</span>に<code>"contextBirth"</code>を指定すればよいです。
    </p>
 
    <p>次のコマンドを実行して、<code>timestamp要素</code>がどうなるのか試してみましょう。</p>
@@ -1371,7 +1371,7 @@ public interface TriggeringPolicy&lt;E&gt; extends LifeCycle {
       <tr>
         <td><span class="prop" container="smtp">charsetEncoding</span></td>
         <td><code>String</code></td>
-        <td>送信されるメッセージは指定された<a href="http://java.sun.com/j2se/1.4.2/docs/api/java/nio/charset/Charset.html">文字セット</a>でエンコードされます。デフォルトの文字セットは"UTF-8"ですが、ほとんどの場合十分でしょう。
+        <td>送信されるメッセージは指定された<a href="https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html">文字セット</a>でエンコードされます。デフォルトの文字セットは"UTF-8"ですが、ほとんどの場合十分でしょう。
         </td>
       </tr>
 

--- a/logback-site/src/site/pages/manual/groovy.html
+++ b/logback-site/src/site/pages/manual/groovy.html
@@ -252,7 +252,7 @@ root(DEBUG, ["FILE"])</pre>
     formatted according to the <code>datePattern</code> parameter. The
     <code>datePattern</code> parameter should follow the conventions
     defined by <a
-    href="http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>. If
+    href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>. If
     the <code>timeReference</code> value is unspecified, it defaults
     to -1, in which case current time, that is time when the
     configuration file is parsed, is used as the time

--- a/logback-site/src/site/pages/manual/groovy_ja.html
+++ b/logback-site/src/site/pages/manual/groovy_ja.html
@@ -142,7 +142,7 @@ root(DEBUG, ["FILE"])</pre>
     <!-- ========================================================== -->        
     <h3>• <span class="code">timestamp(String datePattern, long timeReference = -1)</span></h3>
 
-    <p><code>timestamp()</code>メソッドは、<code>datePattern</code>に指定された書式文字列で<code>timeReference</code>に指定されたlong値の時間を書式化した文字列を返します。第一引数の<code>datePattern</code>に指定する書式文字列は、<a href="http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>で定義されている規則に従わなければなりません。第二引数の<code>timeReference</code>が省略された場合-1が指定されたものとして扱います。これは設定ファイルを解析しているときの現在日時を表す値です。状況によりますが、基準時間として<code>context.birthTime</code>を使うこともあるでしょう。
+    <p><code>timestamp()</code>メソッドは、<code>datePattern</code>に指定された書式文字列で<code>timeReference</code>に指定されたlong値の時間を書式化した文字列を返します。第一引数の<code>datePattern</code>に指定する書式文字列は、<a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>で定義されている規則に従わなければなりません。第二引数の<code>timeReference</code>が省略された場合-1が指定されたものとして扱います。これは設定ファイルを解析しているときの現在日時を表す値です。状況によりますが、基準時間として<code>context.birthTime</code>を使うこともあるでしょう。
     </p>
 
     <p>次の例では、 <code>bySecond</code>変数に"yyyyMMdd'T'HHmmss"という書式で文字列化した現在日時を代入していますそして、"bySecond" 変数を<span class="option">file</span>プロパティの値として使っています。

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -543,7 +543,7 @@ WARN  [main]: Message 2</p>
          <p>Used to output the date of the logging event.  The date
          conversion word admits a pattern string as a parameter. The
          pattern syntax is compatible with the format accepted by <a
-         href="http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html"><code>java.text.SimpleDateFormat</code></a>.</p>
+         href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html"><code>java.text.SimpleDateFormat</code></a>.</p>
 
          <p>You can specify the string <em>"ISO8601"</em> for the
          ISO8601 date format. Note that the %date conversion word

--- a/logback-site/src/site/pages/manual/layouts_ja.html
+++ b/logback-site/src/site/pages/manual/layouts_ja.html
@@ -380,7 +380,7 @@ WARN  [main]: Message 2</p>
           <b>date</b>{<em>pattern</em>, <em>timezone</em>} <br>
         </td>
         <td>
-         <p>ロギングイベントの日時を出力するために使います。引数として日時パターン文字列を指定することができます。日時パターン文字列は<a href="http://java.sun.com/j2se/1.4.2/docs/api/java/text/SimpleDateFormat.html"><code>java.text.SimpleDateFormat</code></a>と互換性があります。</p>
+         <p>ロギングイベントの日時を出力するために使います。引数として日時パターン文字列を指定することができます。日時パターン文字列は<a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html"><code>java.text.SimpleDateFormat</code></a>と互換性があります。</p>
 
          <p>引数に<em>"ISO8601"</em>と指定すると ISO8601 の書式になります。日時パターン文字列が指定されなかった場合、デフォルトは<a href="http://en.wikipedia.org/wiki/ISO_8601">ISO8601書式</a>になるので注意してください。</p>
 


### PR DESCRIPTION
The links were to J2SE 1.4.2 Javadoc, which no longer work.

Update to point to the Java 8 Javadoc.