### PR TITLE
Update TimeBasedRollingPolicy.java

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedRollingPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedRollingPolicy.java
@@ -166,7 +166,7 @@ public class TimeBasedRollingPolicy<E> extends RollingPolicyBase implements Trig
         String elapsedPeriodStem = FileFilterUtil.afterLastSlash(elapsedPeriodsFileName);
 
         if (compressionMode == CompressionMode.NONE) {
-            if (getParentsRawFileProperty() != null) {
+            if (getParentsRawFileProperty() != null && !new File(elapsedPeriodsFileName).exists()) {
                 renameUtil.rename(getParentsRawFileProperty(), elapsedPeriodsFileName);
             } // else { nothing to do if CompressionMode == NONE and parentsRawFileProperty == null }
         } else {


### PR DESCRIPTION
There may be a problem here. 
The log configurations of two load balancing projects are exactly the same, and they are all attached to the same log. 
When the log rollover at 0'clock, there will be repeated renaming operations in Linux environment, resulting in log confusion. 
So we can add a judgment that if elapsedperiodsfile already exists, there is no need to rename it.
Thank you!