### PR TITLE
LOGBACK-1363 Response header field names to be case-insensitive

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/jetty/JettyServerAdapter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/jetty/JettyServerAdapter.java
@@ -20,8 +20,8 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A jetty specific implementation of the {@link ServerAdapter} interface.
@@ -56,7 +56,7 @@ public class JettyServerAdapter implements ServerAdapter {
 
     @Override
     public Map<String, String> buildResponseHeaderMap() {
-        Map<String, String> responseHeaderMap = new HashMap<String, String>();
+        Map<String, String> responseHeaderMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
         HttpFields httpFields = response.getHttpFields();
         Enumeration e = httpFields.getFieldNames();
         while (e.hasMoreElements()) {

--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/TomcatServerAdapter.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/TomcatServerAdapter.java
@@ -18,8 +18,8 @@ import ch.qos.logback.access.spi.ServerAdapter;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A tomcat specific implementation of the {@link ServerAdapter} interface.
@@ -53,7 +53,7 @@ public class TomcatServerAdapter implements ServerAdapter {
 
     @Override
     public Map<String, String> buildResponseHeaderMap() {
-        Map<String, String> responseHeaderMap = new HashMap<String, String>();
+        Map<String, String> responseHeaderMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
         for (String key : response.getHeaderNames()) {
             String value = response.getHeader(key);
             responseHeaderMap.put(key, value);

--- a/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
@@ -84,6 +84,8 @@ public class JettyBasicTest {
 
         assertEquals("127.0.0.1", event.getRemoteHost());
         assertEquals("localhost", event.getServerName());
+        assertEquals("123", event.getResponseHeader("CORRELATION-ID"));
+        assertEquals("123", event.getResponseHeader("correlation-id"));
         listAppender.list.clear();
     }
 

--- a/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyFixtureBase.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyFixtureBase.java
@@ -61,6 +61,7 @@ public class JettyFixtureBase {
         requestLogHandler.setRequestLog(requestLogImpl);
 
         HandlerList handlers = new HandlerList();
+        handlers.addHandler(new ResponseHeaderHandler());
         handlers.addHandler(requestLogHandler);
         handlers.addHandler(getRequestHandler());
 
@@ -93,6 +94,12 @@ public class JettyFixtureBase {
 
             baseRequest.setHandled(true);
 
+        }
+    }
+
+    class ResponseHeaderHandler extends AbstractHandler {
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+            response.addHeader("correlation-id", "123");
         }
     }
 }

--- a/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyFixtureWithListAndConsoleAppenders.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/jetty/JettyFixtureWithListAndConsoleAppenders.java
@@ -47,7 +47,7 @@ public class JettyFixtureWithListAndConsoleAppenders extends JettyFixtureBase {
         console.setName("console");
         PatternLayoutEncoder layout = new PatternLayoutEncoder();
         layout.setContext(requestLogImpl);
-        layout.setPattern("%date %server %clientHost");
+        layout.setPattern("%date %server %clientHost %responseHeader{correlation-id}");
         console.setEncoder(layout);
         layout.start();
         console.start();


### PR DESCRIPTION
Issue: https://jira.qos.ch/browse/LOGBACK-1363