### PR TITLE
Fix Manual Configuration typo

### DIFF
--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -1859,7 +1859,7 @@ fileName=myApp.log
 
  
 
-  <p>At the present time, logback does ships with two fairly simple
+  <p>At the present time, logback does ships with three fairly simple
   implementations of <code>PropertyDefiner</code>.  
   </p>
 


### PR DESCRIPTION
logback does ships with two fairly simple implementations of <code>PropertyDefiner</code>, where two should be fixed as "three", obviously