### PR TITLE
Make property strings escapable

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/subst/Tokenizer.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/subst/Tokenizer.java
@@ -114,29 +114,42 @@ public class Tokenizer {
     private void handleLiteralState(char c, List<Token> tokenList, StringBuilder stringBuilder) {
         switch (c) {
         case CoreConstants.DOLLAR:
+            if (isEscaped(stringBuilder))
+                break;
             addLiteralToken(tokenList, stringBuilder);
             stringBuilder.setLength(0);
             state = TokenizerState.START_STATE;
-            break;
+            return;
         case CoreConstants.COLON_CHAR:
+            if (isEscaped(stringBuilder))
+                break;
             addLiteralToken(tokenList, stringBuilder);
             stringBuilder.setLength(0);
             state = TokenizerState.DEFAULT_VAL_STATE;
-            break;
+            return;
         case CoreConstants.CURLY_LEFT:
+            if (isEscaped(stringBuilder))
+                break;
             addLiteralToken(tokenList, stringBuilder);
             tokenList.add(Token.CURLY_LEFT_TOKEN);
             stringBuilder.setLength(0);
-            break;
+            return;
         case CoreConstants.CURLY_RIGHT:
+            if (isEscaped(stringBuilder))
+                break;
             addLiteralToken(tokenList, stringBuilder);
             tokenList.add(Token.CURLY_RIGHT_TOKEN);
             stringBuilder.setLength(0);
-            break;
-        default:
-            stringBuilder.append(c);
+            return;
         }
+        stringBuilder.append(c);
+    }
 
+    private boolean isEscaped(StringBuilder stringBuilder) {
+        boolean isEscaped = stringBuilder.length() > 0 && stringBuilder.charAt(stringBuilder.length() - 1) == CoreConstants.ESCAPE_CHAR;
+        if (isEscaped)
+            stringBuilder.setLength(stringBuilder.length() - 1);
+        return isEscaped;
     }
 
     private void addLiteralToken(List<Token> tokenList, StringBuilder stringBuilder) {


### PR DESCRIPTION
Currently it's not possible to escape strings like `${some.property}` in the logback.xml.
This is especially problematic when trying to use a replacement command with named groups in the appender pattern.
Therefore something like this will attempt to insert a property value instead of the named group: `%replace(%msg){'(?&lt;namedGroup>somestuffhere)', '${namedGroup}'}`.
I kept this example as simple (stupid) as possible for demonstration purposes since real world patterns where you need named groups often are pretty complex.

With this change, you can escape these property references via the `\` character, similar to how you escape `%` pattern keywords.
Example: `\$\{namedGroup\}`
In this first draft you need to escape all possible keywords (`$` `{` `:` `}`), but it'd be possible to implement a more advanced escaping detection so you just need a simple `\` in front of the `$`.