### PR TITLE
README: fix formatting of section headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-#About logback
+# About logback
 
 Thank you for your interest in logback, the reliable, generic, fast
 and flexible logging library for Java.
@@ -8,13 +8,13 @@ The Logback documentation can be found on the [project
 web-site](https://logback.qos.ch/documentation.html) as well as under
 the docs/ folder of the logback distribution.
 
-#Building logback
+# Building logback
 
 Building logback is documented at:
 
   https://logback.qos.ch/setup.html#ide
 
-#In case of problems
+# In case of problems
 
 In case of problems please do not hesitate to post an e-mail message
 on the logback-user@qos.ch mailing list.  However, please do not
@@ -24,7 +24,7 @@ on the logback-user mailing lists who can quickly answer your
 questions.
 
 
-#Pull requests
+# Pull requests
 
 If you are interested in improving logback, great! The logback community
 looks forward to your contribution. Please follow this process:


### PR DESCRIPTION
Add spaces between # and the section headers to ensure they are displayed correctly on Github