### PR TITLE
Invalid comments in H2 sql script

### DIFF
--- a/logback-classic/src/main/resources/ch/qos/logback/classic/db/script/h2.sql
+++ b/logback-classic/src/main/resources/ch/qos/logback/classic/db/script/h2.sql
@@ -1,12 +1,12 @@
-# Logback: the reliable, generic, fast and flexible logging framework.
-# Copyright (C) 1999-2010, QOS.ch. All rights reserved.
-#
-# See http://logback.qos.ch/license.html for the applicable licensing 
-# conditions.
+-- Logback: the reliable, generic, fast and flexible logging framework.
+-- Copyright (C) 1999-2010, QOS.ch. All rights reserved.
+--
+-- See http://logback.qos.ch/license.html for the applicable licensing 
+-- conditions.
 
-# This SQL script creates the required tables by ch.qos.logback.classic.db.DBAppender.
-#
-# It is intended for H2 databases. 
+-- This SQL script creates the required tables by ch.qos.logback.classic.db.DBAppender.
+--
+-- It is intended for H2 databases. 
 
 
 DROP TABLE logging_event_exception IF EXISTS;


### PR DESCRIPTION
Comments in DB scripts for H2 should start with `--` instead of `#` otherwise we get a SQL Syntax Exception.

This is already done for Oracle and MSSQL.

