### PR TITLE
Improve subAppend method

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java
@@ -227,8 +227,7 @@ public class OutputStreamAppender<E> extends UnsynchronizedAppenderBase<E> {
             // converter. Converters assume that they are in a synchronized block.
             // lock.lock();
 
-            byte[] byteArray = this.encoder.encode(event);
-            writeBytes(byteArray);
+            writeOut(event);
 
         } catch (IOException ioe) {
             // as soon as an exception occurs, move to non-started state


### PR DESCRIPTION
```
protected void subAppend(E event) {
        if (!isStarted()) {
            return;
        }
        try {
            // this step avoids LBCLASSIC-139
            if (event instanceof DeferredProcessingAware) {
                ((DeferredProcessingAware) event).prepareForDeferredProcessing();
            }
            // the synchronization prevents the OutputStream from being closed while we
            // are writing. It also prevents multiple threads from entering the same
            // converter. Converters assume that they are in a synchronized block.
            // lock.lock();

            byte[] byteArray = this.encoder.encode(event);
            writeBytes(byteArray);

        } catch (IOException ioe) {
            // as soon as an exception occurs, move to non-started state
            // and add a single ErrorStatus to the SM.
            this.started = false;
            addStatus(new ErrorStatus("IO failure in appender", this, ioe));
        }
    }
```
```
            byte[] byteArray = this.encoder.encode(event);
            writeBytes(byteArray);
```
these 2 lines can replace by `writeOut(event);`. that allow user implement their own `writeOut` method.