### PR TITLE
If casting ‘diff’ from 'long' to 'int' forcibly, it may overflow.

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
@@ -196,7 +196,7 @@ public class RollingCalendar extends GregorianCalendar {
             return diff / MILLIS_IN_ONE_MINUTE;
         case TOP_OF_HOUR:
 
-            return (int) diff / MILLIS_IN_ONE_HOUR;
+            return diff / MILLIS_IN_ONE_HOUR;
         case TOP_OF_DAY:
             return diff / MILLIS_IN_ONE_DAY;
         case TOP_OF_WEEK:


### PR DESCRIPTION
In my production environment, I found that logback cannot delete files out of date when the application is started up.

Finnaly, I find the code at [this line](https://github.com/qos-ch/logback/blob/4dd08e68321548cd85251ec389f5a832505e1268/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java#L199) which casts ‘diff’ from 'long' to 'int' forcibly will overflow when 'periodicityType' is 'TOP_OF_HOUR' and 'cleanHistoryOnStart' property is set to true.