### PR TITLE
Repair Profile Update Listening is invalid：Because the other jar cont…

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/util/ConfigurationWatchListUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/util/ConfigurationWatchListUtil.java
@@ -38,6 +38,11 @@ public class ConfigurationWatchListUtil {
         context.putObject(CoreConstants.CONFIGURATION_WATCH_LIST, cwl);
     }
     public static void setMainWatchURL(Context context, URL url) {
+        String protocol = url.getProtocol();
+        if (!"file".equals(protocol)) {
+            return ;
+        }
+
         ConfigurationWatchList cwl = getConfigurationWatchList(context);
         if (cwl == null) {
             cwl = new ConfigurationWatchList();


### PR DESCRIPTION
Repair Profile Update Listening is invalid：Because the  jar contains the ‘logback.xml’ .
code : 
ConfigurationWatchListUtil.setMainWatchURL  -- > cwl.clear();
ConfigurationWatchList.addAsFileToWatch --> convertToFile(url); 