### PR TITLE
LOGBACK-1356 Append arguments to message when all are unused.

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEvent.java
@@ -290,12 +290,32 @@ public class LoggingEvent implements ILoggingEvent {
             return formattedMessage;
         }
         if (argumentArray != null) {
-            formattedMessage = MessageFormatter.arrayFormat(message, argumentArray).getMessage();
+            formattedMessage = formatMessage(message, argumentArray);
         } else {
             formattedMessage = message;
         }
 
         return formattedMessage;
+    }
+
+    static String formatMessage(String message, Object[] argumentArray) {
+        String result;
+        if (argumentArray == null || argumentArray.length <= 0) {
+            result = message;
+        } else if (message.contains("{}")) {
+            result = MessageFormatter.arrayFormat(message, argumentArray).getMessage();
+        } else {
+            // LOGBACK-1356 Since the message has no {}, rather than throw away the arguments, append them to the message.
+            StringBuilder stringBuilder = new StringBuilder(message);
+            for (int i = 0; i < argumentArray.length; i++) {
+                Object arg = argumentArray[i];
+                if (arg != null) {
+                    stringBuilder.append(' ').append(arg);
+                }
+            }
+            result = stringBuilder.toString();
+        }
+        return result;
     }
 
     public Map<String, String> getMDCPropertyMap() {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEventVO.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/LoggingEventVO.java
@@ -104,11 +104,7 @@ public class LoggingEventVO implements ILoggingEvent, Serializable {
             return formattedMessage;
         }
 
-        if (argumentArray != null) {
-            formattedMessage = MessageFormatter.arrayFormat(message, argumentArray).getMessage();
-        } else {
-            formattedMessage = message;
-        }
+        formattedMessage = LoggingEvent.formatMessage(message, argumentArray);
 
         return formattedMessage;
     }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/LoggerMessageFormattingTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/LoggerMessageFormattingTest.java
@@ -57,7 +57,7 @@ public class LoggerMessageFormattingTest {
         Logger logger = lc.getLogger(Logger.ROOT_LOGGER_NAME);
         logger.debug("test", new Integer(12), new Integer(13));
         ILoggingEvent event = (ILoggingEvent) listAppender.list.get(0);
-        assertEquals("test", event.getFormattedMessage());
+        assertEquals("test 12 13", event.getFormattedMessage());
     }
 
     @Test

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
@@ -13,9 +13,7 @@
  */
 package ch.qos.logback.classic.pattern;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -76,7 +74,7 @@ public class ConverterTest {
             StringBuilder buf = new StringBuilder();
             converter.write(buf, le);
             // the number below should be the line number of the previous line
-            assertEquals("78", buf.toString());
+            assertEquals("75", buf.toString());
         }
     }
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
@@ -60,7 +60,7 @@ public class LoggingEventTest {
         Object[] argArray = new Object[] { 12, 13 };
         LoggingEvent event = new LoggingEvent("", logger, Level.INFO, message, throwable, argArray);
         assertNull(event.formattedMessage);
-        assertEquals(message, event.getFormattedMessage());
+        assertEquals("testNoFormatting 12 13", event.getFormattedMessage());
     }
 
     @Test

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/PubLoggingEventVO.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/PubLoggingEventVO.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.slf4j.Marker;
-import org.slf4j.helpers.MessageFormatter;
 
 import ch.qos.logback.classic.Level;
 
@@ -78,11 +77,7 @@ public class PubLoggingEventVO implements ILoggingEvent, Serializable {
             return formattedMessage;
         }
 
-        if (argumentArray != null) {
-            formattedMessage = MessageFormatter.arrayFormat(message, argumentArray).getMessage();
-        } else {
-            formattedMessage = message;
-        }
+        formattedMessage = LoggingEvent.formatMessage(message, argumentArray);
 
         return formattedMessage;
     }


### PR DESCRIPTION
This intentionally doesn't depend on the fix for SLF4J-422
so that logback stays compatible with prior versions of slf4j-api.