### PR TITLE
Make formatted_message column nullable

### DIFF
--- a/logback-classic/src/main/resources/ch/qos/logback/classic/db/script/mysql.sql
+++ b/logback-classic/src/main/resources/ch/qos/logback/classic/db/script/mysql.sql
@@ -21,7 +21,7 @@ BEGIN;
 CREATE TABLE logging_event 
   (
     timestmp         BIGINT NOT NULL,
-    formatted_message  TEXT NOT NULL,
+    formatted_message  TEXT NULL,
     logger_name       VARCHAR(254) NOT NULL,
     level_string      VARCHAR(254) NOT NULL,
     thread_name       VARCHAR(254),


### PR DESCRIPTION
Exceptions may have a null message (like NullPointerException). When writting something like:
``
try {
    ...
} catch (Exception e) {
    log.error(e.getMessage(), e);
}
``
Null message exceptions get logged in stdout for example, but not in DB because of the formatted_message column not accepting null values.
I know only MySQL so I didn't touch the other script files.