### PR TITLE
LOGBACK-1000 MDC default value is not parsed

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
@@ -13,23 +13,31 @@
  */
 package ch.qos.logback.classic.pattern;
 
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 import java.util.Map;
 
-import static ch.qos.logback.core.util.OptionHelper.extractDefaultReplacement;
+import ch.qos.logback.core.util.OptionHelper;
 
 public class MDCConverter extends ClassicConverter {
 
     private String key;
-    private String defaultValue = "";
+    private PatternLayout defaultValue = new PatternLayout();
 
     @Override
     public void start() {
-        String[] keyInfo = extractDefaultReplacement(getFirstOption());
+        String[] keyInfo = OptionHelper.extractDefaultReplacement(getFirstOption());
         key = keyInfo[0];
         if (keyInfo[1] != null) {
-            defaultValue = keyInfo[1];
+            if (getContext() != null) {
+                defaultValue.setContext(getContext());
+            } else {
+                defaultValue.setContext(new LoggerContext());
+            }
+            defaultValue.setPattern(keyInfo[1]);
+            defaultValue.start();
         }
         super.start();
     }
@@ -45,7 +53,7 @@ public class MDCConverter extends ClassicConverter {
         Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
 
         if (mdcPropertyMap == null) {
-            return defaultValue;
+            return defaultValue.doLayout(event);
         }
 
         if (key == null) {
@@ -56,7 +64,7 @@ public class MDCConverter extends ClassicConverter {
             if (value != null) {
                 return value;
             } else {
-                return defaultValue;
+                return defaultValue.doLayout(event);
             }
         }
     }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
@@ -28,7 +28,7 @@ public class MDCConverter extends ClassicConverter {
 
     @Override
     public void start() {
-        String[] keyInfo = OptionHelper.extractDefaultReplacement(getFirstOption());
+        String[] keyInfo = OptionHelper.extractDefaultReplacement(String.join("",getOptionList()));
         key = keyInfo[0];
         if (keyInfo[1] != null) {
             if (getContext() != null) {

--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/MDCConverter.java
@@ -28,7 +28,10 @@ public class MDCConverter extends ClassicConverter {
 
     @Override
     public void start() {
-        String[] keyInfo = OptionHelper.extractDefaultReplacement(String.join("",getOptionList()));
+        String[] keyInfo = new String[2];
+        if (getOptionList() != null) {
+            keyInfo = OptionHelper.extractDefaultReplacement(String.join("",getOptionList()));
+        }
         key = keyInfo[0];
         if (keyInfo[1] != null) {
             if (getContext() != null) {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
@@ -153,6 +153,20 @@ public class PatternLayoutTest extends AbstractPatternLayoutBaseTest<ILoggingEve
     }
 
     @Test
+    public void mdcWithNestedDefaultValue() {
+        String pattern = "%thread %mdc{ndef:-%msg} %mdc{abc:-%mdc{xyz:-%mdc{bar:-%date{ISO8601}}}}";
+        pl.setPattern(OptionHelper.substVars(pattern, lc));
+        pl.start();
+        MDC.put("bar", "bar");
+        try {
+            String val = pl.doLayout(getEventObject());
+            assertEquals("main Some message bar", val);
+        } finally {
+            MDC.remove("bar");
+        }
+    }
+
+    @Test
     public void contextNameTest() {
         pl.setPattern("%contextName");
         lc.setName("aValue");


### PR DESCRIPTION
https://jira.qos.ch/browse/LOGBACK-1000

Pattern conversion words used as the default value of an MDC conversion word are detected and converted. As an example, the pattern `%X{akkaSource:-%logger}` will try to use the MDC context for key `akkaSource` and will fall back on the built-in `%logger` conversion if no such MDC exists.