### PR TITLE
setting systemId on InputSource for external entities

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/GenericConfigurator.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/GenericConfigurator.java
@@ -50,7 +50,7 @@ public abstract class GenericConfigurator extends ContextAwareBase {
             urlConnection.setUseCaches(false);
 
             in = urlConnection.getInputStream();
-            doConfigure(in);
+            doConfigure(in, url.toExternalForm());
         } catch (IOException ioe) {
             String errMsg = "Could not open URL [" + url + "].";
             addError(errMsg, ioe);
@@ -75,9 +75,10 @@ public abstract class GenericConfigurator extends ContextAwareBase {
     public final void doConfigure(File file) throws JoranException {
         FileInputStream fis = null;
         try {
-            informContextOfURLUsedForConfiguration(getContext(), file.toURI().toURL());
+            URL url = file.toURI().toURL();
+            informContextOfURLUsedForConfiguration(getContext(), url);
             fis = new FileInputStream(file);
-            doConfigure(fis);
+            doConfigure(fis, url.toExternalForm());
         } catch (IOException ioe) {
             String errMsg = "Could not open [" + file.getPath() + "].";
             addError(errMsg, ioe);
@@ -101,6 +102,12 @@ public abstract class GenericConfigurator extends ContextAwareBase {
 
     public final void doConfigure(InputStream inputStream) throws JoranException {
         doConfigure(new InputSource(inputStream));
+    }
+
+    public final void doConfigure(InputStream inputStream, String systemId) throws JoranException {
+        InputSource inputSource = new InputSource(inputStream);
+        inputSource.setSystemId(systemId);
+        doConfigure(inputSource);
     }
 
     protected BeanDescriptionCache getBeanDescriptionCache() {


### PR DESCRIPTION
Fixes [LOGBACK-1091](http://jira.qos.ch/browse/LOGBACK-1091)
Enables Sax to resolve external entities urls relative to the document being parsed