### PR TITLE
Fixed locale specific function to obtain correct result in Turkish locale environment.

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/names/DefaultDBNameResolver.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/names/DefaultDBNameResolver.java
@@ -13,6 +13,8 @@
  */
 package ch.qos.logback.classic.db.names;
 
+import java.util.Locale;
+
 /**
  * The default name resolver simply returns the enum passes as parameter
  * as a lower case string.
@@ -24,11 +26,11 @@ package ch.qos.logback.classic.db.names;
 public class DefaultDBNameResolver implements DBNameResolver {
 
     public <N extends Enum<?>> String getTableName(N tableName) {
-        return tableName.toString().toLowerCase();
+        return tableName.toString().toLowerCase(Locale.ENGLISH);
     }
 
     public <N extends Enum<?>> String getColumnName(N columnName) {
-        return columnName.toString().toLowerCase();
+        return columnName.toString().toLowerCase(Locale.ENGLISH);
     }
 
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/db/names/SimpleDBNameResolver.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/db/names/SimpleDBNameResolver.java
@@ -13,6 +13,8 @@
  */
 package ch.qos.logback.classic.db.names;
 
+import java.util.Locale;
+
 /**
  * Adds custom prefix/suffix to table and column names.
  *
@@ -30,11 +32,11 @@ public class SimpleDBNameResolver implements DBNameResolver {
     private String columnNameSuffix = "";
 
     public <N extends Enum<?>> String getTableName(N tableName) {
-        return tableNamePrefix + tableName.name().toLowerCase() + tableNameSuffix;
+        return tableNamePrefix + tableName.name().toLowerCase(Locale.ENGLISH) + tableNameSuffix;
     }
 
     public <N extends Enum<?>> String getColumnName(N columnName) {
-        return columnNamePrefix + columnName.name().toLowerCase() + columnNameSuffix;
+        return columnNamePrefix + columnName.name().toLowerCase(Locale.ENGLISH) + columnNameSuffix;
     }
 
     public void setTableNamePrefix(String tableNamePrefix) {


### PR DESCRIPTION
toLowerCase() function returns "ı" character instead of "i" in tr_TR.UTF-8 environment.
Examples: "loggıng_event","tımestmp","level_strıng"

ERROR:  relation "loggıng_event" does not exist at character 13                                                                                                                              
STATEMENT:  INSERT INTO loggıng_event (tımestmp, formatted_message, logger_name, level_strıng, thread_name, reference_flag, arg0, arg1, arg2, arg3, caller_fılename, caller_class, caller_met        hod, caller_lıne) VALUES ($1, $2, $3 ,$4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)

https://blog.codinghorror.com/whats-wrong-with-turkey/
