### PR TITLE
LOGBACK-1590 - Backport of "Improve support for the JANSI library"

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/appender/ConsoleAppenderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/appender/ConsoleAppenderTest.java
@@ -22,6 +22,8 @@ import ch.qos.logback.core.encoder.NopEncoder;
 import ch.qos.logback.core.layout.DummyLayout;
 import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.status.StatusChecker;
+
+import org.fusesource.jansi.AnsiPrintStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,33 +34,40 @@ import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Redirecting System.out is quite messy. Disable this test in Maven bu not in Package.class
+ * Redirecting System.out is quite messy. Disable this test in Maven but not in Package.class
  */
 public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
 
-    XTeeOutputStream tee;
-    PrintStream original;
+    XTeeOutputStream teeOut;
+    XTeeOutputStream teeErr;
+    PrintStream originalOut;
+    PrintStream originalErr;
 
     @Before
     public void setUp() {
-        original = System.out;
-        // tee will output bytes on System out but it will also
+        originalOut = System.out;
+        originalErr = System.err;
+        // teeOut will output bytes on System out but it will also
         // collect them so that the output can be compared against
         // some expected output data
-        // tee = new TeeOutputStream(original);
+        // teeOut = new TeeOutputStream(originalOut);
 
         // keep the console quiet
-        tee = new XTeeOutputStream(null);
+        teeOut = new XTeeOutputStream(null);
+        teeErr = new XTeeOutputStream(null);
 
-        // redirect System.out to tee
-        System.setOut(new PrintStream(tee));
+        // redirect System.out to teeOut and System.err to teeErr
+        System.setOut(new PrintStream(teeOut));
+        System.setErr(new PrintStream(teeErr));
     }
 
     @After
     public void tearDown() {
-        System.setOut(original);
+        System.setOut(originalOut);
+        System.setErr(originalErr);
     }
 
     @Override
@@ -79,7 +88,7 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setEncoder(new DummyEncoder<Object>());
         ca.start();
         ca.doAppend(new Object());
-        assertEquals(DummyLayout.DUMMY, tee.toString());
+        assertEquals(DummyLayout.DUMMY, teeOut.toString());
     }
 
     @Test
@@ -91,7 +100,7 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.start();
         ca.doAppend(new Object());
         ca.stop();
-        assertEquals("open" + CoreConstants.LINE_SEPARATOR + DummyLayout.DUMMY, tee.toString());
+        assertEquals("open" + CoreConstants.LINE_SEPARATOR + DummyLayout.DUMMY, teeOut.toString());
     }
 
     @Test
@@ -105,8 +114,8 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.stop();
         // ConsoleAppender must keep the underlying stream open.
         // The console is not ours to close.
-        assertFalse(tee.isClosed());
-        assertEquals(DummyLayout.DUMMY + "CLOSED", tee.toString());
+        assertFalse(teeOut.isClosed());
+        assertEquals(DummyLayout.DUMMY + "CLOSED", teeOut.toString());
     }
 
     // See http://jira.qos.ch/browse/LBCORE-143
@@ -117,7 +126,7 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setEncoder(encoder);
         ca.start();
         ca.doAppend("a");
-        assertEquals("a" + CoreConstants.LINE_SEPARATOR, tee.toString());
+        assertEquals("a" + CoreConstants.LINE_SEPARATOR, teeOut.toString());
 
         XTeeOutputStream newTee = new XTeeOutputStream(null);
         System.setOut(new PrintStream(newTee));
@@ -134,7 +143,7 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setEncoder(dummyEncoder);
         ca.start();
         ca.doAppend(new Object());
-        assertEquals(DummyLayout.DUMMY, new String(tee.toByteArray(), utf16BE));
+        assertEquals(DummyLayout.DUMMY, new String(teeOut.toByteArray(), utf16BE));
     }
 
     @Test
@@ -158,4 +167,31 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
 
     }
 
+    @Test
+    public void jansiSystemOut() {
+        ConsoleAppender<Object> ca = (ConsoleAppender<Object>) getAppender();
+        DummyEncoder<Object> dummyEncoder = new DummyEncoder<Object>();
+        ca.setEncoder(dummyEncoder);
+        ca.setTarget("System.out");
+        ca.setContext(context);
+        ca.setWithJansi(true);
+        ca.start();
+        assertTrue(ca.getOutputStream() instanceof AnsiPrintStream);
+        ca.doAppend(new Object());
+        assertEquals(DummyLayout.DUMMY, teeOut.toString());
+    }
+
+    @Test
+    public void jansiSystemErr() {
+        ConsoleAppender<Object> ca = (ConsoleAppender<Object>) getAppender();
+        DummyEncoder<Object> dummyEncoder = new DummyEncoder<Object>();
+        ca.setEncoder(dummyEncoder);
+        ca.setTarget("System.err");
+        ca.setContext(context);
+        ca.setWithJansi(true);
+        ca.start();
+        assertTrue(ca.getOutputStream() instanceof AnsiPrintStream);
+        ca.doAppend(new Object());
+        assertEquals(DummyLayout.DUMMY, teeErr.toString());
+    }
 }

--- a/logback-site/src/site/pages/manual/layouts.html
+++ b/logback-site/src/site/pages/manual/layouts.html
@@ -1394,11 +1394,6 @@ Wrapped by: org.springframework.BeanCreationException: Error creating bean with 
 
 <pre id="highlighted" class="prettyprint">&lt;configuration debug="true">
   &lt;appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    &lt;!-- On Windows machines setting withJansi to true enables ANSI
-         color code interpretation by the Jansi library. This requires
-         org.fusesource.jansi:jansi:1.8 on the class path.  Note that
-         Unix-based operating systems such as Linux and Mac OS X
-         support ANSI color codes by default. --&gt;
     <b>&lt;withJansi>true&lt;/withJansi></b>
     &lt;encoder>
       &lt;pattern>[%thread] <b>%highlight(%-5level)</b> <b>%cyan(%logger{15})</b> - %msg %n&lt;/pattern>
@@ -1408,6 +1403,19 @@ Wrapped by: org.springframework.BeanCreationException: Error creating bean with 
     &lt;appender-ref ref="STDOUT" />
   &lt;/root>
 &lt;/configuration></pre>
+
+     <p>Setting <code>withJansi</code> to true enables ANSI
+     color code interpretation by the Jansi library, which transparently
+     filters out ANSI escape sequences if the underlying terminal is not
+     compatible. This is the safest choice for cross-platform deployments,
+     but requires org.fusesource.jansi:jansi:1.17 or higher on the class path.
+     Note that Unix-based operating systems such as Linux and Mac OS X
+     support ANSI color codes natively and usually do not require
+     enabling the Jansi library, but doing so is harmless.
+     On Windows however, enabling Jansi is recommended to benefit from color
+     code interpretation on DOS command prompts, which otherwise
+     risk being sent ANSI escape sequences that they cannot interpret.
+     </p>
 
      <p>Here is the corresponding output:</p>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </modules>
 
   <properties>
-    <project.build.outputTimestamp>2022-03-05T19:45:00Z</project.build.outputTimestamp>    
+    <project.build.outputTimestamp>2022-03-05T19:45:00Z</project.build.outputTimestamp>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -63,7 +63,7 @@
     <!--<tomcat.version>7.0.59</tomcat.version>-->
     <tomcat.version>8.5.9</tomcat.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
-    <jansi.version>1.9</jansi.version>
+    <jansi.version>1.18</jansi.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>    
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
@@ -75,7 +75,7 @@
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <maven-bundle-plugin.version>5.1.4</maven-bundle-plugin.version>
-    
+
   </properties>
 
   <developers>


### PR DESCRIPTION
Here is the copied description of cherry-picked commit : 58f15b51906b8ea25a509a46b33d87aef800d446

---
Motivation:

The Jansi library provides an AnsiPrintStream that intercepts ANSI
sequences and allows the application to react to them accordingly.
Jansi is compatible with a variety of terminals, including xterm-like
terminals for Windows like Mintty and MinGW.

Jansi has a good algorithm to detect whether or not ANSI
sequences will be correctly interpreted or not, and if not, its default
behavior is to filter out such sequences.

Logback's ConsoleAppender has a withJansi option. Unfortunately,
Logback bypasses Jansi's detection algorithm and boldly
assumes that if the OS is Windows, then the terminal is a DOS prompt.
So while DOS prompts get colored, terminals like Mintty or MinGW not
only lose their coloring but are sent DOS escape sequences that they
can't interpret.

Modifications:

- Amend ConsoleAppender so that when withJansi is true, then all
OutputStreams are wrapped in an AnsiPrintStream, effectively delegating
to the JANSI library the decision to filter out ANSI escape sequences
or not, depending on the terminal capability. This also allows users
to disable or customize the coloring behavior by using system properties
recognized by JANSI, such as jansi.strip.
- Amend the documentation and stress that the JANSI library is the
recommended solution for Windows systems, as well as for cross-platform
deployments that include a mix of Windows and non-Windows systems.