### PR TITLE
LOGBACK-1317 Change the scope of the servlet-api from compile/optional to provided

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -128,8 +128,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.icegreen</groupId>


### PR DESCRIPTION
Hi,

The dependency for the Servlet API has the `compile` scope and is marked as optional. Usually in this situation the `provided` scope should be used because it's supposed to be provided by the servlet container.