### PR TITLE
LOGBACK-1498 When excluding stack trace elements never exclude the fi…

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/ThrowableProxyConverter.java
@@ -194,7 +194,7 @@ public class ThrowableProxyConverter extends ThrowableHandlingConverter {
         int ignoredCount = 0;
         for (int i = 0; i < maxIndex; i++) {
             StackTraceElementProxy element = stepArray[i];
-            if (!isIgnoredStackTraceLine(element.toString())) {
+            if (i ==0 || !isIgnoredStackTraceLine(element.toString())) {
                 ThrowableProxyUtil.indent(buf, indent);
                 printStackLine(buf, ignoredCount, element);
                 ignoredCount = 0;

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ThrowableProxyConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ThrowableProxyConverterTest.java
@@ -159,6 +159,24 @@ public class ThrowableProxyConverterTest {
     }
 
     @Test
+    public void skipSelectedLinesButAlwaysIncludeExceptionOrigin() throws Exception {
+        String nameOfContainingMethod = "skipSelectedLine";
+        // given
+        final Throwable t = TestHelper.makeNestedException(0);
+        t.printStackTrace(pw);
+        final ILoggingEvent le = createLoggingEvent(t);
+        tpc.setOptionList(Arrays.asList("full", nameOfContainingMethod, "makeNestedException"));
+        tpc.start();
+
+        // when
+        final String result = tpc.convert(le);
+
+        // then
+        assertThat(result).doesNotContain(nameOfContainingMethod).contains("makeNestedException");
+
+    }
+
+    @Test
     public void skipSelectedLine() throws Exception {
         String nameOfContainingMethod = "skipSelectedLine";
         // given


### PR DESCRIPTION
…rst one.

The first stack trace element should always be reported since this is where the problem occurs.