### PR TITLE
Add getter for SizeBasedTriggeringPolicy.maxFileSize

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeBasedTriggeringPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeBasedTriggeringPolicy.java
@@ -13,11 +13,11 @@
  */
 package ch.qos.logback.core.rolling;
 
-import java.io.File;
-
-import ch.qos.logback.core.util.FileSize;
 import ch.qos.logback.core.util.DefaultInvocationGate;
+import ch.qos.logback.core.util.FileSize;
 import ch.qos.logback.core.util.InvocationGate;
+
+import java.io.File;
 
 /**
  * SizeBasedTriggeringPolicy looks at size of the file being currently written
@@ -31,8 +31,8 @@ import ch.qos.logback.core.util.InvocationGate;
  * 
  */
 public class SizeBasedTriggeringPolicy<E> extends TriggeringPolicyBase<E> {
-
     public static final String SEE_SIZE_FORMAT = "http://logback.qos.ch/codes.html#sbtp_size_format";
+
     /**
      * The default maximum file size.
      */
@@ -57,4 +57,7 @@ public class SizeBasedTriggeringPolicy<E> extends TriggeringPolicyBase<E> {
         this.maxFileSize = aMaxFileSize;
     }
 
+    public FileSize getMaxFileSize() {
+        return maxFileSize;
+    }
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/SizeBasedTriggeringPolicyTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/SizeBasedTriggeringPolicyTest.java
@@ -1,0 +1,36 @@
+package ch.qos.logback.core.rolling;
+
+import ch.qos.logback.core.util.FileSize;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SizeBasedTriggeringPolicyTest {
+    @Test
+    public void constructor() {
+        SizeBasedTriggeringPolicy sizeBasedTriggeringPolicy = new SizeBasedTriggeringPolicy();
+
+        FileSize expected = new FileSize(SizeBasedTriggeringPolicy.DEFAULT_MAX_FILE_SIZE);
+        assertEquals(expected.getSize(), sizeBasedTriggeringPolicy.maxFileSize.getSize());
+    }
+
+    @Test
+    public void setMaxFileSize() throws Exception {
+        FileSize fileSize = new FileSize(300);
+
+        SizeBasedTriggeringPolicy sizeBasedTriggeringPolicy = new SizeBasedTriggeringPolicy();
+        sizeBasedTriggeringPolicy.setMaxFileSize(fileSize);
+
+        assertEquals(fileSize.getSize(), sizeBasedTriggeringPolicy.maxFileSize.getSize());
+    }
+
+    @Test
+    public void getMaxFileSize() throws Exception {
+        FileSize fileSize = new FileSize(300);
+
+        SizeBasedTriggeringPolicy sizeBasedTriggeringPolicy = new SizeBasedTriggeringPolicy();
+        sizeBasedTriggeringPolicy.setMaxFileSize(fileSize);
+
+        assertEquals(fileSize.getSize(), sizeBasedTriggeringPolicy.getMaxFileSize().getSize());
+    }
+}


### PR DESCRIPTION
I noticed that the code style specified 2-space indentation.  The file I altered uses 4-space and I did the same in my test.  Happy to change anything necessary, even nit picks.