### PR TITLE
TimeBasedRolling should allow timestamp gets smaller

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/DefaultTimeBasedFileNamingAndTriggeringPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/DefaultTimeBasedFileNamingAndTriggeringPolicy.java
@@ -45,7 +45,7 @@ public class DefaultTimeBasedFileNamingAndTriggeringPolicy<E> extends TimeBasedF
 
     public boolean isTriggeringEvent(File activeFile, final E event) {
         long time = getCurrentTime();
-        if (time >= nextCheck) {
+        if (time >= nextCheck || time < previousCheck) {
             Date dateOfElapsedPeriod = dateInCurrentPeriod;
             addInfo("Elapsed period: " + dateOfElapsedPeriod);
             elapsedPeriodsFileName = tbrp.fileNamePatternWithoutCompSuffix.convert(dateOfElapsedPeriod);

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -139,7 +139,7 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
         long time = getCurrentTime();
 
         // first check for roll-over based on time
-        if (time >= nextCheck) {
+        if (time >= nextCheck || time < previousCheck) {
             Date dateInElapsedPeriod = dateInCurrentPeriod;
             elapsedPeriodsFileName = tbrp.fileNamePatternWithoutCompSuffix.convertMultipleArguments(dateInElapsedPeriod, currentPeriodsCounter);
             currentPeriodsCounter = 0;

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
@@ -39,6 +39,7 @@ abstract public class TimeBasedFileNamingAndTriggeringPolicyBase<E> extends Cont
     protected Date dateInCurrentPeriod = null;
 
     protected long nextCheck;
+    protected long previousCheck;
     protected boolean started = false;
     protected boolean errorFree = true;
 
@@ -84,6 +85,7 @@ abstract public class TimeBasedFileNamingAndTriggeringPolicyBase<E> extends Cont
 
     protected void computeNextCheck() {
         nextCheck = rc.getNextTriggeringDate(dateInCurrentPeriod).getTime();
+        previousCheck = rc.getEndOfNextNthPeriod(dateInCurrentPeriod, 0).getTime();
     }
 
     protected void setDateInCurrentPeriod(long now) {


### PR DESCRIPTION
If a computer has a service of NTP client, then its system time may go to a previous value, so it should help if triggering policies check both the lower boundary and the upper one.