### PR TITLE
AccessEvent should be processed eagerly (LOGBACK-1189)

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/net/SocketAppender.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/net/SocketAppender.java
@@ -37,10 +37,11 @@ public class SocketAppender extends AbstractSocketAppender<IAccessEvent> {
     public SocketAppender() {
     }
 
-    @Override
-    protected void postProcessEvent(IAccessEvent event) {
-        event.prepareForDeferredProcessing();
-    }
+	@Override
+	protected void append(IAccessEvent event) {
+		event.prepareForDeferredProcessing();
+		super.append(event);
+	}
 
     public PreSerializationTransformer<IAccessEvent> getPST() {
         return pst;


### PR DESCRIPTION
Dear all,

I think, #336(LOGBACK-1189) is timing issue due to [HTTP persistent connection](https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Keep-Alive). 

As mentioned about jetty by @markelliot , Tomcat also re-uses an request object in case of  HTTP persistent connection. So request objects are not immutable even after append(IAccessEvent event) method fired. Thus AccessEvent can not be processed lately.

Thank you!

