### PR TITLE
avoid caller file name being null (is marked 'not null' in database schema)

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/DBAppender.java
@@ -159,7 +159,7 @@ public class DBAppender extends DBAppenderBase<ILoggingEvent> {
 
         StackTraceElement caller = extractFirstCaller(callerDataArray);
 
-        stmt.setString(CALLER_FILENAME_INDEX, caller.getFileName());
+        stmt.setString(CALLER_FILENAME_INDEX, caller.getFileName() == null ? EMPTY_CALLER_DATA.getFileName() : caller.getFileName());
         stmt.setString(CALLER_CLASS_INDEX, caller.getClassName());
         stmt.setString(CALLER_METHOD_INDEX, caller.getMethodName());
         stmt.setString(CALLER_LINE_INDEX, Integer.toString(caller.getLineNumber()));


### PR DESCRIPTION
This is the case e.g. when a code obfusactor (such as proguard) removes the SourceFile attribute from the class file.
Fixes [LOGBACK-1095](http://jira.qos.ch/browse/LOGBACK-1095)