### PR TITLE
Allow only java: namespace in JNDI lookups

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
@@ -20,14 +20,15 @@ public class ClassicConstants {
     public static final String USER_MDC_KEY = "user";
 
     public static final String LOGBACK_CONTEXT_SELECTOR = "logback.ContextSelector";
-    public static final String JNDI_CONFIGURATION_RESOURCE = "java:comp/env/logback/configuration-resource";
-    public static final String JNDI_CONTEXT_NAME = "java:comp/env/logback/context-name";
+    public static final String JNDI_JAVA_NAMESPACE = "java:";
+    public static final String JNDI_CONFIGURATION_RESOURCE = JNDI_JAVA_NAMESPACE + "comp/env/logback/configuration-resource";
+    public static final String JNDI_CONTEXT_NAME = JNDI_JAVA_NAMESPACE + "comp/env/logback/context-name";
 
     /**
      * The maximum number of package separators (dots) that abbreviation
      * algorithms can handle. Class or logger names with more separators will have
      * their first MAX_DOTS parts shortened.
-     * 
+     *
      */
     public static final int MAX_DOTS = 16;
 

--- a/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/InsertFromJNDIAction.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/joran/action/InsertFromJNDIAction.java
@@ -26,7 +26,7 @@ import ch.qos.logback.core.joran.spi.InterpretationContext;
 import ch.qos.logback.core.util.OptionHelper;
 
 /**
- * Insert an env-entry found in JNDI as a new context variable  
+ * Insert an env-entry found in JNDI as a new context variable
 
  * @author Ceki Gulcu
  *
@@ -73,7 +73,7 @@ public class InsertFromJNDIAction extends Action {
                 ActionUtil.setProperty(ec, asKey, envEntryValue, scope);
             }
         } catch (NamingException e) {
-            addError("Failed to lookup JNDI env-entry [" + envEntryName + "]");
+            addError("Failed to lookup JNDI env-entry [" + envEntryName + "]", e);
         }
 
     }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/selector/ContextJNDISelector.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/selector/ContextJNDISelector.java
@@ -125,7 +125,11 @@ public class ContextJNDISelector implements ContextSelector {
     private URL findConfigFileURL(Context ctx, LoggerContext loggerContext) {
         StatusManager sm = loggerContext.getStatusManager();
 
-        String jndiEntryForConfigResource = JNDIUtil.lookup(ctx, JNDI_CONFIGURATION_RESOURCE);
+        String jndiEntryForConfigResource = null;
+        try {
+            jndiEntryForConfigResource = JNDIUtil.lookup(ctx, JNDI_CONFIGURATION_RESOURCE);
+        } catch (NamingException ne) {
+        }
         // Do we have a dedicated configuration file?
         if (jndiEntryForConfigResource != null) {
             sm.add(new InfoStatus("Searching for [" + jndiEntryForConfigResource + "]", this));

--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/JNDIUtil.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/JNDIUtil.java
@@ -17,13 +17,11 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.classic.ClassicConstants;
+import ch.qos.logback.core.util.OptionHelper;
 
 /**
  * A simple utility class to create and use a JNDI Context.
- *
- * <b>Given JNDI based attacks, replaced with emtpy code returning null or "" 
- * until better options are found.</b>
  *
  * @author Ceki G&uuml;lc&uuml;
  * @author S&eacute;bastien Pennec
@@ -32,23 +30,23 @@ import ch.qos.logback.core.CoreConstants;
 public class JNDIUtil {
 
     public static Context getInitialContext() throws NamingException {
-        return null; 
-        //new InitialContext();
+        return new InitialContext();
     }
 
-    static int counter = 0;
-    
-    public static String lookup(Context ctx, String name) {
-    	return CoreConstants.EMPTY_STRING;
-    	
-//    	if (ctx == null) {
-//            return null;
-//        }
-//        try {
-//            Object lookup = ctx.lookup(name);
-//            return lookup == null ? null : lookup.toString();
-//        } catch (NamingException e) {
-//            return null;
-//        }
+    public static String lookup(Context ctx, String name) throws NamingException {
+        if (ctx == null) {
+            return null;
+        }
+
+        if (OptionHelper.isEmpty(name)) {
+            return null;
+        }
+
+        if (!name.startsWith(ClassicConstants.JNDI_JAVA_NAMESPACE)) {
+            throw new NamingException("JNDI name must start with " + ClassicConstants.JNDI_JAVA_NAMESPACE);
+        }
+
+        Object lookup = ctx.lookup(name);
+        return lookup == null ? null : lookup.toString();
     }
 }

--- a/logback-classic/src/test/java/ch/qos/logback/classic/selector/ContextDetachingSCLTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/selector/ContextDetachingSCLTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -29,9 +28,6 @@ import ch.qos.logback.classic.util.MockInitialContextFactory;
 import org.slf4j.LoggerFactoryFriend;
 import org.slf4j.impl.StaticLoggerBinderFriend;
 
-// CVE-xxx
-
-@Ignore 
 public class ContextDetachingSCLTest {
 
     static String INITIAL_CONTEXT_KEY = "java.naming.factory.initial";

--- a/logback-classic/src/test/java/ch/qos/logback/classic/selector/ContextJNDISelectorTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/selector/ContextJNDISelectorTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.impl.StaticLoggerBinderFriend;
@@ -28,9 +27,6 @@ import ch.qos.logback.classic.util.MockInitialContext;
 import ch.qos.logback.classic.util.MockInitialContextFactory;
 import ch.qos.logback.core.Context;
 
-// CVE-2021-xxx
-
-@Ignore
 public class ContextJNDISelectorTest {
 
     static String INITIAL_CONTEXT_KEY = "java.naming.factory.initial";


### PR DESCRIPTION
This limits JNDI lookups to `java:` only and everything else will result in a `NamingExeption`.