### PR TITLE
LOGBACK-543 Use Throwable.toString

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/html/DefaultThrowableRenderer.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/html/DefaultThrowableRenderer.java
@@ -58,7 +58,12 @@ public class DefaultThrowableRenderer implements IThrowableRenderer<ILoggingEven
         if (commonFrames > 0) {
             sb.append("<br />").append(CoreConstants.CAUSED_BY);
         }
-        sb.append(tp.getClassName()).append(": ").append(Transform.escapeTags(tp.getMessage()));
+        String string = tp.getString();
+        if (string == null) {
+            sb.append(tp.getClassName()).append(": ").append(Transform.escapeTags(tp.getMessage()));
+        } else {
+            sb.append(Transform.escapeTags(string));
+        }
         sb.append(CoreConstants.LINE_SEPARATOR);
     }
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
@@ -173,11 +173,7 @@ public class ThrowableProxyConverter extends ThrowableHandlingConverter {
         if (prefix != null) {
             buf.append(prefix);
         }
-        subjoinExceptionMessage(buf, tp);
-    }
-
-    private void subjoinExceptionMessage(StringBuilder buf, IThrowableProxy tp) {
-        buf.append(tp.getClassName()).append(": ").append(tp.getMessage());
+        ThrowableProxyUtil.subjoinExceptionMessage(buf, tp);
     }
 
     protected void subjoinSTEPArray(StringBuilder buf, int indent, IThrowableProxy tp) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/IThrowableProxy.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/IThrowableProxy.java
@@ -18,6 +18,8 @@ public interface IThrowableProxy {
 
     String getClassName();
 
+    String getString();
+
     StackTraceElementProxy[] getStackTraceElementProxyArray();
 
     int getCommonFrames();

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxy.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxy.java
@@ -23,6 +23,7 @@ public class ThrowableProxy implements IThrowableProxy {
     private Throwable throwable;
     private String className;
     private String message;
+    private String string;
     // package-private because of ThrowableProxyUtil
     StackTraceElementProxy[] stackTraceElementProxyArray;
     // package-private because of ThrowableProxyUtil
@@ -52,6 +53,10 @@ public class ThrowableProxy implements IThrowableProxy {
         this.throwable = throwable;
         this.className = throwable.getClass().getName();
         this.message = throwable.getMessage();
+        this.string = throwable.toString();
+        if (this.string.equals(this.className + ": " + this.message)) {
+            this.string = null;
+        }
         this.stackTraceElementProxyArray = ThrowableProxyUtil.steArrayToStepArray(throwable.getStackTrace());
 
         Throwable nested = throwable.getCause();
@@ -90,6 +95,10 @@ public class ThrowableProxy implements IThrowableProxy {
 
     public String getMessage() {
         return message;
+    }
+
+    public String getString() {
+        return string;
     }
 
     /*

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxyUtil.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxyUtil.java
@@ -178,7 +178,12 @@ public class ThrowableProxyUtil {
         subjoinExceptionMessage(buf, tp);
     }
 
-    private static void subjoinExceptionMessage(StringBuilder buf, IThrowableProxy tp) {
-        buf.append(tp.getClassName()).append(": ").append(tp.getMessage());
+    public static void subjoinExceptionMessage(StringBuilder buf, IThrowableProxy tp) {
+        String string = tp.getString();
+        if (string == null) {
+            buf.append(tp.getClassName()).append(": ").append(tp.getMessage());
+        } else {
+            buf.append(string);
+        }
     }
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxyVO.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxyVO.java
@@ -22,6 +22,7 @@ public class ThrowableProxyVO implements IThrowableProxy, Serializable {
 
     private String className;
     private String message;
+    private String string;
     private int commonFramesCount;
     private StackTraceElementProxy[] stackTraceElementProxyArray;
     private IThrowableProxy cause;
@@ -29,6 +30,10 @@ public class ThrowableProxyVO implements IThrowableProxy, Serializable {
 
     public String getMessage() {
         return message;
+    }
+
+    public String getString() {
+        return string;
     }
 
     public String getClassName() {
@@ -97,6 +102,7 @@ public class ThrowableProxyVO implements IThrowableProxy, Serializable {
         ThrowableProxyVO tpvo = new ThrowableProxyVO();
         tpvo.className = throwableProxy.getClassName();
         tpvo.message = throwableProxy.getMessage();
+        tpvo.string = throwableProxy.getString();
         tpvo.commonFramesCount = throwableProxy.getCommonFrames();
         tpvo.stackTraceElementProxyArray = throwableProxy.getStackTraceElementProxyArray();
         IThrowableProxy cause = throwableProxy.getCause();

--- a/logback-classic/src/test/java/ch/qos/logback/classic/html/HTMLLayoutTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/html/HTMLLayoutTest.java
@@ -124,6 +124,27 @@ public class HTMLLayoutTest {
     }
 
     @Test
+    public void testAppendThrowableWithOverriddenToString() throws Exception {
+        StringBuilder buf = new StringBuilder();
+        DummyThrowableProxy tp = new DummyThrowableProxy();
+        tp.setString("test1: msg1 [extra]");
+
+        StackTraceElement ste1 = new StackTraceElement("c1", "m1", "f1", 1);
+        StackTraceElement ste2 = new StackTraceElement("c2", "m2", "f2", 2);
+
+        StackTraceElementProxy[] stepArray = { new StackTraceElementProxy(ste1), new StackTraceElementProxy(ste2) };
+        tp.setStackTraceElementProxyArray(stepArray);
+        DefaultThrowableRenderer renderer = (DefaultThrowableRenderer) layout.getThrowableRenderer();
+
+        renderer.render(buf, tp);
+        System.out.println(buf.toString());
+        String[] result = buf.toString().split(CoreConstants.LINE_SEPARATOR);
+        System.out.println(result[0]);
+        assertEquals("test1: msg1 [extra]", result[0]);
+        assertEquals(DefaultThrowableRenderer.TRACE_PREFIX + "at c1.m1(f1:1)", result[1]);
+    }
+
+    @Test
     public void testDoLayout() throws Exception {
         ILoggingEvent le = createLoggingEvent();
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/DummyThrowableProxy.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/DummyThrowableProxy.java
@@ -17,6 +17,7 @@ public class DummyThrowableProxy implements IThrowableProxy {
 
     private String className;
     private String message;
+    private String string;
     private int commonFramesCount;
     private StackTraceElementProxy[] stackTraceElementProxyArray;
     private IThrowableProxy cause;
@@ -36,6 +37,14 @@ public class DummyThrowableProxy implements IThrowableProxy {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    public void setString(String string) {
+        this.string = string;
     }
 
     public int getCommonFrames() {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/ThrowableProxyTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/ThrowableProxyTest.java
@@ -179,4 +179,14 @@ public class ThrowableProxyTest {
             throw new Exception("someOtherMethod", e);
         }
     }
+
+    @Test
+    public void overriddenToString() {
+        Exception e = new Exception() {
+            public String toString() {
+                return getClass().getName() + " [extra]";
+            }
+        };
+        verify(e);
+    }
 }


### PR DESCRIPTION
#### Steps to reproduce
Log an exception with an overridden `toString`.  For example:
```java
public class TestException extends RuntimeException {
  public String toString() {
    return super.toString() + " [extra state]";
  }
}
```

Actual:
```
test.TestException
	at test.Main.main(Main.java:3)
```

Expected:
```
test.TestException [extra state]
	at test.Main.main(Main.java:3)
```

#### Fix
Add a new `ThrowableProxy.string` field and `getString` method.  The field is optional, and it is set to null if it is equal to the default `Throwable.toString` implementation with class name and message, which avoids overhead in `ThrowableProxyVO` for the common case.