### PR TITLE
LOGBACK-1326 Allow LayoutWrappingEncoder to have a parent of a type other than Appender

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
@@ -15,7 +15,6 @@ package ch.qos.logback.core.encoder;
 
 import java.nio.charset.Charset;
 
-import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.OutputStreamAppender;
@@ -33,8 +32,8 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
      */
     private Charset charset;
 
-    Appender<?> parent;
-    Boolean immediateFlush = null;
+    private Object parent;
+    private Boolean immediateFlush;
 
     public Layout<E> getLayout() {
         return layout;
@@ -52,7 +51,7 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
      * Set the charset to use when converting the string returned by the layout
      * into bytes.
      * <p/>
-     * By default this property has the value
+     * By default this propertyhas the value
      * <code>null</null> which corresponds to
      * the system's default charset.
      *
@@ -145,12 +144,11 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
     }
 
     /**
-     * This method allows RollingPolicy implementations to be aware of their
-     * containing appender.
+     * This method allows RollingPolicy implementations to be aware of their parent.
      * 
-     * @param appender
+     * @param parent
      */
-    public void setParent(Appender<?> parent) {
+    public void setParent(Object parent) {
         this.parent = parent;
     }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
@@ -18,6 +18,7 @@ import java.nio.charset.Charset;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.spi.ContextAware;
 
 public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
 
@@ -32,7 +33,7 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
      */
     private Charset charset;
 
-    private Object parent;
+    private ContextAware parent;
     private Boolean immediateFlush;
 
     public Layout<E> getLayout() {
@@ -148,7 +149,7 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
      * 
      * @param parent
      */
-    public void setParent(Object parent) {
+    public void setParent(ContextAware parent) {
         this.parent = parent;
     }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
@@ -52,7 +52,7 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
      * Set the charset to use when converting the string returned by the layout
      * into bytes.
      * <p/>
-     * By default this propertyhas the value
+     * By default this property has the value
      * <code>null</null> which corresponds to
      * the system's default charset.
      *


### PR DESCRIPTION
See [LOGBACK-1326](https://jira.qos.ch/browse/LOGBACK-1326)

This allows `LayoutWrappingEncoder` to be used within another `Encoder`.

The introduction of `setParent(Appender)` in logback 1.2.1 caused an issue in downstream projects
that allow a `LayoutWrappingEncoder` to be used within another `Encoder`.

Specifically: https://github.com/logstash/logstash-logback-encoder/issues/232