### PR TITLE
LOGBACK-1491 add exports of ch.qos.logback.classic.model.processor

### DIFF
--- a/logback-classic/src/main/java9/module-info.java
+++ b/logback-classic/src/main/java9/module-info.java
@@ -22,6 +22,7 @@ module ch.qos.logback.classic {
   exports ch.qos.logback.classic.jul;
   exports ch.qos.logback.classic.layout;
   exports ch.qos.logback.classic.log4j;
+  exports ch.qos.logback.classic.model.processor;
   exports ch.qos.logback.classic.net;
   exports ch.qos.logback.classic.net.server;
   exports ch.qos.logback.classic.pattern;


### PR DESCRIPTION
add exports of ch.qos.logback.classic.model.processor to the
module-info.java of the module logback-classic to allow the module
logback-core to instanciate the class
ch.qos.logback.classic.model.processor.ConfigurationModelHandler in
ch.qos.logback.core.model.processor.DefaultProcessor::instantiateHandler.