### PR TITLE
fix LOGBACK-1194: scanPeriod attribute required for auto-reload to work

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/ConfigurationAction.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/ConfigurationAction.java
@@ -38,6 +38,7 @@ public class ConfigurationAction extends Action {
     static final String PACKAGING_DATA_ATTR = "packagingData";
     static final String SCAN_ATTR = "scan";
     static final String SCAN_PERIOD_ATTR = "scanPeriod";
+    static final Duration SCAN_PERIOD_DEFAULT = Duration.buildByMinutes(1);
     static final String DEBUG_SYSTEM_PROPERTY_KEY = "logback.debug";
 
     long threshold = 0;
@@ -132,6 +133,8 @@ public class ConfigurationAction extends Action {
             } catch (NumberFormatException nfe) {
                 addError("Error while converting [" + scanAttrib + "] to long", nfe);
             }
+        } else {
+            duration = SCAN_PERIOD_DEFAULT;
         }
         return duration;
     }

--- a/logback-classic/src/test/input/joran/roct/scan_period_default.xml
+++ b/logback-classic/src/test/input/joran/roct/scan_period_default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration scan="true">
+
+  <root level="ERROR"/>    
+
+</configuration> 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/joran/ReconfigureOnChangeTaskTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/joran/ReconfigureOnChangeTaskTest.java
@@ -19,6 +19,7 @@ import static ch.qos.logback.classic.joran.ReconfigureOnChangeTask.FALLING_BACK_
 import static ch.qos.logback.classic.joran.ReconfigureOnChangeTask.RE_REGISTERING_PREVIOUS_SAFE_CONFIGURATION;
 import static ch.qos.logback.core.CoreConstants.RECONFIGURE_ON_CHANGE_TASK;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -75,6 +76,8 @@ public class ReconfigureOnChangeTaskTest {
     final static String INCLUSION_SCAN_INNER0_AS_STR = JORAN_INPUT_PREFIX + "roct/inclusion/inner0.xml";
 
     final static String INCLUSION_SCAN_INNER1_AS_STR = "target/test-classes/asResource/inner1.xml";
+
+    final static String SCAN_PERIOD_DEFAULT_FILE_AS_STR = JORAN_INPUT_PREFIX + "roct/scan_period_default.xml";
 
     LoggerContext loggerContext = new LoggerContext();
     Logger logger = loggerContext.getLogger(this.getClass());
@@ -353,6 +356,15 @@ public class ReconfigureOnChangeTaskTest {
 
     void addInfo(String msg, Object o) {
         loggerContext.getStatusManager().add(new InfoStatus(msg, o));
+    }
+
+    @Test
+    public void checkReconfigureTaskScheduledWhenDefaultScanPeriodUsed() throws JoranException {
+        File file = new File(SCAN_PERIOD_DEFAULT_FILE_AS_STR);
+        configure(file);
+
+        final List<ScheduledFuture<?>> scheduledFutures = loggerContext.getScheduledFutures();
+        assertFalse(scheduledFutures.isEmpty());
     }
 
     enum UpdateType {


### PR DESCRIPTION
Use a default scanning period of one minute if scan="true" but scanPeriod is not set.

I added a test that checks if there are any scheduled tasks in the context which seems to work fine. But it feels like a rather indirect way to test if the default is used.