### PR TITLE
test: add test on equals of FileNamePattern against null value

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/FileNamePatternTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/FileNamePatternTest.java
@@ -16,6 +16,7 @@ package ch.qos.logback.core.rolling.helper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -189,4 +190,11 @@ public class FileNamePatternTest {
         FileNamePattern fnp = new FileNamePattern("%d{hh, " + tz.getID() + "}", context);
         assertEquals(tz, fnp.getPrimaryDateTokenConverter().getTimeZone());
     }
+
+    @Test
+    public void testNotEqualsNull() {
+        FileNamePattern pp = new FileNamePattern("t", context);
+        assertFalse(pp.equals(null));
+    }
+
 }


### PR DESCRIPTION
Hello,

I propose this changes to specify the [equals()](https://github.com/qos-ch/logback/blob/master/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileNamePattern.java#L96) method of `ch.qos.logback.core.rolling.helper.FileNamePattern` against null value 