### PR TITLE
Ensure periods go back to max history when cleaning files due to total size cap

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -95,8 +95,8 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
     void capTotalSize(Date now) {
         long totalSize = 0;
         long totalRemoved = 0;
-        for (int offset = 0; offset < maxHistory; offset++) {
-            Date date = rc.getEndOfNextNthPeriod(now, -offset);
+        for (int offset = 0; offset > getPeriodOffsetForDeletionTarget(); offset--) {
+            Date date = rc.getEndOfNextNthPeriod(now, offset);
             File[] matchingFileArray = getFilesInPeriod(date);
             descendingSort(matchingFileArray, date);
             for (File f : matchingFileArray) {


### PR DESCRIPTION
In reference to issue https://jira.qos.ch/browse/LOGBACK-1531

I noticed that other tests were using a common framework to simulate running a TimeBasedRollingPolicy however I wasn't sure how to modify that for my test case so I've implemented something without the framework. If that's a problem I could iterate on that. Wanted to first see if you agree this is a bug and that the fix is good.