### PR TITLE
Add back getMaxFileSize to SizeAndTimeBasedFNATP

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -180,4 +180,8 @@ public class SizeAndTimeBasedFNATP<E> extends TimeBasedFileNamingAndTriggeringPo
         this.maxFileSize = aMaxFileSize;
     }
 
+    public FileSize getMaxFileSize() {
+        return maxFileSize;
+    }
+
 }


### PR DESCRIPTION
We are seeing some code breaking changes since the removal of getMaxFileSize from SizeAndTimeBasedFNATP. 
I believe the removal might also have been a mistake per the discussion [Here](https://github.com/qos-ch/logback/commit/03e26684d43066d53dbf926e060a73d43bee77fd#diff-66c41ed75a26ca4c4dbf685c15a5e6feb7fdf7c43de3bc7f2944e96ecaec03ea)