### PR TITLE
LOGBACK-1219 changes in logback-access to allow S/sessionID usage in Jetty 9.3+ 

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -262,11 +262,9 @@ public class AccessEvent implements Serializable, IAccessEvent {
     @Override
     public String getSessionID() {
         if (sessionID == null) {
-            if (httpRequest != null) {
-                final HttpSession session = httpRequest.getSession();
-                if (session != null) {
-                    sessionID = session.getId();
-                }
+            final HttpSession session;
+            if (httpRequest != null && (session = httpRequest.getSession(false)) != null) {
+                sessionID = session.getId();
             } else {
                 sessionID = NA;
             }


### PR DESCRIPTION
When Session ID field is used in logback-access it tries to create new HttpSession instead of just probe/discover it. That happens in final stage of HTTP request processing and result in "IllegalStateException: Response is committed".

In this fix getSession() call replaced by getSession(false) as proposed in issue to avoid new session creation.

Tested with jetty-9.4.8.v20171121