### PR TITLE
LOGBACK-1173 Remove key on stop() in FileAppender

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -132,6 +132,14 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
             super.start();
         }
     }
+    
+    @Override
+    public void stop() {
+        @SuppressWarnings("unchecked")
+        Map<String, String> map = (Map<String, String>) context.getObject(CoreConstants.FA_FILENAME_COLLISION_MAP);
+        map.remove(getName());
+        super.stop();
+    }
 
     protected boolean checkForFileCollisionInPreviousFileAppenders() {
         boolean collisionsDetected = false;

--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -136,7 +136,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
     @Override
     public void stop() {
         @SuppressWarnings("unchecked")
-        Map<String, String> map = (Map<String, String>) context.getObject(CoreConstants.FA_FILENAME_COLLISION_MAP);
+        Map<String, String> map = (Map<String, String>) context.getObject(CoreConstants.RFA_FILENAME_PATTERN_COLLISION_MAP);
         map.remove(getName());
         super.stop();
     }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
@@ -149,6 +149,9 @@ public class RollingFileAppender<E> extends FileAppender<E> {
             rollingPolicy.stop();
         if (triggeringPolicy != null)
             triggeringPolicy.stop();
+        @SuppressWarnings("unchecked")
+        Map<String, String> map = (Map<String, String>) context.getObject(CoreConstants.FA_FILENAME_COLLISION_MAP);
+        map.remove(getName());
         super.stop();
     }
 


### PR DESCRIPTION
Initially I didn't recognize that separate maps were being updated in FileAppender and RollingFileAppender.  744c6e1 corrects that.
