### PR TITLE
LOGBACK-783 - add bzip2 support

### DIFF
--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -40,6 +40,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingPolicyBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingPolicyBase.java
@@ -21,7 +21,7 @@ import ch.qos.logback.core.spi.ContextAwareBase;
 /**
  * Implements methods common to most, it not all, rolling policies. Currently
  * such methods are limited to a compression mode getter/setter.
- * 
+ *
  * @author Ceki G&uuml;lc&uuml;
  */
 public abstract class RollingPolicyBase extends ContextAwareBase implements RollingPolicy {
@@ -42,7 +42,7 @@ public abstract class RollingPolicyBase extends ContextAwareBase implements Roll
      * mode depending on last letters of the fileNamePatternStr. Patterns ending
      * with .gz imply GZIP compression, endings with '.zip' imply ZIP compression.
      * Otherwise and by default, there is no compression.
-     * 
+     *
      */
     protected void determineCompressionMode() {
         if (fileNamePatternStr.endsWith(".gz")) {
@@ -51,6 +51,9 @@ public abstract class RollingPolicyBase extends ContextAwareBase implements Roll
         } else if (fileNamePatternStr.endsWith(".zip")) {
             addInfo("Will use zip compression");
             compressionMode = CompressionMode.ZIP;
+        } else if (fileNamePatternStr.endsWith(".bz2")) {
+            addInfo("Will use bzip2 compression");
+            compressionMode = CompressionMode.BZIP2;
         } else {
             addInfo("No compression will be used");
             compressionMode = CompressionMode.NONE;

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/CompressionMode.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/CompressionMode.java
@@ -14,5 +14,5 @@
 package ch.qos.logback.core.rolling.helper;
 
 public enum CompressionMode {
-    NONE, GZ, ZIP;
+    NONE, GZ, ZIP, BZIP2;
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/testUtil/FileToBufferUtil.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/testUtil/FileToBufferUtil.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
 public class FileToBufferUtil {
 
@@ -33,6 +34,8 @@ public class FileToBufferUtil {
             gzFileReadIntoList(file, stringList);
         } else if (file.getName().endsWith(".zip")) {
             zipFileReadIntoList(file, stringList);
+        } else if (file.getName().endsWith(".bzip2")) {
+            bzip2FileReadIntoList(file, stringList);
         } else {
             regularReadIntoList(file, stringList);
         }
@@ -69,6 +72,12 @@ public class FileToBufferUtil {
         FileInputStream fis = new FileInputStream(file);
         GZIPInputStream gzis = new GZIPInputStream(fis);
         readInputStream(gzis, stringList);
+    }
+
+    static public void bzip2FileReadIntoList(File file, List<String> stringList) throws IOException {
+        FileInputStream fis = new FileInputStream(file);
+        BZip2CompressorInputStream bz2is = new BZip2CompressorInputStream(fis);
+        readInputStream(bz2is, stringList);
     }
 
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/util/Compare.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/util/Compare.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipInputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
 public class Compare {
     static final int B1_NULL = -1;
@@ -32,6 +33,8 @@ public class Compare {
             return gzFileCompare(file1, file2);
         } else if (file1.endsWith(".zip")) {
             return zipFileCompare(file1, file2);
+        } else if (file1.endsWith(".bzip2")) {
+            return bzip2FileCompare(file1, file2);
         } else {
             return regularFileCompare(file1, file2);
         }
@@ -43,11 +46,23 @@ public class Compare {
         return new BufferedReader(new InputStreamReader(gzis));
     }
 
+    static BufferedReader bzip2FileToBufferedReader(String file) throws IOException {
+        FileInputStream fis = new FileInputStream(file);
+        BZip2CompressorInputStream bz2is = new BZip2CompressorInputStream(fis);
+        return new BufferedReader(new InputStreamReader(bz2is));
+    }
+
     static BufferedReader zipFileToBufferedReader(String file) throws IOException {
         FileInputStream fis = new FileInputStream(file);
         ZipInputStream zis = new ZipInputStream(fis);
         zis.getNextEntry();
         return new BufferedReader(new InputStreamReader(zis));
+    }
+
+    public static boolean bzip2FileCompare(String file1, String file2) throws IOException {
+        BufferedReader in1 = bzip2FileToBufferedReader(file1);
+        BufferedReader in2 = bzip2FileToBufferedReader(file2);
+        return bufferCompare(in1, in2, file1, file2);
     }
 
     public static boolean gzFileCompare(String file1, String file2) throws IOException {
@@ -102,9 +117,9 @@ public class Compare {
     }
 
     /**
-     * 
+     *
      * Prints file on the console.
-     * 
+     *
      */
     private static void outputFile(String file) throws FileNotFoundException, IOException {
         BufferedReader in1 = null;

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <junit.version>4.10</junit.version>
     <javax.mail.version>1.4</javax.mail.version>
     <janino.version>2.7.8</janino.version>
+    <compress.version>1.12</compress.version>
     <groovy.version>2.4.0</groovy.version>
     <!-- slf4j.version property is used below, in
          logback-classic/pom.xml and in setClasspath.cmd 
@@ -144,6 +145,11 @@
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>
         <version>${jansi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${compress.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>


### PR DESCRIPTION
Since the operations guys around me prefer to have bzip2 in use for archived / compressed logs, I thought my logging framework should support this. So I wanted to support the [discussion](http://jira.qos.ch/browse/LOGBACK-783) with a small pull request:
Logfile rotation patterns ending with bz2 will result in rotated log files compressed with bzip2.