### PR TITLE
LOGBACK-945 ServerSocketReceiver to accept many clients.

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/server/ServerSocketReceiver.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/server/ServerSocketReceiver.java
@@ -18,6 +18,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import javax.net.ServerSocketFactory;
 
@@ -57,7 +58,7 @@ public class ServerSocketReceiver extends ReceiverBase {
 
             ServerListener<RemoteAppenderClient> listener = createServerListener(serverSocket);
 
-            runner = createServerRunner(listener, getContext().getScheduledExecutorService());
+            runner = createServerRunner(listener, Executors.newCachedThreadPool());
             runner.setContext(getContext());
             return true;
         } catch (Exception ex) {


### PR DESCRIPTION
ServerSocketReceiver cannot accept many clients.

There are a 4 years old bug report and a pull request.
https://jira.qos.ch/browse/LOGBACK-945
https://github.com/qos-ch/logback/pull/168

It is possible to fix this by modifying one line.
I wish this bug is fixed.