### PR TITLE
LOGBACK-1217:SizeAndTimeBasedRollingPolicy not deleting files with 4 …

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileNamePattern.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileNamePattern.java
@@ -171,7 +171,7 @@ public class FileNamePattern extends ContextAwareBase {
             if (p instanceof LiteralConverter) {
                 buf.append(p.convert(null));
             } else if (p instanceof IntegerTokenConverter) {
-                buf.append("(\\d{1,3})");
+                buf.append("(\\d{1,5})");
             } else if (p instanceof DateTokenConverter) {
                 buf.append(p.convert(date));
             }

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/FileNamePatternTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/FileNamePatternTest.java
@@ -145,12 +145,12 @@ public class FileNamePatternTest {
         {
             FileNamePattern fnp = new FileNamePattern("foo-%d{yyyy.MM.dd}-%i.txt", context);
             String regex = fnp.toRegexForFixedDate(cal.getTime());
-            assertEquals("foo-2003.05.20-(\\d{1,3}).txt", regex);
+            assertEquals("foo-2003.05.20-(\\d{1,5}).txt", regex);
         }
         {
             FileNamePattern fnp = new FileNamePattern("\\toto\\foo-%d{yyyy\\MM\\dd}-%i.txt", context);
             String regex = fnp.toRegexForFixedDate(cal.getTime());
-            assertEquals("/toto/foo-2003/05/20-(\\d{1,3}).txt", regex);
+            assertEquals("/toto/foo-2003/05/20-(\\d{1,5}).txt", regex);
         }
     }
 


### PR DESCRIPTION
…digit "%i"

With this fix, SizeAndTimeBasedRollingPolicy will delete if the file
name has extension from 1 digit till 5 digits.