### PR TITLE
User correct file name when roll-over based on size

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -162,9 +162,18 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
             return false;
         }
         if (activeFile.length() >= maxFileSize.getSize()) {
-
             elapsedPeriodsFileName = tbrp.fileNamePatternWithoutCompSuffix.convertMultipleArguments(dateInCurrentPeriod, currentPeriodsCounter);
-            currentPeriodsCounter++;
+
+            // re-check for roll-over based on time, e.g. fileNamePattern is:
+            // %d{yyyyMMdd}/logback-%d{yyyyMMdd_HHmmss, aux}.txt
+            String newFileName = tbrp.fileNamePatternWithoutCompSuffix.convertMultipleArguments(new Date(time), currentPeriodsCounter);
+            if (elapsedPeriodsFileName.equals(newFileName)) {
+                currentPeriodsCounter++;
+            } else {
+                currentPeriodsCounter = 0;
+                setDateInCurrentPeriod(time);
+                computeNextCheck();
+            }
             return true;
         }
 


### PR DESCRIPTION
When I rolling by day,  and use fileNamePattern have small unit than day, e.g. fileNamePattern is:

%d{yyyyMMdd}/logback-%d{yyyyMMdd_HHmmss, aux}.txt

Then the time part in the file name is fixed:

logback-20170723_234823-0.txt
logback-20170723_234823-1.txt
logback-20170723_234823-2.txt
logback-20170723_234823-3.txt
logback-20170723_234823-4.txt
logback-20170723_234823-5.txt

This looks is ugly and  wrongly.