### PR TITLE
Maven Reproducible builds

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -137,6 +137,7 @@
             </Import-Package>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.6
             </Bundle-RequiredExecutionEnvironment>
+            <_removeheaders>Bnd-LastModified</_removeheaders>
           </instructions>
         </configuration>
       </plugin>

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -326,6 +326,7 @@
             <!-- Needed to integrate ServiceLoader mechanism with OSGi -->
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability> 
   			<Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider</Provide-Capability>
+  			<_removeheaders>Bnd-LastModified</_removeheaders>
     
     
           </instructions>

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -142,6 +142,7 @@
             </Import-Package>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.6
             </Bundle-RequiredExecutionEnvironment>
+            <_removeheaders>Bnd-LastModified</_removeheaders>
           </instructions>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <site-plugin.version>3.7.1</site-plugin.version>
     <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <license-plugin.version>3.0</license-plugin.version>
+    <project.build.outputTimestamp>2020-03-31T20:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <developers>
@@ -281,7 +282,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.3.1</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -301,7 +302,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.1.2</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Add new build properties and update maven jar and maven source plugins version.

Context of the change: 
Make logback builds reproducible regarding the [Guide to Configuring for Reproducible Builds](https://maven.apache.org/guides/mini/guide-reproducible-builds.html)

The work is done with help of @hboutemy to achieve the goal.

