### PR TITLE
LOGBACK-1240 Log files aren't deleted on startup with hourly rotation

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
@@ -195,8 +195,7 @@ public class RollingCalendar extends GregorianCalendar {
         case TOP_OF_MINUTE:
             return diff / MILLIS_IN_ONE_MINUTE;
         case TOP_OF_HOUR:
-
-            return (int) diff / MILLIS_IN_ONE_HOUR;
+            return diff / MILLIS_IN_ONE_HOUR;
         case TOP_OF_DAY:
             return diff / MILLIS_IN_ONE_DAY;
         case TOP_OF_WEEK:

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/TimeBasedRollingWithArchiveRemoval_Test.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/TimeBasedRollingWithArchiveRemoval_Test.java
@@ -326,11 +326,11 @@ public class TimeBasedRollingWithArchiveRemoval_Test extends ScaffoldingForRolli
         checkDirPatternCompliance(maxHistory + 1);
     }
 
-    void logTwiceAndStop(long currentTime, String fileNamePattern, int maxHistory) {
+    void logTwiceAndStop(long currentTime, String fileNamePattern, int maxHistory, long timePeriod) {
         ConfigParameters params = new ConfigParameters(currentTime).fileNamePattern(fileNamePattern).maxHistory(maxHistory);
         buildRollingFileAppender(params, DO_CLEAN_HISTORY_ON_START);
         rfa.doAppend("Hello ----------------------------------------------------------" + new Date(currentTime));
-        currentTime += MILLIS_IN_DAY / 2;
+        currentTime += timePeriod / 2;
         add(tbrp.compressionFuture);
         add(tbrp.cleanUpFuture);
         waitForJobsToComplete();
@@ -340,14 +340,12 @@ public class TimeBasedRollingWithArchiveRemoval_Test extends ScaffoldingForRolli
     }
 
     @Test
-    public void cleanHistoryOnStart() {
+    public void cleanHistoryOnStartWithDayPattern() {
         long simulatedTime = WED_2016_03_23_T_230705_CET;
-        System.out.println(new Date(simulatedTime));
-
         String fileNamePattern = randomOutputDir + "clean-%d{" + DAILY_DATE_PATTERN + "}.txt";
         int maxHistory = 3;
         for (int i = 0; i <= 5; i++) {
-            logTwiceAndStop(simulatedTime, fileNamePattern, maxHistory);
+            logTwiceAndStop(simulatedTime, fileNamePattern, maxHistory, MILLIS_IN_DAY);
             simulatedTime += MILLIS_IN_DAY;
         }
         StatusPrinter.print(context);
@@ -355,13 +353,13 @@ public class TimeBasedRollingWithArchiveRemoval_Test extends ScaffoldingForRolli
     }
 
     @Test
-    public void cleanHistoryOnStartWithDayPattern() {
+    public void cleanHistoryOnStartWithHourDayPattern() {
         long simulatedTime = WED_2016_03_23_T_230705_CET;
-        String fileNamePattern = randomOutputDir + "clean-%d{yyyy-MM-dd}.txt";
+        String fileNamePattern = randomOutputDir + "clean-%d{yyyy-MM-dd-HH}.txt";
         int maxHistory = 3;
         for (int i = 0; i <= 5; i++) {
-            logTwiceAndStop(simulatedTime, fileNamePattern, maxHistory);
-            simulatedTime += MILLIS_IN_DAY;
+            logTwiceAndStop(simulatedTime, fileNamePattern, maxHistory, MILLIS_IN_HOUR);
+            simulatedTime += MILLIS_IN_HOUR;
         }
         StatusPrinter.print(context);
         checkFileCount(expectedCountWithoutFolders(maxHistory));
@@ -378,7 +376,7 @@ public class TimeBasedRollingWithArchiveRemoval_Test extends ScaffoldingForRolli
         String fileNamePattern = randomOutputDir + "clean-%d{HH}.txt";
         int maxHistory = 3;
         for (int i = 0; i <= 5; i++) {
-            logTwiceAndStop(now, fileNamePattern, maxHistory);
+            logTwiceAndStop(now, fileNamePattern, maxHistory, MILLIS_IN_DAY);
             now = now + MILLIS_IN_HOUR;
         }
         StatusPrinter.print(context);


### PR DESCRIPTION
Remove casting to int in calculation of periodBarriersCrossed in RollingCalendar and add a test. Casting caused the the value to become negative resulting in no archives being deleted.