### PR TITLE
Fixes LOGBACK-360

### DIFF
--- a/logback-classic/src/main/resources/ch/qos/logback/classic/db/script/mssql.sql
+++ b/logback-classic/src/main/resources/ch/qos/logback/classic/db/script/mssql.sql
@@ -29,13 +29,13 @@ CREATE TABLE logging_event
     caller_class      VARCHAR(254) NOT NULL,
     caller_method     VARCHAR(254) NOT NULL,
     caller_line       CHAR(4) NOT NULL,
-    event_id          DECIMAL(40) NOT NULL identity,
+    event_id          DECIMAL(38) NOT NULL identity,
     PRIMARY KEY(event_id) 
   ) 
 
 CREATE TABLE logging_event_property 
   ( 
-    event_id          DECIMAL(40) NOT NULL, 
+    event_id          DECIMAL(38) NOT NULL, 
     mapped_key        VARCHAR(254) NOT NULL, 
     mapped_value      VARCHAR(1024), 
     PRIMARY KEY(event_id, mapped_key), 
@@ -44,7 +44,7 @@ CREATE TABLE logging_event_property
 
 CREATE TABLE logging_event_exception 
   ( 
-    event_id         DECIMAL(40) NOT NULL, 
+    event_id         DECIMAL(38) NOT NULL, 
     i                SMALLINT NOT NULL, 
     trace_line       VARCHAR(254) NOT NULL, 
     PRIMARY KEY(event_id, i), 


### PR DESCRIPTION
The way it currently stands, this script won't run.

SQL Server doesn't support DECIMAL's of size 40.

According [to this doc](https://docs.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql), the max is 38.

Changing the precision to 38 seems to solve the issue.