### PR TITLE
Pyke 8367 logback v 1.2.2 fixes

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -44,7 +44,6 @@ public class SyslogOutputStream extends OutputStream {
     public SyslogOutputStream(String syslogHost, int port) throws UnknownHostException, SocketException {
         this.address = InetAddress.getByName(syslogHost);
         this.port = port;
-        //this.ds = new DatagramSocket();
     }
 
     public void write(byte[] byteArray, int offset, int len) throws IOException {

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -67,15 +67,23 @@ public class SyslogOutputStream extends OutputStream {
         if (bytes.length == 0) {
             return;
         }
-        if (this.ds != null) {
-            ds.send(packet);
-        }
 
+        sendAndClose(packet);
+    }
+
+    public void sendAndClose(DatagramPacket packet)throws IOException{
+        System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
+        System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
+        System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$;$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
+        if (this.ds == null || this.ds.isClosed()) {
+            ds = new DatagramSocket();
+        }
+        ds.send(packet);
+        CloseUtil.closeQuietly(ds);
     }
 
     public void close() {
         address = null;
-        CloseUtil.closeQuietly(ds);
         ds = null;
     }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -14,7 +14,6 @@
 package ch.qos.logback.core.net;
 
 import ch.qos.logback.core.util.CloseUtil;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -13,6 +13,8 @@
  */
 package ch.qos.logback.core.net;
 
+import ch.qos.logback.core.util.CloseUtil;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -73,6 +75,7 @@ public class SyslogOutputStream extends OutputStream {
 
     public void close() {
         address = null;
+        CloseUtil.closeQuietly(ds);
         ds = null;
     }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -44,7 +44,7 @@ public class SyslogOutputStream extends OutputStream {
     public SyslogOutputStream(String syslogHost, int port) throws UnknownHostException, SocketException {
         this.address = InetAddress.getByName(syslogHost);
         this.port = port;
-        this.ds = new DatagramSocket();
+        //this.ds = new DatagramSocket();
     }
 
     public void write(byte[] byteArray, int offset, int len) throws IOException {
@@ -67,14 +67,10 @@ public class SyslogOutputStream extends OutputStream {
         if (bytes.length == 0) {
             return;
         }
-
         sendAndClose(packet);
     }
 
     public void sendAndClose(DatagramPacket packet)throws IOException{
-        System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
-        System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
-        System.out.println("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$;$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
         if (this.ds == null || this.ds.isClosed()) {
             ds = new DatagramSocket();
         }
@@ -97,6 +93,9 @@ public class SyslogOutputStream extends OutputStream {
     }
 
     int getSendBufferSize() throws SocketException {
-        return ds.getSendBufferSize();
+        ds = new DatagramSocket();
+        int bs= ds.getSendBufferSize();
+        ds.close();
+        return bs;
     }
 }


### PR DESCRIPTION
Fix just targets opening and closing sockets just before and after its use.

Local Test Results :

Tests run: 493, Failures: 0, Errors: 0, Skipped: 7

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.139 s
[INFO] Finished at: 2018-10-04T11:34:11+05:30
[INFO] Final Memory: 16M/393M
