### PR TITLE
ConcurrentModificationException may be thrown when calling getCopyOfContextMap 

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
@@ -186,7 +186,12 @@ public class LogbackMDCAdapter implements MDCAdapter {
         if (hashMap == null) {
             return null;
         } else {
-            return new HashMap<String, String>(hashMap);
+            // it is possible gets a reference of this thread local from OTHER threads, (e.g for debugging purposes), and modify it
+            // so we don't want an exception when we make a copy of this map, hence we need to synchronize when iterating over it
+            //noinspection SynchronizationOnLocalVariableOrMethodParameter
+            synchronized (hashMap) {
+                return new HashMap<String, String>(hashMap);
+            }
         }
     }
 


### PR DESCRIPTION
ConcurrentModificationException may be thrown when calling LogbackMDCAdapter.getCopyOfContextMap when iterating over the thread local map, synchronizing over it during iteration would solve the problem.

it can happen when an external thread gets a reference of this map (even though this is thread local), e.g for debugging purposes, and modifies it