### PR TITLE
Fixed typo within constant about incorrect attribute for parameters

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/ParamAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/ParamAction.java
@@ -21,7 +21,7 @@ import ch.qos.logback.core.joran.util.beans.BeanDescriptionCache;
 
 public class ParamAction extends Action {
     static String NO_NAME = "No name attribute in <param> element";
-    static String NO_VALUE = "No name attribute in <param> element";
+    static String NO_VALUE = "No value attribute in <param> element";
     boolean inError = false;
 
 	private final BeanDescriptionCache beanDescriptionCache;


### PR DESCRIPTION
Constant referenced incorrect attribute name in the event that a parameter action was misconfigured as the constant for the attribute in question is actually **value**.