### PR TITLE
MDC Inheritance flag (LOGBACK-624)

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
@@ -42,7 +42,7 @@ public class LogbackMDCAdapter implements MDCAdapter {
     // returns true if the map should be copied on inherit thread local. Defaults to true.
     private static boolean copyOnInherit() {
         try {
-            return Boolean.valueOf(System.getProperty(PROPERTY_COPY_ON_INHERIT, Boolean.TRUE.toString()));
+            return Boolean.valueOf(System.getProperty(PROPERTY_COPY_ON_INHERIT, Boolean.FALSE.toString()));
         } catch (Exception e) {
             return true;
         }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterInheritanceTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterInheritanceTest.java
@@ -1,0 +1,68 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.util;
+
+import ch.qos.logback.core.testUtil.RandomUtil;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+
+public class LogbackMDCAdapterInheritanceTest extends LogbackMDCAdapterTest {
+
+    protected boolean copyOnInhertiance() {
+        return true;
+    }
+
+    /**
+     * Test that LogbackMDCAdapter copies its hashmap when a child
+     * thread inherits it.
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void copyOnInheritenceTest() throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        String firstKey = "x" + diff;
+        String secondKey = "o" + diff;
+        mdcAdapter.put(firstKey, firstKey + A_SUFFIX);
+
+        ChildThread childThread = new ChildThread(mdcAdapter, firstKey, secondKey, countDownLatch, firstKey + A_SUFFIX);
+        childThread.start();
+        countDownLatch.await();
+        mdcAdapter.put(firstKey, firstKey + B_SUFFIX);
+        childThread.join();
+
+        assertNull(mdcAdapter.get(secondKey));
+        assertTrue(childThread.successful);
+
+        Map<String, String> parentHM = getMapFromMDCAdapter(mdcAdapter);
+        assertTrue(parentHM != childThread.childHM);
+
+        Map<String, String> parentHMWitness = new  HashMap<String, String>();
+        parentHMWitness.put(firstKey, firstKey + B_SUFFIX);
+        assertEquals(parentHMWitness, parentHM);
+
+        Map<String, String> childHMWitness = new  HashMap<String, String>();
+        childHMWitness.put(firstKey, firstKey + A_SUFFIX);
+        childHMWitness.put(secondKey, secondKey + A_SUFFIX);
+        assertEquals(childHMWitness, childThread.childHM);
+
+    }
+
+
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterNoInhertianceTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterNoInhertianceTest.java
@@ -1,0 +1,66 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.util;
+
+import ch.qos.logback.core.testUtil.RandomUtil;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+
+public class LogbackMDCAdapterNoInhertianceTest extends LogbackMDCAdapterTest {
+
+    protected boolean copyOnInhertiance() {
+        return false;
+    }
+
+    /**
+     * Test that LogbackMDCAdapter does not copy its hashmap when a child
+     * thread inherits it.
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void noCopyOnInheritenceTest() throws InterruptedException {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        String firstKey = "x" + diff;
+        String secondKey = "o" + diff;
+        mdcAdapter.put(firstKey, firstKey + A_SUFFIX);
+
+        ChildThread childThread = new ChildThread(mdcAdapter, firstKey, secondKey, countDownLatch);
+        childThread.start();
+        countDownLatch.await();
+        mdcAdapter.put(firstKey, firstKey + B_SUFFIX);
+        childThread.join();
+
+        assertNull(mdcAdapter.get(secondKey));
+        assertTrue(childThread.successful);
+
+        Map<String, String> parentHM = getMapFromMDCAdapter(mdcAdapter);
+        assertTrue(parentHM != childThread.childHM);
+
+        HashMap<String, String> parentHMWitness = new HashMap<String, String>();
+        parentHMWitness.put(firstKey, firstKey + B_SUFFIX);
+        assertEquals(parentHMWitness, parentHM);
+
+        HashMap<String, String> childHMWitness = new HashMap<String, String>();
+        childHMWitness.put(secondKey, secondKey + A_SUFFIX);
+        assertEquals(childHMWitness, childThread.childHM);
+
+    }
+
+}


### PR DESCRIPTION
The ability to choose between MDC thread inheritance it a missing feature in logback in my opinion, I've read the discussion on LOGBACK-624, and I understand why some think that this feature is bad practice, but existing products that used logback < 1.1.4 and now want to upgrade may get broken due to this change.
Also, I think its Ok if the default is set to not inherit, but there must be some way to allow changing this behavior via some flag.
I've made minimal changes that were proposed as an attachment on LOGBACK-624 by the reporter Alexander Treptow.