### PR TITLE
Adds a getSingleton method expected by SLF4J

### DIFF
--- a/logback-classic/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/logback-classic/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -32,6 +32,11 @@ public class StaticMDCBinder {
     private StaticMDCBinder() {
     }
 
+    
+    public static StaticMDCBinder getSingleton() {
+        return SINGLETON;
+    }
+    
     /**
      * Currently this method always returns an instance of 
      * {@link StaticMDCBinder}.


### PR DESCRIPTION
SLF4J introduced the change in 1.7.14, see https://github.com/qos-ch/slf4j/blob/v_1.7.21/slf4j-api/src/main/java/org/slf4j/MDC.java#L88-L104
The `StaticLoggerBinder` is up to date but not `StaticMDCBinder`