### PR TITLE
No need in reflection for PreparedStatement.getGeneratedKeys() 

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/db/DBAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/db/DBAppender.java
@@ -36,7 +36,6 @@ import ch.qos.logback.core.db.DBAppenderBase;
 public class DBAppender extends DBAppenderBase<IAccessEvent> {
     protected static final String insertSQL;
     protected final String insertHeaderSQL = "INSERT INTO  access_event_header (event_id, header_key, header_value) VALUES (?, ?, ?)";
-    protected static final Method GET_GENERATED_KEYS_METHOD;
 
     private boolean insertHeaders = false;
 
@@ -55,14 +54,6 @@ public class DBAppender extends DBAppenderBase<IAccessEvent> {
         sql.append("postContent) ");
         sql.append(" VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?, ?)");
         insertSQL = sql.toString();
-
-        Method getGeneratedKeysMethod;
-        try {
-            getGeneratedKeysMethod = PreparedStatement.class.getMethod("getGeneratedKeys", (Class[]) null);
-        } catch (Exception ex) {
-            getGeneratedKeysMethod = null;
-        }
-        GET_GENERATED_KEYS_METHOD = getGeneratedKeysMethod;
     }
 
     @Override
@@ -122,11 +113,6 @@ public class DBAppender extends DBAppenderBase<IAccessEvent> {
 
             insertHeaderStatement.close();
         }
-    }
-
-    @Override
-    protected Method getGeneratedKeysMethod() {
-        return GET_GENERATED_KEYS_METHOD;
     }
 
     @Override

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
@@ -44,7 +44,6 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     protected String insertPropertiesSQL;
     protected String insertExceptionSQL;
     protected String insertSQL;
-    protected static final Method GET_GENERATED_KEYS_METHOD;
 
     private DBNameResolver dbNameResolver;
 
@@ -65,18 +64,6 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
     static final int EVENT_ID_INDEX = 15;
 
     static final StackTraceElement EMPTY_CALLER_DATA = CallerData.naInstance();
-
-    static {
-        // PreparedStatement.getGeneratedKeys() method was added in JDK 1.4
-        Method getGeneratedKeysMethod;
-        try {
-            // the
-            getGeneratedKeysMethod = PreparedStatement.class.getMethod("getGeneratedKeys", (Class[]) null);
-        } catch (Exception ex) {
-            getGeneratedKeysMethod = null;
-        }
-        GET_GENERATED_KEYS_METHOD = getGeneratedKeysMethod;
-    }
 
     public void setDbNameResolver(DBNameResolver dbNameResolver) {
         this.dbNameResolver = dbNameResolver;
@@ -191,11 +178,6 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
         }
 
         return mergedMap;
-    }
-
-    @Override
-    protected Method getGeneratedKeysMethod() {
-        return GET_GENERATED_KEYS_METHOD;
     }
 
     @Override


### PR DESCRIPTION
PreparedStatement.getGeneratedKeys()  was added in JDK 1.4
logback require java 1.6