### PR TITLE
FF-1341 SizeAndTimeBasedRollingPolicy-does-not-zip-all-the-files-on-d…

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -108,7 +108,7 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
     }
 
     protected ArchiveRemover createArchiveRemover() {
-        return new SizeAndTimeBasedArchiveRemover(tbrp.fileNamePattern, rc);
+        return new SizeAndTimeBasedArchiveRemover(tbrp.fileNamePattern, tbrp.getCompressionMode(), rc);
     }
 
     void computeCurrentPeriodsHighestCounterValue(final String stemRegex) {

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemover.java
@@ -23,17 +23,29 @@ import java.util.regex.Pattern;
 public class SizeAndTimeBasedArchiveRemover extends TimeBasedArchiveRemover {
 
     protected static final int NO_INDEX = -1;
+    private CompressionMode compressionMode;
 
-    public SizeAndTimeBasedArchiveRemover(FileNamePattern fileNamePattern, RollingCalendar rc) {
+    public SizeAndTimeBasedArchiveRemover(FileNamePattern fileNamePattern, CompressionMode compressionMode, RollingCalendar rc) {
         super(fileNamePattern, rc);
+        this.compressionMode = compressionMode;
     }
 
     protected File[] getFilesInPeriod(Date dateOfPeriodToClean) {
         File archive0 = new File(fileNamePattern.convertMultipleArguments(dateOfPeriodToClean, 0));
         File parentDir = getParentDir(archive0);
-        String stemRegex = createStemRegex(dateOfPeriodToClean);
+        String stemRegex = createStemRegexWithoutCompression(dateOfPeriodToClean);
         File[] matchingFileArray = FileFilterUtil.filesInFolderMatchingStemRegex(parentDir, stemRegex);
         return matchingFileArray;
+    }
+
+    /**
+     * Method to create the stem regex without compression suffix.
+     * @param dateOfPeriodToClean Date of the period to clean.
+     * @return Regex without compression suffix.
+     */
+    private String createStemRegexWithoutCompression(final Date dateOfPeriodToClean) {
+        String regex = fileNamePattern.toRegexForFixedDate(dateOfPeriodToClean).replaceAll(compressionMode.name().toLowerCase(), "*");
+        return FileFilterUtil.afterLastSlash(regex);
     }
 
     private String createStemRegex(final Date dateOfPeriodToClean) {

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemoverTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemoverTest.java
@@ -17,7 +17,7 @@ public class SizeAndTimeBasedArchiveRemoverTest {
     @Test
     public void smoke() {
         FileNamePattern fileNamePattern = new FileNamePattern("smoke-%d-%i.gz", context);
-        SizeAndTimeBasedArchiveRemover remover = new SizeAndTimeBasedArchiveRemover(fileNamePattern, null);
+        SizeAndTimeBasedArchiveRemover remover = new SizeAndTimeBasedArchiveRemover(fileNamePattern, CompressionMode.GZ, null);
         File[] fileArray = new File[2];
         File[] expected = new File[2];
 
@@ -32,7 +32,7 @@ public class SizeAndTimeBasedArchiveRemoverTest {
     @Test
     public void badFilenames() {
         FileNamePattern fileNamePattern = new FileNamePattern("smoke-%d-%i.gz", context);
-        SizeAndTimeBasedArchiveRemover remover = new SizeAndTimeBasedArchiveRemover(fileNamePattern, null);
+        SizeAndTimeBasedArchiveRemover remover = new SizeAndTimeBasedArchiveRemover(fileNamePattern, CompressionMode.GZ, null);
         File[] fileArray = new File[2];
         File[] expected = new File[2];
 


### PR DESCRIPTION
FF-1341 Changed SizeAndTimeBasedArchiveRemover to list all files of folder which to be cleaned. 
At present, stemRegex only selects the archive files to delete, changed stemRegex to list all files of clean up directory.