### PR TITLE
small refactor in OutputStreamAppender

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java
@@ -222,13 +222,7 @@ public class OutputStreamAppender<E> extends UnsynchronizedAppenderBase<E> {
             if (event instanceof DeferredProcessingAware) {
                 ((DeferredProcessingAware) event).prepareForDeferredProcessing();
             }
-            // the synchronization prevents the OutputStream from being closed while we
-            // are writing. It also prevents multiple threads from entering the same
-            // converter. Converters assume that they are in a synchronized block.
-            // lock.lock();
-
-            byte[] byteArray = this.encoder.encode(event);
-            writeBytes(byteArray);
+            writeOut(event);
 
         } catch (IOException ioe) {
             // as soon as an exception occurs, move to non-started state


### PR DESCRIPTION
Looks like this code has been duplicated in the recent refactor.
this also makes it possible to override the output mechanism - as the `writeOut` method is protected while the `writeBytes` method is private.