### PR TITLE
Fixed periods count in rolling calendar when using hourly rollover

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
@@ -196,7 +196,7 @@ public class RollingCalendar extends GregorianCalendar {
             return diff / MILLIS_IN_ONE_MINUTE;
         case TOP_OF_HOUR:
 
-            return (int) diff / MILLIS_IN_ONE_HOUR;
+            return diff / MILLIS_IN_ONE_HOUR;
         case TOP_OF_DAY:
             return diff / MILLIS_IN_ONE_DAY;
         case TOP_OF_WEEK:


### PR DESCRIPTION
When you use SizeAndTimeBasedFNATP, it uses TimeBasedArchiveRemover to clean old files, which uses RollingCallendar to compute the number of elapsed periods.

However, in TimeBasedArchiveRemover, the line:
`rc.periodBarriersCrossed(nowInMillis, nowInMillis + INACTIVITY_TOLERANCE_IN_MILLIS) `
will return a negative number when the periodicityType is TOP_OF_HOUR due to a premature cast to integer.

To test this, use the following configuration:

```
<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
  <file>file.log</file>
  <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
    <fileNamePattern>file.%d{yyyy-MM-dd-HH}.%i.log</fileNamePattern>
    <maxHistory>1</maxHistory>
  </rollingPolicy>

  <encoder><pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern></encoder>
</appender>
```

And create files with more than 1 hour and less than 336 hours