### PR TITLE
LOGBACK-783 - add bzip2 support

### DIFF
--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -40,6 +40,12 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingPolicyBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingPolicyBase.java
@@ -21,7 +21,7 @@ import ch.qos.logback.core.spi.ContextAwareBase;
 /**
  * Implements methods common to most, it not all, rolling policies. Currently
  * such methods are limited to a compression mode getter/setter.
- * 
+ *
  * @author Ceki G&uuml;lc&uuml;
  */
 public abstract class RollingPolicyBase extends ContextAwareBase implements RollingPolicy {
@@ -42,7 +42,7 @@ public abstract class RollingPolicyBase extends ContextAwareBase implements Roll
      * mode depending on last letters of the fileNamePatternStr. Patterns ending
      * with .gz imply GZIP compression, endings with '.zip' imply ZIP compression.
      * Otherwise and by default, there is no compression.
-     * 
+     *
      */
     protected void determineCompressionMode() {
         if (fileNamePatternStr.endsWith(".gz")) {
@@ -51,6 +51,9 @@ public abstract class RollingPolicyBase extends ContextAwareBase implements Roll
         } else if (fileNamePatternStr.endsWith(".zip")) {
             addInfo("Will use zip compression");
             compressionMode = CompressionMode.ZIP;
+        } else if (fileNamePatternStr.endsWith(".bz2")) {
+            addInfo("Will use bzip2 compression");
+            compressionMode = CompressionMode.BZIP2;
         } else {
             addInfo("No compression will be used");
             compressionMode = CompressionMode.NONE;

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/CompressionMode.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/CompressionMode.java
@@ -14,5 +14,5 @@
 package ch.qos.logback.core.rolling.helper;
 
 public enum CompressionMode {
-    NONE, GZ, ZIP;
+    NONE, GZ, ZIP, BZIP2;
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 
 import ch.qos.logback.core.rolling.RolloverFailure;
 import ch.qos.logback.core.spi.ContextAwareBase;
@@ -49,7 +50,7 @@ public class Compressor extends ContextAwareBase {
     /**
      * @param nameOfFile2Compress
      * @param nameOfCompressedFile
-     * @param innerEntryName 
+     * @param innerEntryName
      *            The name of the file within the zip file. Use for ZIP compression.
      */
     public void compress(String nameOfFile2Compress, String nameOfCompressedFile, String innerEntryName) {
@@ -60,8 +61,75 @@ public class Compressor extends ContextAwareBase {
         case ZIP:
             zipCompress(nameOfFile2Compress, nameOfCompressedFile, innerEntryName);
             break;
+        case BZIP2:
+            bzip2Compress(nameOfFile2Compress, nameOfCompressedFile);
+            break;
         case NONE:
             throw new UnsupportedOperationException("compress method called in NONE compression mode");
+        }
+    }
+
+    private void bzip2Compress(String nameOfFile2bz2, String nameOfbz2edFile) {
+        File file2bz2 = new File(nameOfFile2bz2);
+
+        if (!file2bz2.exists()) {
+            addStatus(new WarnStatus("The file to compress named [" + nameOfFile2bz2 + "] does not exist.", this));
+
+            return;
+        }
+
+        if (!nameOfbz2edFile.endsWith(".bz2")) {
+            nameOfbz2edFile = nameOfbz2edFile + ".bz2";
+        }
+
+        File bz2edFile = new File(nameOfbz2edFile);
+
+        if (bz2edFile.exists()) {
+            addWarn("The target compressed file named [" + nameOfbz2edFile + "] exist already. Aborting file compression.");
+            return;
+        }
+
+        addInfo("BZIP2 compressing [" + file2bz2 + "] as [" + bz2edFile + "]");
+        createMissingTargetDirsIfNecessary(bz2edFile);
+
+        BufferedInputStream bis = null;
+
+        BZip2CompressorOutputStream bz2os = null;
+        try {
+            bis = new BufferedInputStream(new FileInputStream(nameOfFile2bz2));
+            bz2os = new BZip2CompressorOutputStream(new FileOutputStream(nameOfbz2edFile));
+            byte[] inbuf = new byte[BUFFER_SIZE];
+            int n;
+
+            while ((n = bis.read(inbuf)) != -1) {
+                bz2os.write(inbuf, 0, n);
+            }
+
+            bis.close();
+            bis = null;
+            bz2os.close();
+            bz2os = null;
+
+            if (!file2bz2.delete()) {
+                addStatus(new WarnStatus("Could not delete [" + nameOfFile2bz2 + "].", this));
+            }
+        } catch (Exception e) {
+            addStatus(new ErrorStatus("Error occurred while compressing [" + nameOfFile2bz2 + "] into [" + nameOfbz2edFile + "].", this, e));
+        } finally {
+            if (bis != null) {
+                try {
+                    bis.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            if (bz2os != null) {
+                try {
+                    bz2os.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
         }
     }
 
@@ -239,6 +307,11 @@ public class Compressor extends ContextAwareBase {
                 return fileNamePatternStr.substring(0, len - 4);
             else
                 return fileNamePatternStr;
+        case BZIP2:
+            if (fileNamePatternStr.endsWith(".bz2"))
+                return fileNamePatternStr.substring(0, len - 4);
+            else
+                return fileNamePatternStr;
         case NONE:
             return fileNamePatternStr;
         }
@@ -251,13 +324,13 @@ public class Compressor extends ContextAwareBase {
             addError("Failed to create parent directories for [" + file.getAbsolutePath() + "]");
         }
     }
-    
+
     @Override
     public String toString() {
         return this.getClass().getName();
     }
 
-    
+
     public Future<?> asyncCompress(String nameOfFile2Compress, String nameOfCompressedFile, String innerEntryName) throws RolloverFailure {
         CompressionRunnable runnable = new CompressionRunnable(nameOfFile2Compress, nameOfCompressedFile, innerEntryName);
         ExecutorService executorService = context.getExecutorService();
@@ -282,5 +355,5 @@ public class Compressor extends ContextAwareBase {
         }
     }
 
-  
+
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/testUtil/FileToBufferUtil.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/testUtil/FileToBufferUtil.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
 public class FileToBufferUtil {
 
@@ -33,6 +34,8 @@ public class FileToBufferUtil {
             gzFileReadIntoList(file, stringList);
         } else if (file.getName().endsWith(".zip")) {
             zipFileReadIntoList(file, stringList);
+        } else if (file.getName().endsWith(".bzip2")) {
+            bzip2FileReadIntoList(file, stringList);
         } else {
             regularReadIntoList(file, stringList);
         }
@@ -69,6 +72,12 @@ public class FileToBufferUtil {
         FileInputStream fis = new FileInputStream(file);
         GZIPInputStream gzis = new GZIPInputStream(fis);
         readInputStream(gzis, stringList);
+    }
+
+    static public void bzip2FileReadIntoList(File file, List<String> stringList) throws IOException {
+        FileInputStream fis = new FileInputStream(file);
+        BZip2CompressorInputStream bz2is = new BZip2CompressorInputStream(fis);
+        readInputStream(bz2is, stringList);
     }
 
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/util/Compare.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/util/Compare.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipInputStream;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
 public class Compare {
     static final int B1_NULL = -1;
@@ -32,6 +33,8 @@ public class Compare {
             return gzFileCompare(file1, file2);
         } else if (file1.endsWith(".zip")) {
             return zipFileCompare(file1, file2);
+        } else if (file1.endsWith(".bzip2")) {
+            return bzip2FileCompare(file1, file2);
         } else {
             return regularFileCompare(file1, file2);
         }
@@ -43,11 +46,23 @@ public class Compare {
         return new BufferedReader(new InputStreamReader(gzis));
     }
 
+    static BufferedReader bzip2FileToBufferedReader(String file) throws IOException {
+        FileInputStream fis = new FileInputStream(file);
+        BZip2CompressorInputStream bz2is = new BZip2CompressorInputStream(fis);
+        return new BufferedReader(new InputStreamReader(bz2is));
+    }
+
     static BufferedReader zipFileToBufferedReader(String file) throws IOException {
         FileInputStream fis = new FileInputStream(file);
         ZipInputStream zis = new ZipInputStream(fis);
         zis.getNextEntry();
         return new BufferedReader(new InputStreamReader(zis));
+    }
+
+    public static boolean bzip2FileCompare(String file1, String file2) throws IOException {
+        BufferedReader in1 = bzip2FileToBufferedReader(file1);
+        BufferedReader in2 = bzip2FileToBufferedReader(file2);
+        return bufferCompare(in1, in2, file1, file2);
     }
 
     public static boolean gzFileCompare(String file1, String file2) throws IOException {
@@ -102,9 +117,9 @@ public class Compare {
     }
 
     /**
-     * 
+     *
      * Prints file on the console.
-     * 
+     *
      */
     private static void outputFile(String file) throws FileNotFoundException, IOException {
         BufferedReader in1 = null;

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <junit.version>4.10</junit.version>
     <javax.mail.version>1.4</javax.mail.version>
     <janino.version>2.7.8</janino.version>
+    <compress.version>1.12</compress.version>
     <groovy.version>2.4.0</groovy.version>
     <!-- slf4j.version property is used below, in
          logback-classic/pom.xml and in setClasspath.cmd 
@@ -144,6 +145,11 @@
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>
         <version>${jansi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${compress.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>


### PR DESCRIPTION
Since the operations guys around me prefer to have bzip2 in use for archived / compressed logs, I thought my logging framework should support this. So I wanted to support the [discussion](http://jira.qos.ch/browse/LOGBACK-783) with a small pull request:
Logfile rotation patterns ending with bz2 will result in rotated log files compressed with bzip2.