### PR TITLE
Add feature timer for DuplicateMessageFilter

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/turbo/DuplicateMessageFilter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/turbo/DuplicateMessageFilter.java
@@ -37,15 +37,20 @@ public class DuplicateMessageFilter extends TurboFilter {
      * The default number of allows repetitions.
      */
     public static final int DEFAULT_ALLOWED_REPETITIONS = 5;
+    /**
+     * The default time before cache reset.
+     */
+    public static final long DEFAULT_CACHE_RESET_WINDOW = Long.MAX_VALUE;
 
     public int allowedRepetitions = DEFAULT_ALLOWED_REPETITIONS;
     public int cacheSize = DEFAULT_CACHE_SIZE;
+    public long cacheResetWindow = DEFAULT_CACHE_RESET_WINDOW;
 
     private LRUMessageCache msgCache;
 
     @Override
     public void start() {
-        msgCache = new LRUMessageCache(cacheSize);
+        msgCache = new LRUMessageCache(cacheSize, cacheResetWindow);
         super.start();
     }
 
@@ -87,4 +92,16 @@ public class DuplicateMessageFilter extends TurboFilter {
         this.cacheSize = cacheSize;
     }
 
+    public long getCacheResetWindow() {
+        return cacheResetWindow;
+    }
+
+    /**
+     * The time window in ms before the cache resets
+     *
+     * @param cacheResetWindow
+     */
+    public void setCacheResetWindow(long cacheResetWindow) {
+        this.cacheResetWindow = cacheResetWindow;
+    }
 }

--- a/logback-site/src/site/pages/manual/filters.html
+++ b/logback-site/src/site/pages/manual/filters.html
@@ -989,6 +989,14 @@ logger.debug("Hello {}.", name1);</pre>
     property. By the default, this is set to 100.
     </p>
 
+    <p>The cache can be truncated periodically so that messages
+    will be written even if they have repetitions - but no more
+    than x times every time period.
+    The period after which the cache is truncated is in milliseconds
+    and is set by the <span class="option">CacheResetWindow</span>
+    property. By default it is switched off by being set to Long.MaxLong.
+    </p>
+
     
     <em>Example: <code>DuplicateMessageFilter</code> 
     configuration (logback-examples/src/main/resources/chapters/filters/duplicateMessage.xml)</em>


### PR DESCRIPTION
Add feature timer for DuplicateMessageFilter
Signed-off-by: Nimrod Ofek ofek.nimrod@gmail.com
https://jira.qos.ch/browse/LOGBACK-715 - Add feature timer for DuplicateMessageFilter.
Current DuplicateMessageFilter is unchanged, unless the CacheResetWindow property is set to anything other then Long.MaxLong.