### PR TITLE
LOGBACK-1175-fix-filename-pattern-regex

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileNamePattern.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileNamePattern.java
@@ -171,7 +171,7 @@ public class FileNamePattern extends ContextAwareBase {
             if (p instanceof LiteralConverter) {
                 buf.append(p.convert(null));
             } else if (p instanceof IntegerTokenConverter) {
-                buf.append("(\\d{1,3})");
+                buf.append("(\\d+)");
             } else if (p instanceof DateTokenConverter) {
                 buf.append(p.convert(date));
             }
@@ -190,7 +190,7 @@ public class FileNamePattern extends ContextAwareBase {
             if (p instanceof LiteralConverter) {
                 buf.append(p.convert(null));
             } else if (p instanceof IntegerTokenConverter) {
-                buf.append("\\d{1,2}");
+                buf.append("\\d+");
             } else if (p instanceof DateTokenConverter) {
                 DateTokenConverter<Object> dtc = (DateTokenConverter<Object>) p;
                 buf.append(dtc.toRegex());

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/FileNamePatternTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/FileNamePatternTest.java
@@ -145,12 +145,12 @@ public class FileNamePatternTest {
         {
             FileNamePattern fnp = new FileNamePattern("foo-%d{yyyy.MM.dd}-%i.txt", context);
             String regex = fnp.toRegexForFixedDate(cal.getTime());
-            assertEquals("foo-2003.05.20-(\\d{1,3}).txt", regex);
+            assertEquals("foo-2003.05.20-(\\d+).txt", regex);
         }
         {
             FileNamePattern fnp = new FileNamePattern("\\toto\\foo-%d{yyyy\\MM\\dd}-%i.txt", context);
             String regex = fnp.toRegexForFixedDate(cal.getTime());
-            assertEquals("/toto/foo-2003/05/20-(\\d{1,3}).txt", regex);
+            assertEquals("/toto/foo-2003/05/20-(\\d+).txt", regex);
         }
     }
 
@@ -159,12 +159,12 @@ public class FileNamePatternTest {
         {
             FileNamePattern fnp = new FileNamePattern("foo-%d{yyyy.MM.dd}-%i.txt", context);
             String regex = fnp.toRegex();
-            assertEquals("foo-\\d{4}\\.\\d{2}\\.\\d{2}-\\d{1,2}.txt", regex);
+            assertEquals("foo-\\d{4}\\.\\d{2}\\.\\d{2}-\\d+.txt", regex);
         }
         {
             FileNamePattern fnp = new FileNamePattern("foo-%d{yyyy.MM.dd'T'}-%i.txt", context);
             String regex = fnp.toRegex();
-            assertEquals("foo-\\d{4}\\.\\d{2}\\.\\d{2}T-\\d{1,2}.txt", regex);
+            assertEquals("foo-\\d{4}\\.\\d{2}\\.\\d{2}T-\\d+.txt", regex);
         }
     }
 


### PR DESCRIPTION
Unit tests
Removing index limit for filename pattern regex.

There's 3 tests failing on master:
RollingCalendarTest.testCollisionFreenes:148->checkCollisionFreeness:158
RollingCalendarTest.testPeriodicity:63 expected:<TOP_OF_WEEK> but was:<TOP_OF_MONTH>
TimeBasedRollingWithArchiveRemoval_Test.checkThatSmallTotalSizeCapLeavesAtLeastOneArhcive:191->checkFileCount:484 expected:<1> but was:<0>

The first 2 are related to PeridiocityType TOP_OF_WEEK
