### PR TITLE
Backport fix for LOGBACK-1027 from 1.3.x.

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxy.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/ThrowableProxy.java
@@ -15,8 +15,11 @@ package ch.qos.logback.classic.spi;
 
 import ch.qos.logback.core.CoreConstants;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
 
 public class ThrowableProxy implements IThrowableProxy {
 
@@ -29,59 +32,52 @@ public class ThrowableProxy implements IThrowableProxy {
     int commonFrames;
     private ThrowableProxy cause;
     private ThrowableProxy[] suppressed = NO_SUPPRESSED;
+    private final Set<Throwable> alreadyProcessedSet;
 
     private transient PackagingDataCalculator packagingDataCalculator;
     private boolean calculatedPackageData = false;
 
-    private static final Method GET_SUPPRESSED_METHOD;
-
-    static {
-        Method method = null;
-        try {
-            method = Throwable.class.getMethod("getSuppressed");
-        } catch (NoSuchMethodException e) {
-            // ignore, will get thrown in Java < 7
-        }
-        GET_SUPPRESSED_METHOD = method;
-    }
-
     private static final ThrowableProxy[] NO_SUPPRESSED = new ThrowableProxy[0];
 
     public ThrowableProxy(Throwable throwable) {
+        // Using Collections.newSetFromMap(new IdentityHashMap<>()) is inspired from
+        // Throwable.printStackTrace(PrintStreamOrWriter):
+        // Guard against malicious overrides of Throwable.equals by
+        // using a Set with identity equality semantics.
+        this(throwable, Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>()));
+    }
+
+    public ThrowableProxy(Throwable throwable, Set<Throwable> alreadyProcessedSet) {
 
         this.throwable = throwable;
         this.className = throwable.getClass().getName();
         this.message = throwable.getMessage();
         this.stackTraceElementProxyArray = ThrowableProxyUtil.steArrayToStepArray(throwable.getStackTrace());
+        this.alreadyProcessedSet = alreadyProcessedSet;
+
+        alreadyProcessedSet.add(throwable);
 
         Throwable nested = throwable.getCause();
 
-        if (nested != null) {
-            this.cause = new ThrowableProxy(nested);
+        if (nested != null && !alreadyProcessedSet.contains(nested)) {
+            this.cause = new ThrowableProxy(nested, alreadyProcessedSet);
             this.cause.commonFrames = ThrowableProxyUtil.findNumberOfCommonFrames(nested.getStackTrace(), stackTraceElementProxyArray);
         }
-        if (GET_SUPPRESSED_METHOD != null) {
-            // this will only execute on Java 7
-            try {
-                Object obj = GET_SUPPRESSED_METHOD.invoke(throwable);
-                if (obj instanceof Throwable[]) {
-                    Throwable[] throwableSuppressed = (Throwable[]) obj;
-                    if (throwableSuppressed.length > 0) {
-                        suppressed = new ThrowableProxy[throwableSuppressed.length];
-                        for (int i = 0; i < throwableSuppressed.length; i++) {
-                            this.suppressed[i] = new ThrowableProxy(throwableSuppressed[i]);
-                            this.suppressed[i].commonFrames = ThrowableProxyUtil.findNumberOfCommonFrames(throwableSuppressed[i].getStackTrace(),
-                                            stackTraceElementProxyArray);
-                        }
-                    }
+        Throwable[] throwableSuppressed = throwable.getSuppressed();
+        if (throwableSuppressed.length > 0) {
+            List<ThrowableProxy> suppressedList = new ArrayList<ThrowableProxy>(throwableSuppressed.length);
+            for (int i = 0; i < throwableSuppressed.length; i++) {
+                Throwable sup = throwableSuppressed[i];
+                if (alreadyProcessedSet.contains(sup)) {
+                    continue; // loop detected
                 }
-            } catch (IllegalAccessException e) {
-                // ignore
-            } catch (InvocationTargetException e) {
-                // ignore
+                ThrowableProxy throwableProxy = new ThrowableProxy(sup, alreadyProcessedSet);
+                throwableProxy.commonFrames = ThrowableProxyUtil.findNumberOfCommonFrames(sup.getStackTrace(),
+                    stackTraceElementProxyArray);
+                suppressedList.add(throwableProxy);
             }
+            this.suppressed = suppressedList.toArray(new ThrowableProxy[suppressedList.size()]);
         }
-
     }
 
     public Throwable getThrowable() {
@@ -94,7 +90,7 @@ public class ThrowableProxy implements IThrowableProxy {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ch.qos.logback.classic.spi.IThrowableProxy#getClassName()
      */
     public String getClassName() {
@@ -111,7 +107,7 @@ public class ThrowableProxy implements IThrowableProxy {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ch.qos.logback.classic.spi.IThrowableProxy#getCause()
      */
     public IThrowableProxy getCause() {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/spi/ThrowableProxyTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/spi/ThrowableProxyTest.java
@@ -15,18 +15,17 @@ package ch.qos.logback.classic.spi;
 
 import static ch.qos.logback.classic.util.TestHelper.addSuppressed;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
-import ch.qos.logback.classic.util.TestHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import ch.qos.logback.classic.util.TestHelper;
 
 public class ThrowableProxyTest {
 
@@ -80,7 +79,7 @@ public class ThrowableProxyTest {
     @Test
     public void suppressed() throws InvocationTargetException, IllegalAccessException {
         assumeTrue(TestHelper.suppressedSupported()); // only execute on Java 7, would work anyway but doesn't make
-                                                      // sense.
+        // sense.
         Exception ex = null;
         try {
             someMethod();
@@ -97,7 +96,7 @@ public class ThrowableProxyTest {
     @Test
     public void suppressedWithCause() throws InvocationTargetException, IllegalAccessException {
         assumeTrue(TestHelper.suppressedSupported()); // only execute on Java 7, would work anyway but doesn't make
-                                                      // sense.
+        // sense.
         Exception ex = null;
         try {
             someMethod();
@@ -114,7 +113,7 @@ public class ThrowableProxyTest {
     @Test
     public void suppressedWithSuppressed() throws Exception {
         assumeTrue(TestHelper.suppressedSupported()); // only execute on Java 7, would work anyway but doesn't make
-                                                      // sense.
+        // sense.
         Exception ex = null;
         try {
             someMethod();
@@ -132,6 +131,8 @@ public class ThrowableProxyTest {
     @Test
     public void nullSTE() {
         Throwable t = new Exception("someMethodWithNullException") {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public StackTraceElement[] getStackTrace() {
                 return null;
@@ -159,12 +160,32 @@ public class ThrowableProxyTest {
         verify(w);
     }
 
+    // see also https://jira.qos.ch/browse/LOGBACK-1454
+    @Test
+    public void nestedLoop1() {
+        Exception e = new Exception("foo");
+        Exception e2 = new Exception(e);
+        e.initCause(e2);
+        new ThrowableProxy(e);
+    }
+
+    // see also https://jira.qos.ch/browse/LOGBACK-1454
+    @Test
+    public void nestedLoop2() {
+        Exception e = new Exception("foo");
+        Exception e2 = new Exception(e);
+        e.addSuppressed(e2);
+        new ThrowableProxy(e);
+    }
+
     void someMethod() throws Exception {
         throw new Exception("someMethod");
     }
 
     void someMethodWithNullException() throws Exception {
         throw new Exception("someMethodWithNullException") {
+            private static final long serialVersionUID = -2419053636101615373L;
+
             @Override
             public StackTraceElement[] getStackTrace() {
                 return null;


### PR DESCRIPTION
For users of Logback 1.2.x suffering from LOGBACK-1027, provide a solution by backporting the fix from the master branch.