### PR TITLE
Use isEmpty() instead of using equals() to check whether string is empty

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/OptionHelper.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/OptionHelper.java
@@ -19,7 +19,6 @@ import java.util.Properties;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.qos.logback.core.Context;
-import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.PropertyContainer;
 import ch.qos.logback.core.spi.ScanException;
@@ -260,7 +259,7 @@ public class OptionHelper {
     }
 
     public static boolean isNullOrEmpty(@Nullable String str) {
-        return ((str == null) || CoreConstants.EMPTY_STRING.equals(str.trim()));
+        return ((str == null) || str.trim().isEmpty());
     }
 
 }


### PR DESCRIPTION
Using isEmpty() gives better performance in the hot paths. 
*Reference:* Post comparing different implementations of String empty checks and it's performance impact. https://medium.com/javarevisited/micro-optimizations-in-java-string-equals-22be19fd8416