### PR TITLE
Fix addBasicProperty so it properly supports complex types

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/util/PropertySetter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/util/PropertySetter.java
@@ -278,7 +278,7 @@ public class PropertySetter extends ContextAwareBase {
             return;
         }
         if (arg != null) {
-            invokeMethodWithSingleParameterOnThisObject(adderMethod, strValue);
+            invokeMethodWithSingleParameterOnThisObject(adderMethod, arg);
         }
     }
 


### PR DESCRIPTION
I found a bug in logback-core/Joran where it wouldn't call the `addValue(Value v)` property on my custom Layout class. The reason for this failure was that Joran, after converting the string into an instance of `Value` would then pass the original string as the sole argument for the reflection call to `addValue(Value v)`