### PR TITLE
module-info.java missing dependency on java.logging

### DIFF
--- a/logback-classic/src/main/java9/module-info.java
+++ b/logback-classic/src/main/java9/module-info.java
@@ -1,4 +1,5 @@
 module ch.qos.logback.classic { 
+  requires java.logging;
   requires org.slf4j;
   requires static java.management;
   requires static javax.servlet.api;


### PR DESCRIPTION
class `ch.qos.logback.classic.jul.JULHelper` requires `java.logging`.

Relevant stack trace is:

```
Exception in thread "main" java.lang.IllegalAccessError: class ch.qos.logback.classic.jul.JULHelper (in module ch.qos.logback.classic) cannot access class java.util.logging.Logger (in module java.logging) because module ch.qos.logback.classic does not read module java.logging
	at ch.qos.logback.classic/ch.qos.logback.classic.jul.JULHelper.asJULLogger(JULHelper.java:66)
	at ch.qos.logback.classic/ch.qos.logback.classic.jul.JULHelper.asJULLogger(JULHelper.java:70)
	at ch.qos.logback.classic/ch.qos.logback.classic.jul.LevelChangePropagator.propagate(LevelChangePropagator.java:61)
	at ch.qos.logback.classic/ch.qos.logback.classic.jul.LevelChangePropagator.propagateExistingLoggerLevels(LevelChangePropagator.java:88)
	at ch.qos.logback.classic/ch.qos.logback.classic.jul.LevelChangePropagator.start(LevelChangePropagator.java:97)
	at ch.qos.logback.classic/ch.qos.logback.classic.joran.action.LoggerContextListenerAction.end(LoggerContextListenerAction.java:70)
	at ch.qos.logback.core/ch.qos.logback.core.joran.spi.Interpreter.callEndAction(Interpreter.java:309)
	at ch.qos.logback.core/ch.qos.logback.core.joran.spi.Interpreter.endElement(Interpreter.java:193)
	at ch.qos.logback.core/ch.qos.logback.core.joran.spi.Interpreter.endElement(Interpreter.java:179)
	at ch.qos.logback.core/ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:62)
	at ch.qos.logback.core/ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
	at ch.qos.logback.core/ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
	at ch.qos.logback.core/ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
	at ch.qos.logback.core/ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
	at ch.qos.logback.classic/ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:82)
	at ch.qos.logback.classic/ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:157)
	at ch.qos.logback.classic/ch.qos.logback.classic.spi.LogbackServiceProvider.initializeLoggerContext(LogbackServiceProvider.java:49)
	at ch.qos.logback.classic/ch.qos.logback.classic.spi.LogbackServiceProvider.initialize(LogbackServiceProvider.java:40)
	at org.slf4j/org.slf4j.LoggerFactory.bind(LoggerFactory.java:152)
	at org.slf4j/org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:139)
	at org.slf4j/org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:418)
	at org.slf4j/org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:404)
	at org.slf4j/org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:353)
```