### PR TITLE
LayoutWrappingEncoder#isStarted should return actual started state

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/encoder/PatternLayoutEncoderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/encoder/PatternLayoutEncoderTest.java
@@ -77,4 +77,10 @@ public class PatternLayoutEncoderTest {
         assertEquals(msg, new String(baos.toByteArray(), utf8Charset));
     }
 
+    @Test
+    public void isStarted() throws IOException {
+        assertTrue(!ple.isStarted());
+        ple.start();
+        assertTrue(ple.isStarted());
+    }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
@@ -115,7 +115,7 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
     }
 
     public boolean isStarted() {
-        return false;
+        return started;
     }
 
     public void start() {


### PR DESCRIPTION
This doesn't seem like it's actually that important, but I was trying to write some tests to make sure I was configuring my application's logger correctly and I found that the encoder I was configuring always returned `false` for `isStarted`. It's not obvious to me that this should be the case, so this PR updates `LayoutWrappingEncoder#isStarted` to return the actual value of the protected `started` member. I added a test to a descendant class because I didn't see where `LayoutWrappingEncoder` was tested directly.