### PR TITLE
Fix LOGBACK-1247.

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/AsyncAppenderBaseTest.java
@@ -232,8 +232,9 @@ public class AsyncAppenderBaseTest {
 
     // Interruption of current thread when in doAppend method should not be
     // consumed by async appender. See also http://jira.qos.ch/browse/LOGBACK-910
+    // and https://jira.qos.ch/browse/LOGBACK-1247
     @Test
-    public void verifyInterruptionIsNotSwallowed() {
+    public void verifyInterruptionIsNotSwallowedAndEventIsLogged() {
         asyncAppenderBase.addAppender(delayingListAppender);
         asyncAppenderBase.start();
         Thread.currentThread().interrupt();
@@ -241,6 +242,8 @@ public class AsyncAppenderBaseTest {
         assertTrue(Thread.currentThread().isInterrupted());
         // clear flag for next test
         Thread.interrupted();
+        asyncAppenderBase.stop();
+        verify(delayingListAppender, 1);
     }
 
     @Test


### PR DESCRIPTION
AsyncAppenderBase no longer drops events when the thread is interrupted.
Tested by changing the existing test for PULSE-910 to also verify that the event was logged.

I'm getting some test failures in DefaultSocketConnectorTest, but those happen both with and without my changes.