### PR TITLE
allowing for layout to be overridden

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogAppenderBase.java
@@ -259,7 +259,7 @@ public abstract class SyslogAppenderBase<E> extends AppenderBase<E> {
     }
 
     public void setLayout(Layout<E> layout) {
-        addWarn("The layout of a SyslogAppender cannot be set directly. See also " + SYSLOG_LAYOUT_URL);
+        this.layout = layout;
     }
 
     @Override


### PR DESCRIPTION
I'm trying to change the behaviour of the SyslogAppender. One of the things I'd like is short hostnames and I’m not the only one: 
http://logback.10977.n7.nabble.com/Syslog-Appender-Short-Host-Name-td1102.html
https://github.com/qos-ch/logback/pull/139/files
https://jira.qos.ch/browse/LOGBACK-1011 
This change allows me to override the layout without affecting current functionality, so current user should not be impacted. 