### PR TITLE
LOGBACK-888: Add possibility to mark property file/resource as optional

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/PropertyAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/PropertyAction.java
@@ -28,6 +28,7 @@ import ch.qos.logback.core.model.PropertyModel;
 public class PropertyAction extends BaseModelAction {
 
     static final String RESOURCE_ATTRIBUTE = "resource";
+    static final String OPTIONAL_ATTRIBUTE = "optional";
 
 
     @Override
@@ -46,6 +47,7 @@ public class PropertyAction extends BaseModelAction {
         propertyModel.setScopeStr(attributes.getValue(SCOPE_ATTRIBUTE));
         propertyModel.setFile(attributes.getValue(FILE_ATTRIBUTE));
         propertyModel.setResource(attributes.getValue(RESOURCE_ATTRIBUTE));
+        propertyModel.setOptional(attributes.getValue(OPTIONAL_ATTRIBUTE));
         return propertyModel;
     }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/model/PropertyModel.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/model/PropertyModel.java
@@ -8,6 +8,7 @@ public class PropertyModel extends NamedModel {
 
     String file;
     String resource;
+    String optional;
 
 
     public String getValue() {
@@ -42,4 +43,11 @@ public class PropertyModel extends NamedModel {
         this.resource = resource;
     }
 
+    public String getOptional() {
+        return optional;
+    }
+
+    public void setOptional(String optional) {
+        this.optional = optional;
+    }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/model/processor/PropertyModelHandler.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/model/processor/PropertyModelHandler.java
@@ -19,8 +19,8 @@ import ch.qos.logback.core.util.OptionHelper;
 
 public class PropertyModelHandler extends ModelHandlerBase {
 
-    public static final String INVALID_ATTRIBUTES = "In <property> element, either the \"file\" attribute alone, or "
-                    + "the \"resource\" element alone, or both the \"name\" and \"value\" attributes must be set.";
+    public static final String INVALID_ATTRIBUTES = "In <property> element, set either both \"name\" and \"value\" "
+                    + "attributes, or one of \"file\" or \"resource\" (optionally paired with \"optional\").";
 
     public PropertyModelHandler(Context context) {
         super(context);
@@ -46,7 +46,9 @@ public class PropertyModelHandler extends ModelHandlerBase {
                 FileInputStream istream = new FileInputStream(file);
                 loadAndSetProperties(interpretationContext, istream, scope);
             } catch (FileNotFoundException e) {
-                addError("Could not find properties file [" + file + "].");
+                if (!OptionHelper.toBoolean(propertyModel.getOptional(), false)) {
+                    addError("Could not find properties file [" + file + "].");
+                }
             } catch (IOException e1) {
                 addError("Could not read properties file [" + file + "].", e1);
             }
@@ -55,7 +57,9 @@ public class PropertyModelHandler extends ModelHandlerBase {
             resource = interpretationContext.subst(resource);
             URL resourceURL = Loader.getResourceBySelfClassLoader(resource);
             if (resourceURL == null) {
-                addError("Could not find resource [" + resource + "].");
+                if (!OptionHelper.toBoolean(propertyModel.getOptional(), false)) {
+                    addError("Could not find resource [" + resource + "].");
+                }
             } else {
                 try {
                     InputStream istream = resourceURL.openStream();
@@ -106,6 +110,10 @@ public class PropertyModelHandler extends ModelHandlerBase {
         String name = propertyModel.getName();
         String value = propertyModel.getValue();
         String resource = propertyModel.getResource();
+
+        // Note: not checking that the "optional" attribute is empty because there's a risk that doing so would cause
+        // problems and break existing configuration files.
+
         return (!(OptionHelper.isNullOrEmpty(name) || OptionHelper.isNullOrEmpty(value)) && (OptionHelper.isNullOrEmpty(file) && OptionHelper.isNullOrEmpty(resource)));
     }
 

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -1643,6 +1643,12 @@ import ch.qos.logback.classic.LoggerContext;
    &lt;/root>
 &lt;/configuration></pre>
 
+   <p>If the specified file or resource cannot be found, logback will
+   throw an error. In case the included file is optional, you can suppress
+   that error by setting <span class="attr">optional</span> attribute to
+   <code>true</code> in the <code>&lt;property&gt;</code> element.</p>
+
+   <pre class="prettyprint source">&lt;property <b>optional="true"</b> ... /></pre>
 
    <h4 class="doAnchor" name="scopes">Scopes</h4>
 


### PR DESCRIPTION
Support attribute "optional" in property element.

Similar to the already existing support in the include element, it
prevents errors loading non-existent property files/resources.