### PR TITLE
Fix manual for Groovy's safe dereferencing operator

### DIFF
--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -2832,8 +2832,8 @@ logger.error(<b>notifyAdmin</b>,
 
     <p>Note that since the event may lack a marker, the value of
     e.marker can be null. Hence the use of Groovy's <a
-    href="http://groovy.codehaus.org/Null+Object+Pattern">safe
-    dereferencing operator</a>, that is the .? operator.
+    href="http://docs.groovy-lang.org/docs/next/html/documentation/design-pattern-in-groovy.html#_null_object_pattern">
+    safe dereferencing operator</a>, that is the ?. operator.
     </p>
 
 

--- a/logback-site/src/site/pages/manual/filters.html
+++ b/logback-site/src/site/pages/manual/filters.html
@@ -347,8 +347,8 @@ public class SampleFilter extends Filter&lt;ILoggingEvent> {
     value for "req.userAgent" matching the
     <code>/Googlebot|msnbot|Yahoo/</code> regular expression. Note
     that since the MDC map can be null, we are also using Groovy's <a
-    href="http://groovy.codehaus.org/Null+Object+Pattern">safe
-    dereferencing operator</a>, that is the ?. operator. The equivalent
+    href="http://docs.groovy-lang.org/docs/next/html/documentation/design-pattern-in-groovy.html#_null_object_pattern">
+    safe dereferencing operator</a>, that is the ?. operator. The equivalent
     logic would have been much longer if expressed in Java.
     </p>
     


### PR DESCRIPTION
Fix dead link and typo on manual about Groovy's safe dereferencing operator