### PR TITLE
LOGBACK-1334 support conditional processing with JavaScript

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/ConfigurationAction.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/ConfigurationAction.java
@@ -25,6 +25,7 @@ import ch.qos.logback.classic.joran.ReconfigureOnChangeTask;
 import ch.qos.logback.classic.util.EnvUtil;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.joran.action.Action;
+import ch.qos.logback.core.joran.conditional.PropertyEvalJavaScriptBuilder;
 import ch.qos.logback.core.joran.spi.InterpretationContext;
 import ch.qos.logback.core.joran.util.ConfigurationWatchListUtil;
 import ch.qos.logback.core.status.OnConsoleStatusListener;
@@ -60,6 +61,14 @@ public class ConfigurationAction extends Action {
         }
 
         processScanAttrib(ic, attributes);
+        
+        String conditionalJs = ic.subst(attributes.getValue(PropertyEvalJavaScriptBuilder.CONDITIONAL_JS_ATTR));
+        if ("true".equalsIgnoreCase(conditionalJs)) {
+            ic.getObjectMap().put(PropertyEvalJavaScriptBuilder.CONDITIONAL_JS_ATTR, Boolean.TRUE);
+            addInfo("Using JavaScript for conditional expressions instead of Janino library");
+        } else {
+            ic.getObjectMap().remove(PropertyEvalJavaScriptBuilder.CONDITIONAL_JS_ATTR);
+        }
 
         LoggerContext lc = (LoggerContext) context;
         boolean packagingData = OptionHelper.toBoolean(ic.subst(attributes.getValue(PACKAGING_DATA_ATTR)), LoggerContext.DEFAULT_PACKAGING_DATA);

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/conditional/Evaluation.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/conditional/Evaluation.java
@@ -1,0 +1,10 @@
+package ch.qos.logback.core.joran.conditional;
+
+import ch.qos.logback.core.Context;
+
+public interface Evaluation {
+
+    Condition build(String script);
+    void setContext(Context context);
+
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/conditional/IfAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/conditional/IfAction.java
@@ -47,7 +47,10 @@ public class IfAction extends Action {
         }
 
         ic.pushObject(this);
-        if (!EnvUtil.isJaninoAvailable()) {
+        
+        boolean useJavaScript = Boolean.TRUE.equals(ic.getObjectMap().get(PropertyEvalJavaScriptBuilder.CONDITIONAL_JS_ATTR));
+        
+        if (!useJavaScript && !EnvUtil.isJaninoAvailable()) {
             addError(MISSING_JANINO_MSG);
             addError(MISSING_JANINO_SEE);
             return;
@@ -59,10 +62,15 @@ public class IfAction extends Action {
 
         if (!OptionHelper.isEmpty(conditionAttribute)) {
             conditionAttribute = OptionHelper.substVars(conditionAttribute, ic, context);
-            PropertyEvalScriptBuilder pesb = new PropertyEvalScriptBuilder(ic);
-            pesb.setContext(context);
+            Evaluation builder;
+            if (useJavaScript) {
+                builder = new PropertyEvalJavaScriptBuilder(ic);
+            } else {
+                builder = new PropertyEvalScriptBuilder(ic);
+            }
+            builder.setContext(context);
             try {
-                condition = pesb.build(conditionAttribute);
+                condition = builder.build(conditionAttribute);
             } catch (Exception e) {
                 addError("Failed to parse condition [" + conditionAttribute + "]", e);
             }

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/conditional/PropertyEvalJavaScriptBuilder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/conditional/PropertyEvalJavaScriptBuilder.java
@@ -1,0 +1,94 @@
+package ch.qos.logback.core.joran.conditional;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.ref.WeakReference;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.spi.PropertyContainer;
+
+public class PropertyEvalJavaScriptBuilder implements Evaluation {
+
+    public static final String CONDITIONAL_JS_ATTR = "conditional-js";
+    private static final String JS_ENGINE_NAME = "JavaScript";
+
+    // variable names provided in JavaScript context
+    static final String PROPERTIES = "props";
+    static final String CONTEXT = "ctx";
+
+    private static WeakReference<ScriptEngine> globalEngine = new WeakReference<ScriptEngine>(null);
+    private Context context;
+    ScriptEngine engine;
+
+    final PropertyContainer localPropContainer;
+
+    PropertyEvalJavaScriptBuilder(PropertyContainer localPropContainer) {
+        this.localPropContainer = localPropContainer;
+        
+        engine = globalEngine.get();
+        if (engine == null) {
+            final ScriptEngineManager factory = new ScriptEngineManager();
+            engine = factory.getEngineByName(JS_ENGINE_NAME);
+            if (engine == null) {
+                throw new IllegalStateException("JavaScript not supported");
+            }
+            final Reader reader = new InputStreamReader(getClass().getResourceAsStream("functions.js"));
+            try {
+                engine.eval(reader);
+            } catch (ScriptException e) {
+                throw new IllegalStateException(e);
+            } finally {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+            globalEngine = new WeakReference<ScriptEngine>(engine);
+        }
+    }
+    
+    @Override
+    public Condition build(String script) {
+        return new JavaScriptCondition(engine, localPropContainer, context, script);
+    }
+
+    @Override
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    private static class JavaScriptCondition implements Condition {
+        
+        final ScriptEngine executor;
+        final String script;
+
+        JavaScriptCondition(ScriptEngine engine, PropertyContainer properties, Context context, String expression) {
+            executor = engine;
+            Bindings bindings = executor.getBindings(ScriptContext.ENGINE_SCOPE);
+            bindings.put(PROPERTIES, properties);
+            bindings.put(CONTEXT, context);
+            script = expression;
+        }
+
+        @Override
+        public boolean evaluate() {
+            try {
+                Object result = executor.eval(script);
+                if (result != null && Boolean.class.equals(result.getClass())) {
+                    return ((Boolean) result).booleanValue();
+                }
+                return false;
+            } catch (ScriptException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}

--- a/logback-core/src/main/resources/ch/qos/logback/core/joran/conditional/functions.js
+++ b/logback-core/src/main/resources/ch/qos/logback/core/joran/conditional/functions.js
@@ -1,0 +1,27 @@
+var OptionHelper;
+if (typeof(Java) !== "undefined") {
+    // Nashorn interpreter
+    OptionHelper = Java.type("ch.qos.logback.core.util.OptionHelper");
+} else if (typeof(Packages) !== "undefined") {
+    // Rhino interpreter
+    OptionHelper = Packages.ch.qos.logback.core.util.OptionHelper;
+    String.prototype.contains = function(str) {
+        return this.indexOf(str) >= 0;
+    };
+} else {
+    throw "cannot access OptionHelper (neither Nashorn nor Rhino?)";
+}
+
+var property = function(key) {
+    var val = OptionHelper.propertyLookup(key, props, ctx);
+    return val ? val : "";
+};
+var p = property;
+
+var isDefined = function(key) {
+    return !(p(key) === "");
+};
+
+var isNull = function(key) {
+    return p(key) === "";
+};

--- a/logback-core/src/test/input/joran/conditional/javaScriptEvaluation.xml
+++ b/logback-core/src/test/input/joran/conditional/javaScriptEvaluation.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<x conditional-js="true">
+  <stack name="BEGIN"/>
+  <if condition='property("sysKeyJS").equals("val1")'>
+    <then>
+      <stack name="a"/>
+    </then>
+  </if>
+  <stack name="END"/>
+</x>

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/conditional/JavaScriptEvaluationTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/conditional/JavaScriptEvaluationTest.java
@@ -1,0 +1,83 @@
+package ch.qos.logback.core.joran.conditional;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Stack;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.Attributes;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.joran.TrivialConfigurator;
+import ch.qos.logback.core.joran.action.Action;
+import ch.qos.logback.core.joran.action.NOPAction;
+import ch.qos.logback.core.joran.action.ext.StackAction;
+import ch.qos.logback.core.joran.spi.ActionException;
+import ch.qos.logback.core.joran.spi.ElementSelector;
+import ch.qos.logback.core.joran.spi.InterpretationContext;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.status.StatusChecker;
+import ch.qos.logback.core.util.CoreTestConstants;
+import ch.qos.logback.core.util.StatusPrinter;
+
+public class JavaScriptEvaluationTest {
+
+    Context context = new ContextBase();
+    StatusChecker checker = new StatusChecker(context);
+    TrivialConfigurator tc;
+    static final String CONDITIONAL_DIR_PREFIX = CoreTestConstants.JORAN_INPUT_PREFIX + "conditional/";
+
+    String val1 = "val1";
+    String sysKey = "sysKeyJS";
+
+    StackAction stackAction = new StackAction();
+
+    @Before
+    public void setUp() throws Exception {
+        HashMap<ElementSelector, Action> rulesMap = new HashMap<ElementSelector, Action>();
+        rulesMap.put(new ElementSelector("x"), new Action() {
+            @Override
+            public void begin(InterpretationContext ic, String name, Attributes attributes) throws ActionException {
+                // ensure JavaScript evaluation is to be used
+                assertEquals("true", attributes.getValue(PropertyEvalJavaScriptBuilder.CONDITIONAL_JS_ATTR));
+                // activate JavaScript evaluation
+                ic.getObjectMap().put(PropertyEvalJavaScriptBuilder.CONDITIONAL_JS_ATTR, Boolean.TRUE);
+            }
+            @Override
+            public void end(InterpretationContext ic, String name) throws ActionException {
+            }            
+        });
+        rulesMap.put(new ElementSelector("x/stack"), stackAction);
+        rulesMap.put(new ElementSelector("*/if"), new IfAction());
+        rulesMap.put(new ElementSelector("*/if/then"), new ThenAction());
+        rulesMap.put(new ElementSelector("*/if/then/*"), new NOPAction());
+
+        tc = new TrivialConfigurator(rulesMap);
+        tc.setContext(context);
+        System.setProperty(sysKey, val1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        StatusPrinter.printIfErrorsOccured(context);
+        System.clearProperty(sysKey);
+    }
+
+    @Test
+    public void javaScriptIsUsed() throws JoranException, Throwable {
+        tc.doConfigure(CONDITIONAL_DIR_PREFIX + "javaScriptEvaluation.xml");
+        verifyConfig(new String[] { "BEGIN", "a", "END" });
+    }
+
+    void verifyConfig(String[] expected) {
+        Stack<String> witness = new Stack<String>();
+        witness.addAll(Arrays.asList(expected));
+        assertEquals(witness, stackAction.getStack());
+    }
+
+}

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/conditional/PackageTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/conditional/PackageTest.java
@@ -18,7 +18,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ PropertyEvalScriptBuilderTest.class, IfThenElseTest.class, IfThenElseAndIncludeCompositionTest.class })
+@SuiteClasses({ PropertyEvalScriptBuilderTest.class, PropertyEvalJavaScriptBuilderTest.class, IfThenElseTest.class, IfThenElseAndIncludeCompositionTest.class })
 public class PackageTest {
 
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/joran/conditional/PropertyEvalJavaScriptBuilderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/conditional/PropertyEvalJavaScriptBuilderTest.java
@@ -1,0 +1,41 @@
+package ch.qos.logback.core.joran.conditional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PropertyEvalJavaScriptBuilderTest extends PropertyEvalScriptBuilderTest {
+
+    PropertyEvalJavaScriptBuilder builder = new PropertyEvalJavaScriptBuilder(localPropContainer);
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        builder.setContext(context);
+    }
+
+    @Override
+    void buildAndAssertTrue(String script) throws Exception {
+        Condition condition = builder.build(script);
+        assertNotNull(condition);
+        assertTrue(condition.evaluate());
+    }
+
+    @Override
+    void buildAndAssertFalse(String script) throws Exception {
+        Condition condition = builder.build(script);
+        assertNotNull(condition);
+        assertFalse(condition.evaluate());
+    }
+
+    @Test
+    public void javaScriptEngineIsReused() throws Exception {
+        PropertyEvalJavaScriptBuilder anotherBuilder = new PropertyEvalJavaScriptBuilder(localPropContainer);
+        assertSame(builder.engine, anotherBuilder.engine);
+    }
+    
+}

--- a/logback-site/src/site/pages/codes.html
+++ b/logback-site/src/site/pages/codes.html
@@ -598,7 +598,11 @@
   library</a>.  See the <a href="setup.html#janino">setup
   instructions</a> for adding Janino to your class path.
   </p>
-
+  <p>Alternatively, <a href="manual/configuration.html#javascript">JavaScript
+  evaluation</a> can be configured, removing the need for the
+  Janino library.
+  </p>
+  
   <!-- ============================================================= -->
   <h3 class="doAnchor" name="block">As of logback version 0.9.28,
   JaninoEventEvaluator expects Java blocks.

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -594,6 +594,19 @@ java.lang.Exception: 99 is invalid
   <b>lc.setPackagingDataEnabled(true);</b>
 </pre>
 
+   <h3 class="doAnchor" name="javascript">Conditional processing with
+   JavaScript</h3>
+
+   <p>As an alternative to the Janino library for
+   <a href="manual/configuration.html#conditional">conditional
+   processing</a> in configuration files JavaScript can be used.
+   To activate, set the attribute <span class="attr">conditional-js</span>
+   on the <em>configuration</em> element to true:</p>
+   
+   <pre class="prettyprint source">&lt;configuration conditional-js="true"&gt;
+...
+&lt;/configuration&gt;</pre>
+
    <h3 class="doAnchor" name="joranDirectly">Invoking
    <code>JoranConfigurator</code> directly</h3>
 
@@ -1898,7 +1911,9 @@ fileName=myApp.log
   <code>&lt;then></code> and <code>&lt;else></code> elements so that a
   single configuration file can adequately target several
   environments. Note that conditional processing requires the <a
-  href="../setup.html#janino">Janino library</a>.
+  href="../setup.html#janino">Janino library</a>, unless
+  <a href="../setup.html#javascript">JavaScript evaluation</a>
+  is chosen.
   </p>
 
   <p>The general format for conditional statements is shown below.</p>

--- a/logback-site/src/site/pages/setup.html
+++ b/logback-site/src/site/pages/setup.html
@@ -203,7 +203,10 @@
    <p><a href="manual/configuration.html#conditional">Conditional
    processing</a> in configuration files requires the <a
    href="http://docs.codehaus.org/display/JANINO/Home"><b>Janino
-   library</b></a>. Moreover, the evaluator examples based on
+   library</b></a>, unless
+   <a href="manual/configuration.html#javascript">JavaScript
+   evaluation</a> is chosen.
+   Moreover, the evaluator examples based on
    <code>JaninoEventEvaluator</code> require Janino as well.  Once you
    download Janino, simply place <em>commons-compiler.jar</em> and
    <em>janino.jar</em> on your application's class path.
@@ -224,7 +227,6 @@
   &lt;artifactId>janino&lt;/artifactId>
   &lt;version>${janino.version}&lt;/version>
 &lt;/dependency></pre>
-
 
 
    


### PR DESCRIPTION
This feature supports using JavaScript to evaluate conditions in the `if` element instead of expressions evaluated through Janino. The feature needs to be activated with a new attribute on the `configuration` element, thus providing full backwards compatibility with existing configuration files.

See also https://jira.qos.ch/browse/LOGBACK-1334

As signed CLA was sent by mail.

Release notes input:
<p>Allow condition evaluation via JavaScript
instead of requiring the additional Janino
library, as described in
<a href="https://jira.qos.ch/browse/LOGBACK-1334">LOGBACK-1334</a>.
</p>
