### PR TITLE
LOGBACK-1595 Update JANSI library to 2.4.0

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/ConsoleAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ConsoleAppender.java
@@ -14,7 +14,6 @@
 package ch.qos.logback.core;
 
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
@@ -43,10 +42,9 @@ public class ConsoleAppender<E> extends OutputStreamAppender<E> {
     protected ConsoleTarget target = ConsoleTarget.SystemOut;
     protected boolean withJansi = false;
 
-    private final static String AnsiConsole_CLASS_NAME = "org.fusesource.jansi.AnsiConsole";
-    private final static String wrapSystemOut_METHOD_NAME = "wrapSystemOut";
-    private final static String wrapSystemErr_METHOD_NAME = "wrapSystemErr";
-    private final static Class<?>[] ARGUMENT_TYPES = { PrintStream.class };
+    private final static String JANSI_CLASS_NAME = "org.fusesource.jansi.AnsiConsole";
+    private final static String JANSI_OUT_METHOD_NAME = "out";
+    private final static String JANSI_ERR_METHOD_NAME = "err";
 
     /**
      * Sets the value of the <b>Target</b> option. Recognized values are
@@ -80,28 +78,23 @@ public class ConsoleAppender<E> extends OutputStreamAppender<E> {
 
     @Override
     public void start() {
-        OutputStream targetStream = target.getStream();
         // enable jansi only if withJansi set to true
-        if (withJansi) {
-            targetStream = wrapWithJansi(targetStream);
-        }
-        setOutputStream(targetStream);
+        setOutputStream(withJansi ? getJansiStream() : target.getStream());
         super.start();
     }
 
-    private OutputStream wrapWithJansi(OutputStream targetStream) {
+    private OutputStream getJansiStream() {
         try {
             addInfo("Enabling JANSI AnsiPrintStream for the console.");
             ClassLoader classLoader = Loader.getClassLoaderOfObject(context);
-            Class<?> classObj = classLoader.loadClass(AnsiConsole_CLASS_NAME);
-            String methodName = target == ConsoleTarget.SystemOut ? wrapSystemOut_METHOD_NAME
-                    : wrapSystemErr_METHOD_NAME;
-            Method method = classObj.getMethod(methodName, ARGUMENT_TYPES);
-            return (OutputStream) method.invoke(null, new PrintStream(targetStream));
+            Class<?> classObj = classLoader.loadClass(JANSI_CLASS_NAME);
+            String methodName = target == ConsoleTarget.SystemOut ? JANSI_OUT_METHOD_NAME : JANSI_ERR_METHOD_NAME;
+            Method method = classObj.getMethod(methodName);
+            return (OutputStream) method.invoke(null);
         } catch (Exception e) {
             addWarn("Failed to create AnsiPrintStream. Falling back on the default stream.", e);
         }
-        return targetStream;
+        return target.getStream();
     }
 
     /**

--- a/logback-core/src/test/java/ch/qos/logback/core/appender/ConsoleAppenderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/appender/ConsoleAppenderTest.java
@@ -177,8 +177,7 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setWithJansi(true);
         ca.start();
         Assertions.assertTrue(ca.getOutputStream() instanceof AnsiPrintStream);
-        ca.doAppend(new Object());
-        Assertions.assertEquals(DummyLayout.DUMMY, teeOut.toString());
+        // Jansi uses FileDescriptor.out instead of System.out, thus we can't intercept the output
     }
 
     @Test
@@ -191,7 +190,6 @@ public class ConsoleAppenderTest extends AbstractAppenderTest<Object> {
         ca.setWithJansi(true);
         ca.start();
         Assertions.assertTrue(ca.getOutputStream() instanceof AnsiPrintStream);
-        ca.doAppend(new Object());
-        Assertions.assertEquals(DummyLayout.DUMMY, teeErr.toString());
+        // Jansi uses FileDescriptor.err instead of System.err, thus we can't intercept the output
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
     <module>logback-core</module>
     <module>logback-core-blackbox</module>
     <module>logback-classic</module>
-    <module>logback-classic-blackbox</module>    
+    <module>logback-classic-blackbox</module>
     <module>logback-access</module>
     <module>logback-examples</module>
   </modules>
 
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
-    <project.build.outputTimestamp>2022-10-07T20:47:29Z</project.build.outputTimestamp>    
+    <project.build.outputTimestamp>2022-10-07T20:47:29Z</project.build.outputTimestamp>
     <jdk.version>11</jdk.version>
     <maven.compiler.release>${jdk.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -76,7 +76,7 @@
     <tomcat.version>10.0.10</tomcat.version>
     <jetty.version>11.0.12</jetty.version>
 
-    <jansi.version>1.18</jansi.version>
+    <jansi.version>2.4.0</jansi.version>
     <mockito-core.version>4.8.0</mockito-core.version>
     <byte-buddy.version>1.12.14</byte-buddy.version>
 


### PR DESCRIPTION
Motivation:

Use the last version of JANSI library to benefit of its last updates/bugfixes.

Modifications:

- Amend ConsoleAppender to use the new JANSI API. Since 2.0, the "wrapSystemOut"/"wrapSystemErr" methods have been removed and now JANSI uses "FileDescriptor.out" and "FileDescriptor.err" directly. As stated in this JANSI commit https://github.com/fusesource/jansi/commit/57aa84d4120395922458f61f20e741198f051087 :
  > This has the downside of not playing well if the user has overriden the system streams previously, but any kind of wrappers around the streams should happen after JANSI processing
