### PR TITLE
LOGBACK-1225 allows LogbackMDCAdapter.setContextMap() to accept a null value provided by getCopyOfContextMap()

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
@@ -13,12 +13,12 @@
  */
 package ch.qos.logback.classic.util;
 
+import org.slf4j.spi.MDCAdapter;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import org.slf4j.spi.MDCAdapter;
 
 /**
  * A <em>Mapped Diagnostic Context</em>, or MDC in short, is an instrument for
@@ -193,10 +193,14 @@ public class LogbackMDCAdapter implements MDCAdapter {
     public void setContextMap(Map<String, String> contextMap) {
         lastOperation.set(WRITE_OPERATION);
 
-        Map<String, String> newMap = Collections.synchronizedMap(new HashMap<String, String>());
-        newMap.putAll(contextMap);
+        if (contextMap == null) {
+            copyOnThreadLocal.remove();
+        } else {
+            Map<String, String> newMap = Collections.synchronizedMap(new HashMap<String, String>());
+            newMap.putAll(contextMap);
 
-        // the newMap replaces the old one for serialisation's sake
-        copyOnThreadLocal.set(newMap);
+            // the newMap replaces the old one for serialisation's sake
+            copyOnThreadLocal.set(newMap);
+        }
     }
 }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
@@ -13,12 +13,12 @@
  */
 package ch.qos.logback.classic.util;
 
-import org.slf4j.spi.MDCAdapter;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.slf4j.spi.MDCAdapter;
 
 /**
  * A <em>Mapped Diagnostic Context</em>, or MDC in short, is an instrument for

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterTest.java
@@ -13,14 +13,18 @@
  */
 package ch.qos.logback.classic.util;
 
-import ch.qos.logback.core.testUtil.RandomUtil;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import ch.qos.logback.core.testUtil.RandomUtil;
 
 public class LogbackMDCAdapterTest {
 

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterTest.java
@@ -13,18 +13,14 @@
  */
 package ch.qos.logback.classic.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import ch.qos.logback.core.testUtil.RandomUtil;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Test;
-import ch.qos.logback.core.testUtil.RandomUtil;
+import static org.junit.Assert.*;
 
 public class LogbackMDCAdapterTest {
 
@@ -92,6 +88,13 @@ public class LogbackMDCAdapterTest {
 
         // verify that map0 is the same instance and that value was updated
         assertSame(map0, mdcAdapter.copyOnThreadLocal.get());
+    }
+
+    @Test
+    public void setContextMapHandlesNull() {
+        mdcAdapter.setContextMap(null);
+        // Should not throw first of all and then
+        assertNull(mdcAdapter.getCopyOfContextMap());
     }
 
     // =================================================


### PR DESCRIPTION
The previous pull request did not respect the import ordering. This commit reverts the formatting changes made to the import statements while maintaining the code changes made by user dimas.