### PR TITLE
closing DatagramSocket to ensure underlying FileDescriptor is closed …

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -72,6 +72,9 @@ public class SyslogOutputStream extends OutputStream {
     }
 
     public void close() {
+        if (ds != null) {
+            ds.close();
+        }
         address = null;
         ds = null;
     }


### PR DESCRIPTION
…immediately

fixes [LOGBACK-1019](http://jira.qos.ch/browse/LOGBACK-1019)