### PR TITLE
modify StartEvent.java toString value

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/event/StartEvent.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/event/StartEvent.java
@@ -40,8 +40,7 @@ public class StartEvent extends SaxEvent {
         b.append(getQName());
         if(attributes != null) {
             for(int i = 0; i < attributes.getLength(); i++) {
-                if(i > 0) 
-                    b.append(' ');
+                b.append(' ');
                 b.append(attributes.getLocalName(i)).append("=\"").append(attributes.getValue(i)).append("\"");
             }
         }


### PR DESCRIPTION
we  can get a better view values when debugging, like "StartEvent(configuration debug="false" scanPeriod="30 seconds")  [21,54]", instead of "StartEvent(configurationdebug="false" scanPeriod="30 seconds")  [21,54]"