### PR TITLE
Add MDC support to logback-access (LOGBACK-1016)

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -28,6 +28,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-catalina</artifactId>
       <scope>compile</scope>

--- a/logback-access/src/main/java/ch/qos/logback/access/PatternLayout.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/PatternLayout.java
@@ -44,6 +44,7 @@ import ch.qos.logback.access.pattern.SessionIDConverter;
 import ch.qos.logback.access.pattern.StatusCodeConverter;
 import ch.qos.logback.access.pattern.ThreadNameConverter;
 import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.pattern.MDCConverter;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.pattern.color.*;
 import ch.qos.logback.core.pattern.parser.Parser;
@@ -158,6 +159,9 @@ public class PatternLayout extends PatternLayoutBase<IAccessEvent> {
         defaultConverterMap.put("T", ElapsedSecondsConverter.class.getName());
         
         defaultConverterMap.put("n", LineSeparatorConverter.class.getName());
+
+        defaultConverterMap.put("X", MDCConverter.class.getName());
+        defaultConverterMap.put("mdc", MDCConverter.class.getName());
 
         defaultConverterMap.put("black", BlackCompositeConverter.class.getName());
         defaultConverterMap.put("red", RedCompositeConverter.class.getName());

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -17,6 +17,7 @@ import ch.qos.logback.access.AccessConstants;
 import ch.qos.logback.access.pattern.AccessConverter;
 import ch.qos.logback.access.servlet.Util;
 
+import ch.qos.logback.core.util.LogbackMDCAdapter;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,12 +25,16 @@ import javax.servlet.http.HttpSession;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.Vector;
+
+import org.slf4j.MDC;
+import org.slf4j.spi.MDCAdapter;
 
 // Contributors:  Joern Huxhorn (see also bug #110)
 
@@ -70,6 +75,8 @@ public class AccessEvent implements Serializable, IAccessEvent {
     Map<String, String[]> requestParameterMap;
     Map<String, String> responseHeaderMap;
     Map<String, Object> attributeMap;
+
+    private Map<String, String> mdcPropertyMap;
 
     long contentLength = SENTINEL;
     int statusCode = SENTINEL;
@@ -573,6 +580,24 @@ public class AccessEvent implements Serializable, IAccessEvent {
         return new ArrayList<String>(responseHeaderMap.keySet());
     }
 
+    public Map<String, String> getMDCPropertyMap() {
+        // populate mdcPropertyMap if null
+        if (mdcPropertyMap == null) {
+            MDCAdapter mdc = MDC.getMDCAdapter();
+            if (mdc instanceof LogbackMDCAdapter) {
+                mdcPropertyMap = ((LogbackMDCAdapter) mdc).getPropertyMap();
+            } else {
+                mdcPropertyMap = mdc.getCopyOfContextMap();
+            }
+        }
+        // mdcPropertyMap still null, use emptyMap()
+        if (mdcPropertyMap == null) {
+            mdcPropertyMap = Collections.emptyMap();
+        }
+
+        return mdcPropertyMap;
+    }
+
     public void prepareForDeferredProcessing() {
         getRequestHeaderMap();
         getRequestParameterMap();
@@ -593,6 +618,8 @@ public class AccessEvent implements Serializable, IAccessEvent {
         getContentLength();
         getRequestContent();
         getResponseContent();
+
+        getMDCPropertyMap();
 
         copyAttributeMap();
     }

--- a/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/IAccessEvent.java
@@ -15,6 +15,7 @@ package ch.qos.logback.access.spi;
 
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 
+import ch.qos.logback.core.spi.MDCAware;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Enumeration;
@@ -33,7 +34,7 @@ import java.util.Map;
  * @author S&eacute;bastien Pennec
  * @author J&ouml;rn Huxhorn
  */
-public interface IAccessEvent extends DeferredProcessingAware {
+public interface IAccessEvent extends DeferredProcessingAware, MDCAware {
 
     String NA = "-";
     int SENTINEL = -1;
@@ -91,9 +92,9 @@ public interface IAccessEvent extends DeferredProcessingAware {
 
     void setThreadName(String threadName);
     String getThreadName();
-    
+
     String getQueryString();
-    
+
     String getRemoteAddr();
 
     String getRequestHeader(String key);

--- a/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.pattern.*;
 import ch.qos.logback.classic.pattern.color.HighlightingCompositeConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.pattern.MDCConverter;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.pattern.color.*;
 import ch.qos.logback.core.pattern.parser.Parser;

--- a/logback-classic/src/main/java/ch/qos/logback/classic/html/HTMLLayout.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/html/HTMLLayout.java
@@ -16,9 +16,8 @@ package ch.qos.logback.classic.html;
 import java.util.Map;
 
 import ch.qos.logback.classic.PatternLayout;
-import ch.qos.logback.classic.pattern.MDCConverter;
+import ch.qos.logback.core.pattern.MDCConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.html.DefaultCssBuilder;
 import ch.qos.logback.core.helpers.Transform;
 import ch.qos.logback.core.html.HTMLLayoutBase;
 import ch.qos.logback.core.html.IThrowableRenderer;

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/ILoggingEvent.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/ILoggingEvent.java
@@ -19,15 +19,16 @@ import org.slf4j.Marker;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
+import ch.qos.logback.core.spi.MDCAware;
 
 /**
  * The central interface in logback-classic. In a nutshell, logback-classic is
  * nothing more than a processing chain built around this interface.
- * 
+ *
  * @author Ceki G&uuml;lc&uuml;
  * @since 0.9.16
  */
-public interface ILoggingEvent extends DeferredProcessingAware {
+public interface ILoggingEvent extends DeferredProcessingAware, MDCAware {
 
     String getThreadName();
 
@@ -48,9 +49,9 @@ public interface ILoggingEvent extends DeferredProcessingAware {
     /**
      * Return caller data associated with this event. Note that calling this event
      * may trigger the computation of caller data.
-     * 
+     *
      * @return the caller data associated with this event.
-     * 
+     *
      * @see #hasCallerData()
      */
     StackTraceElement[] getCallerData();
@@ -58,21 +59,16 @@ public interface ILoggingEvent extends DeferredProcessingAware {
     /**
      * If this event has caller data, then true is returned. Otherwise the
      * returned value is null.
-     * 
+     *
      * <p>Logback components wishing to use caller data if available without
      * causing it to be computed can invoke this method before invoking
      * {@link #getCallerData()}.
-     * 
+     *
      * @return whether this event has caller data
      */
     boolean hasCallerData();
 
     Marker getMarker();
-
-    /**
-     * Returns the MDC map. The returned value can be an empty map but not null.
-     */
-    Map<String, String> getMDCPropertyMap();
 
     /**
      * Synonym for [@link #getMDCPropertyMap}.

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
@@ -25,7 +25,7 @@ import org.slf4j.helpers.MessageFormatter;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.util.LogbackMDCAdapter;
+import ch.qos.logback.core.util.LogbackMDCAdapter;
 
 import org.slf4j.spi.MDCAdapter;
 

--- a/logback-classic/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/logback-classic/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -15,7 +15,7 @@ package org.slf4j.impl;
 
 import org.slf4j.spi.MDCAdapter;
 
-import ch.qos.logback.classic.util.LogbackMDCAdapter;
+import ch.qos.logback.core.util.LogbackMDCAdapter;
 
 /**
  * This implementation is bound to {@link LogbackMDCAdapter}.

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
@@ -32,6 +32,7 @@ import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.net.SyslogConstants;
 import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.core.pattern.FormatInfo;
+import ch.qos.logback.core.pattern.MDCConverter;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -71,7 +72,7 @@ public class ConverterTest {
             StringBuilder buf = new StringBuilder();
             converter.write(buf, le);
             // the number below should be the line number of the previous line
-            assertEquals("72", buf.toString());
+            assertEquals("73", buf.toString());
         }
     }
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/PackageTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/PackageTest.java
@@ -17,9 +17,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import ch.qos.logback.core.pattern.MDCConverterTest;
+
 @RunWith(Suite.class)
-@SuiteClasses({ ConverterTest.class, TargetLengthBasedClassNameAbbreviatorTest.class, MDCConverterTest.class, MarkerConverterTest.class,
-        ExtendedThrowableProxyConverterTest.class, ThrowableProxyConverterTest.class, RootCauseFirstThrowableProxyConverterTest.class })
+@SuiteClasses({ConverterTest.class, TargetLengthBasedClassNameAbbreviatorTest.class, MarkerConverterTest.class,
+               ExtendedThrowableProxyConverterTest.class, ThrowableProxyConverterTest.class, RootCauseFirstThrowableProxyConverterTest.class })
 public class PackageTest {
 
 }

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>joda-time</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/MDCConverter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/MDCConverter.java
@@ -11,15 +11,15 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.pattern;
-
-import ch.qos.logback.classic.spi.ILoggingEvent;
+package ch.qos.logback.core.pattern;
 
 import java.util.Map;
 
+import ch.qos.logback.core.spi.MDCAware;
+
 import static ch.qos.logback.core.util.OptionHelper.extractDefaultReplacement;
 
-public class MDCConverter extends ClassicConverter {
+public class MDCConverter extends DynamicConverter<MDCAware> {
 
     private String key;
     private String defaultValue = "";
@@ -41,7 +41,7 @@ public class MDCConverter extends ClassicConverter {
     }
 
     @Override
-    public String convert(ILoggingEvent event) {
+    public String convert(MDCAware event) {
         Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
 
         if (mdcPropertyMap == null) {

--- a/logback-core/src/main/java/ch/qos/logback/core/spi/MDCAware.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/spi/MDCAware.java
@@ -11,13 +11,14 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.util;
+package ch.qos.logback.core.spi;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import java.util.Map;
 
-@RunWith(Suite.class)
-@SuiteClasses({ ContextInitializerTest.class, ContextInitializerAutoConfigTest.class, LevelToSyslogSeverityTest.class })
-public class PackageTest {
+public interface MDCAware {
+
+    /**
+     * Returns the MDC map. The returned value can be an empty map but not null.
+     */
+    Map<String, String> getMDCPropertyMap();
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/util/LogbackMDCAdapter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/LogbackMDCAdapter.java
@@ -11,7 +11,7 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.util;
+package ch.qos.logback.core.util;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/logback-core/src/test/java/ch/qos/logback/core/pattern/MDCConverterTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/pattern/MDCConverterTest.java
@@ -11,68 +11,68 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.pattern;
+package ch.qos.logback.core.pattern;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import ch.qos.logback.core.testUtil.RandomUtil;
+import ch.qos.logback.core.spi.MDCAware;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.MDC;
-
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
-import ch.qos.logback.core.util.SystemInfo;
 
 public class MDCConverterTest {
-
-    LoggerContext lc;
     MDCConverter converter;
-    int diff = RandomUtil.getPositiveInt();
 
     @Before
     public void setUp() throws Exception {
-        lc = new LoggerContext();
         converter = new MDCConverter();
         converter.start();
-        MDC.clear();
     }
 
     @After
     public void tearDown() throws Exception {
-        lc = null;
         converter.stop();
         converter = null;
-        MDC.clear();
     }
 
     @Test
     public void testConvertWithOneEntry() {
-        String k = "MDCConverterTest_k" + diff;
-        String v = "MDCConverterTest_v" + diff;
+        String k = "MDCConverterTest_k";
+        String v = "MDCConverterTest_v";
 
-        MDC.put(k, v);
-        ILoggingEvent le = createLoggingEvent();
-        String result = converter.convert(le);
+        Event event = new Event();
+        event.putMDC(k, v);
+
+        String result = converter.convert(event);
         assertEquals(k + "=" + v, result);
     }
 
     @Test
     public void testConvertWithMultipleEntries() {
-        MDC.put("testKey", "testValue");
-        MDC.put("testKey2", "testValue2");
-        ILoggingEvent le = createLoggingEvent();
-        String result = converter.convert(le);
+        Event event = new Event();
+        event.putMDC("testKey", "testValue");
+        event.putMDC("testKey2", "testValue2");
+
+        String result = converter.convert(event);
         boolean isConform = result.matches("testKey2?=testValue2?, testKey2?=testValue2?");
         assertTrue(result + " is not conform", isConform);
     }
 
-    private ILoggingEvent createLoggingEvent() {
-        return new LoggingEvent(this.getClass().getName(), lc.getLogger(Logger.ROOT_LOGGER_NAME), Level.DEBUG, "test message", null, null);
+    private static class Event implements MDCAware {
+
+        private Map<String, String> mdc = new HashMap<String, String>();
+
+        public void putMDC(String key, String value) {
+            mdc.put(key, value);
+        }
+
+        @Override
+        public Map<String, String> getMDCPropertyMap() {
+            return mdc;
+        }
     }
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/pattern/PackageTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/pattern/PackageTest.java
@@ -18,6 +18,6 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ SpacePadderTest.class, ch.qos.logback.core.pattern.parser.PackageTest.class })
+@SuiteClasses({ SpacePadderTest.class, ch.qos.logback.core.pattern.parser.PackageTest.class, MDCConverterTest.class })
 public class PackageTest {
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/util/LogbackMDCAdapterTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/util/LogbackMDCAdapterTest.java
@@ -11,7 +11,7 @@
  * under the terms of the GNU Lesser General Public License version 2.1
  * as published by the Free Software Foundation.
  */
-package ch.qos.logback.classic.util;
+package ch.qos.logback.core.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/logback-core/src/test/java/ch/qos/logback/core/util/PackageTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/util/PackageTest.java
@@ -19,6 +19,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({ DurationTest.class, FileSizeTest.class, FileUtilTest.class, OptionHelperTest.class, StatusPrinterTest.class, TimeUtilTest.class,
-        ContentTypeUtilTest.class, CharSequenceToRegexMapperTest.class })
+        ContentTypeUtilTest.class, CharSequenceToRegexMapperTest.class, LogbackMDCAdapterTest.class  })
 public class PackageTest {
 }


### PR DESCRIPTION
- Add MDC support to AccessEvent (mirroring the code in LoggingEvent)
- Move LogbackMDCAdapter and MDCConverter to core so it can be shared by both
- Refactor MDCConverterTest to have fewer dependencies

This is the first time I've gone through the logback code, so please let me know if I didn't do something correctly or there is a better way to do something. Thanks!