### PR TITLE
[LOGBACK-1266] Upgrade Junit to 4.12 and adjustments required to make that happen

### DIFF
--- a/logback-classic/integration.xml
+++ b/logback-classic/integration.xml
@@ -18,6 +18,7 @@
 		<pathelement location="./target/classes/" />
 		<pathelement location="./target/test-classes/" />
 		<pathelement location="./lib/slf4j-api-${slf4j.version}.jar" />
+        <pathelement location="./lib/hamcrest-core-1.3.jar" />
     <pathelement location="./src/test/input/integration/autoInit/" />
 	</path >
 

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -179,7 +179,39 @@
     </resources>
 
     <plugins>
-     
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>${slf4j.version}</version>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.basedir}/lib</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.hamcrest</groupId>
+                  <artifactId>hamcrest-core</artifactId>
+                  <version>1.3</version>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.basedir}/lib</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.version>4.10</junit.version>
+    <junit.version>4.12</junit.version>
     <javax.mail.version>1.4</javax.mail.version>
     <janino.version>3.0.6</janino.version>
     <groovy.version>2.4.0</groovy.version>


### PR DESCRIPTION
- Junit upgraded to 4.12 from 4.10
- In dependency Management, exclude legacy hamcrest version so 1.3 persists for junit 4.12
- Logback classic integration.xml now will need hamcrest pulled in.  While slf4j auto does that in specific configuration, lean more on maven and have maven just copy slf4j and hamcrest to the lib directory.

Result, build is succesfully on 4.12 now and builds without issue even with ant integration.xml
