### PR TITLE
Allow reporting of logging loss in AsyncAppenderBase

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -148,7 +148,7 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
         put(eventObject);
     }
 
-    private boolean isQueueBelowDiscardingThreshold() {
+    public boolean isQueueBelowDiscardingThreshold() {
         return (blockingQueue.remainingCapacity() < discardingThreshold);
     }
 


### PR DESCRIPTION
Made `AsyncAppenderBase.isQueueBelowDiscardingThreshold` public to facilitate reporting loss of log events in a health check.

For example, with this change one could now call `isQueueBelowDiscardingThreshold` from a dropwizard metrics health-check.
