### PR TITLE
LOGBACK-888: Add possibility to mark property file/resource as optional

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/joran/action/PropertyActionTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/joran/action/PropertyActionTest.java
@@ -16,8 +16,6 @@ package ch.qos.logback.core.joran.action;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Iterator;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,8 +23,6 @@ import org.junit.Test;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.ContextBase;
 import ch.qos.logback.core.joran.spi.InterpretationContext;
-import ch.qos.logback.core.status.ErrorStatus;
-import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.util.CoreTestConstants;
 import ch.qos.logback.core.util.StatusPrinter;
 
@@ -145,18 +141,38 @@ public class PropertyActionTest {
         atts.setValue("file", "toto");
         propertyAction.begin(ec, null, atts);
         assertEquals(1, context.getStatusManager().getCount());
-        assertTrue(checkFileErrors());
+        assertEquals("Could not find properties file [toto].", getFirstStatusMessage());
+    }
+
+    @Test
+    public void testLoadOptionalMissingFile() {
+        atts.setValue("file", "toto");
+        atts.setValue("optional", "true");
+        propertyAction.begin(ec, null, atts);
+        assertEquals(0, context.getStatusManager().getCount());
+    }
+
+    @Test
+    public void testLoadResourceNotPossible() {
+        atts.setValue("resource", "toto");
+        propertyAction.begin(ec, null, atts);
+        assertEquals(1, context.getStatusManager().getCount());
+        assertEquals("Could not find resource [toto].", getFirstStatusMessage());
+    }
+
+    @Test
+    public void testLoadOptionalMissingResource() {
+        atts.setValue("resource", "toto");
+        atts.setValue("optional", "true");
+        propertyAction.begin(ec, null, atts);
+        assertEquals(0, context.getStatusManager().getCount());
     }
 
     private boolean checkError() {
-        Iterator<Status> it = context.getStatusManager().getCopyOfStatusList().iterator();
-        ErrorStatus es = (ErrorStatus) it.next();
-        return PropertyAction.INVALID_ATTRIBUTES.equals(es.getMessage());
+        return PropertyAction.INVALID_ATTRIBUTES.equals(getFirstStatusMessage());
     }
 
-    private boolean checkFileErrors() {
-        Iterator<Status> it = context.getStatusManager().getCopyOfStatusList().iterator();
-        ErrorStatus es1 = (ErrorStatus) it.next();
-        return "Could not find properties file [toto].".equals(es1.getMessage());
+    private String getFirstStatusMessage() {
+        return context.getStatusManager().getCopyOfStatusList().get(0).getMessage();
     }
 }

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -1639,6 +1639,13 @@ import ch.qos.logback.classic.LoggerContext;
 &lt;/configuration></pre>
 
 
+   <p>If the specified file or resource cannot be found, logback will
+   throw an error. In case the included file is optional, you can suppress
+   that error by setting <span class="attr">optional</span> attribute to
+   <code>true</code> in the <code>&lt;property&gt;</code> element.</p>
+
+   <pre class="prettyprint source">&lt;property <b>optional="true"</b> ... /></pre>
+
    <h4 class="doAnchor" name="scopes">Scopes</h4>
 
    <p>A property can be defined for insertion in <em>local scope</em>,


### PR DESCRIPTION
Support attribute "optional" in property element.

Similar to the already existing support in the include element, it
prevents errors loading non-existent property files/resources.