### PR TITLE
Remove an unused import in LogbackValve

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
@@ -67,8 +67,6 @@ import ch.qos.logback.core.util.Loader;
 import ch.qos.logback.core.util.OptionHelper;
 import ch.qos.logback.core.util.StatusListenerConfigHelper;
 
-//import org.apache.catalina.Lifecycle;
-
 /**
  * This class is an implementation of tomcat's Valve interface, by extending
  * ValveBase.


### PR DESCRIPTION
This PR simply removes an unused `import` statement which is already commented out in `LogbackValve`.