### PR TITLE
Update Jansi library to 2.1.0

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/appender/ConsoleAppenderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/appender/ConsoleAppenderTest.java
@@ -177,8 +177,7 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setWithJansi(true);
         ca.start();
         assertTrue(ca.getOutputStream() instanceof AnsiPrintStream);
-        ca.doAppend(new Object());
-        assertEquals(DummyLayout.DUMMY, teeOut.toString());
+        // Jansi uses FileDescriptor.out instead of System.out, thus we can't intercept the output
     }
 
     @Test
@@ -191,7 +190,6 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setWithJansi(true);
         ca.start();
         assertTrue(ca.getOutputStream() instanceof AnsiPrintStream);
-        ca.doAppend(new Object());
-        assertEquals(DummyLayout.DUMMY, teeErr.toString());
+        // Jansi uses FileDescriptor.err instead of System.err, thus we can't intercept the output
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <tomcat.version>10.0.10</tomcat.version>
     <jetty.version>11.0.6</jetty.version>
     <compiler-plugin.version>3.8.0</compiler-plugin.version> <!-- 3.6.1, 3.7.0 -->
-    <jansi.version>1.18</jansi.version>
+    <jansi.version>2.4.0</jansi.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>    


### PR DESCRIPTION
Motivation:

Use the last version of Jansi library to benefit of its last updates/bugfixes.

Modifications:

- Amend ConsoleAppender to use the new JANSI API. Since 2.0, the "wrapSystemOut"/"wrapSystemErr" methods have been removed and now JANSI uses "FileDescriptor.out" and "FileDescriptor.err" directly. As stated in [this JANSI commit](https://github.com/fusesource/jansi/commit/57aa84d4120395922458f61f20e741198f051087) :

> This has the downside of not playing well if the user has overridden the system streams previously, but any kind of wrappers around the streams should happen after JANSI processing

So it is not possible to test the output on stdout/err anymore.