### PR TITLE
LOGBACK-1302: Throwable is trimmed twice which causes bad message

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
@@ -290,6 +290,12 @@ public class LoggingEvent implements ILoggingEvent {
             return formattedMessage;
         }
         if (argumentArray != null) {
+            if (throwableProxy != null && argumentArray.length > 0) {
+                Object possibleThrowable = argumentArray[argumentArray.length - 1];
+                if (possibleThrowable instanceof Throwable) {
+                    argumentArray[argumentArray.length - 1] = possibleThrowable.toString();
+                }
+            }
             formattedMessage = MessageFormatter.arrayFormat(message, argumentArray).getMessage();
         } else {
             formattedMessage = message;

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
@@ -96,6 +96,27 @@ public class LoggingEventTest {
         assertEquals("42-description of exception", event.getFormattedMessage() );
     }
 
+    @Test
+    public void testFormattingWithThrowableAsOnlyFormattingArgument() {
+        String message = "{}";
+        Throwable throwable = null;
+        Throwable meaningfulException = new MeaningfulException("description of exception");
+        Object[] argArray = new Object[] { meaningfulException, meaningfulException };
+        LoggingEvent event = new LoggingEvent("", logger, Level.INFO, message, throwable, argArray);
+        assertNull(event.formattedMessage);
+        assertEquals("description of exception", event.getFormattedMessage() );
+    }
+
+    @Test
+    public void testFormattingWithThrowableAsOnlyArgument() {
+        String message = "testNoFormatting";
+        Throwable throwable = null;
+        Object[] argArray = new Object[] { new MeaningfulException("description of exception") };
+        LoggingEvent event = new LoggingEvent("", logger, Level.INFO, message, throwable, argArray);
+        assertNull(event.formattedMessage);
+        assertEquals("testNoFormatting", event.getFormattedMessage() );
+    }
+
     // Sample class with some more-or-less meaningful toString
     private static final class MeaningfulException extends RuntimeException {
         private MeaningfulException(String message) {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
@@ -72,4 +72,39 @@ public class LoggingEventTest {
         assertNull(event.formattedMessage);
         assertEquals(message, event.getFormattedMessage());
     }
+
+    @Test
+    public void testFormattingWithThrowableNotALastArgument() {
+        String message = "{}-{}";
+        Throwable throwable = null;
+        Throwable meaningfulException = new MeaningfulException("description of exception");
+        Object[] argArray = new Object[] { meaningfulException, 42, meaningfulException };
+        LoggingEvent event = new LoggingEvent("", logger, Level.INFO, message, throwable, argArray);
+        assertNull(event.formattedMessage);
+        assertEquals("description of exception-42", event.getFormattedMessage() );
+    }
+
+    @Test
+    // Seems strange while I've faced this use case in real codebase
+    public void testFormattingWithThrowableAsLastArgument() {
+        String message = "{}-{}";
+        Throwable throwable = null;
+        Throwable meaningfulException = new MeaningfulException("description of exception");
+        Object[] argArray = new Object[] { 42, meaningfulException, meaningfulException };
+        LoggingEvent event = new LoggingEvent("", logger, Level.INFO, message, throwable, argArray);
+        assertNull(event.formattedMessage);
+        assertEquals("42-description of exception", event.getFormattedMessage() );
+    }
+
+    // Sample class with some more-or-less meaningful toString
+    private static final class MeaningfulException extends RuntimeException {
+        private MeaningfulException(String message) {
+            super(message);
+        }
+
+        @Override
+        public String toString() {
+            return getLocalizedMessage();
+        }
+    }
 }


### PR DESCRIPTION
Closes https://jira.qos.ch/browse/LOGBACK-1302