### PR TITLE
Remove disturbing println

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -280,7 +280,6 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
     class Worker extends Thread {
 
         public void run() {
-            System.out.println("Worker started");
             AsyncAppenderBase<E> parent = AsyncAppenderBase.this;
             AppenderAttachableImpl<E> aai = parent.aai;
 


### PR DESCRIPTION
This pull request remove disturbing `System.out.println` when AsyncAppender is used.

Signed-off-by: Thibault Meyer <meyer.thibault@gmail.com>