### PR TITLE
asyncAppender cannot refer to itself

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -245,6 +245,12 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
     }
 
     public void addAppender(Appender<E> newAppender) {
+
+        if (newAppender == this) {
+            addError("Ignoring asyncAppender named [ " + newAppender.getName() + "] because asyncAppender cannot refer to itself");
+            return;
+        }
+
         if (appenderCount == 0) {
             appenderCount++;
             addInfo("Attaching appender named [" + newAppender.getName() + "] to AsyncAppender.");


### PR DESCRIPTION
When users configure appender, they often copy the existing configuration directly. Because the user is careless, the asynchronous appender often configures to point to itself, resulting in hang when the request thread writes the log, and the system cannot provide services. This kind of careless configuration has caused several failures in our company. We hope that the wrong configuration can be ignored when adding appender, so as to improve the stability of logback.

config below：

`<?xml version="1.0" encoding="UTF-8"?>
<configuration>
    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
        <!-- encoder 默认配置为PatternLayoutEncoder -->
        <encoder>
            <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss}  %msg%n</pattern>
        </encoder>
    </appender>
    <appender name="testAppender" class="ch.qos.logback.core.FileAppender">
        <File>/Users/eye/workplace/learn/info/src/main/webapp/WEB-INF/logback.log</File>
        <Append>true</Append>
        <encoder>
            <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss}  %msg%n</pattern>
        </encoder>
        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
            <level>INFO</level>
        </filter>
    </appender>
    <!-- 异步输出 -->
    <appender name="testAppenderAsync" class="ch.qos.logback.classic.AsyncAppender">
        <!-- 不丢失日志.默认的,如果队列的80%已满,则会丢弃TRACT、DEBUG、INFO级别的日志 -->
        <discardingThreshold>0</discardingThreshold>
        <!-- 更改默认的队列的深度,该值会影响性能.默认值为256 -->
        <queueSize>10</queueSize>
        <!-- 添加附加的appender,最多只能添加一个 -->
        <appender-ref ref="testAppenderAsync"/>
    </appender>

    <logger name="testLogger" level="TRACE" additivity="false">
        <appender-ref ref="testAppenderAsync"/>
    </logger>
</configuration>`


test code：
`public class TestLogbackHang {

    public static void main(String[] args) throws Exception {
        load();
        Logger logger = LoggerFactory.getLogger("testLogger");

        for (int i = 0; i < 100; i++) {
            logger.info("back " + i);
        }

    }

    public static void load() throws IOException, JoranException {
        LoggerContext lc = (LoggerContext)LoggerFactory.getILoggerFactory();
        File externalConfigFile = new File("/Users/eye/workplace/learn/info/src/main/webapp/WEB-INF/logback.xml");
        if (!externalConfigFile.exists()) {
            throw new IOException("Logback External Config File Parameter does not reference a file that exists");
        } else {
            if (!externalConfigFile.isFile()) {
                throw new IOException("Logback External Config File Parameter exists, but does not reference a file");
            } else {
                if (!externalConfigFile.canRead()) {
                    throw new IOException("Logback External Config File exists and is a file, but cannot be read.");
                } else {
                    JoranConfigurator configurator = new JoranConfigurator();
                    configurator.setContext(lc);
                    lc.reset();
                    configurator.doConfigure("/Users/eye/workplace/learn/info/src/main/webapp/WEB-INF/logback.xml");
                    StatusPrinter.printInCaseOfErrorsOrWarnings(lc);
                }
            }
        }
    }

}
`
