### PR TITLE
Suppress duplicate messages for a while

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/turbo/DuplicateMessageFilter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/turbo/DuplicateMessageFilter.java
@@ -37,15 +37,20 @@ public class DuplicateMessageFilter extends TurboFilter {
      * The default number of allows repetitions.
      */
     public static final int DEFAULT_ALLOWED_REPETITIONS = 5;
+    /**
+     * The default time log messages expire after [ms].
+     */
+    public static final int DEFAULT_SUPPRESSION_TIME_IN_MS = 65000;
 
     public int allowedRepetitions = DEFAULT_ALLOWED_REPETITIONS;
     public int cacheSize = DEFAULT_CACHE_SIZE;
+    public int suppressionTimeMs = DEFAULT_SUPPRESSION_TIME_IN_MS;
 
-    private LRUMessageCache msgCache;
+    private ExpiringLRUMessageCache msgCache;
 
     @Override
     public void start() {
-        msgCache = new LRUMessageCache(cacheSize);
+        msgCache = new ExpiringLRUMessageCache(cacheSize, suppressionTimeMs);
         super.start();
     }
 
@@ -87,4 +92,16 @@ public class DuplicateMessageFilter extends TurboFilter {
         this.cacheSize = cacheSize;
     }
 
+    public int getSuppressionTimeMs() {
+        return suppressionTimeMs;
+    }
+
+    /**
+     * The allowed time log messages expire after [ms]
+     *
+     * @param suppressionTimeMs
+     */
+    public void setSuppressionTimeMs(int suppressionTimeMs) {
+        this.suppressionTimeMs = suppressionTimeMs;
+    }
 }

--- a/logback-site/src/site/pages/manual/filters.html
+++ b/logback-site/src/site/pages/manual/filters.html
@@ -944,7 +944,8 @@ public class SampleTurboFilter extends TurboFilter {
 
     <p>The <code>DuplicateMessageFilter</code> merits a separate
     presentation.  This filter detects duplicate messages, and beyond
-    a certain number of repetitions, drops repeated messages.
+    a certain number of repetitions, drops repeated messages until they
+    do not appear for a while.
     </p>
 
     <p>To detect repetition, this filter uses simple String equality
@@ -987,7 +988,14 @@ logger.debug("Hello {}.", name1);</pre>
     property. By the default, this is set to 100.
     </p>
 
-    
+    <p>The time until messages are not dropped anymore can be specified
+    by the <span class="option">SuppressionTimeMs</span> property. For
+    example, if the property is set to 10000 (ms), then all subsequent
+    occurrences of the same message within the next 10s will be dropped.
+    By default, the <span class="option">SuppressionTimeMs</span> property
+    is set to 60000 (ms).
+    </p>
+
     <em>Example: <code>DuplicateMessageFilter</code> 
     configuration (logback-examples/src/main/resources/chapters/filters/duplicateMessage.xml)</em>
 


### PR DESCRIPTION
Currently the DuplicateMessageFilter filters messages forever which is not optimal. I believe in most cases people want to filter annoying in fixed-interval reoccurring messages or errors temporarily occurring in high volume. In the latter case you definitely want to "know" when it occurs again (actually you're also interested when its over, but that's a bit more difficult).
Thus the DuplicateMessageFilter shall log messages again after they did not occur for a while.