### PR TITLE
LOGBACK-1612 level change propagator inconsistent with jul to slf4j

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/jul/JULHelper.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/jul/JULHelper.java
@@ -30,23 +30,29 @@ public class JULHelper {
         return julLogger.getName().equals("");
     }
 
+    /**
+     * @param lbLevel
+     * @return the lowest JUL level that jul-to-slf4j SLF4JBridgeHandler
+     * logs at the given logback level. This will be used as the argument
+     * for java.util.logging.Logger.setLevel.
+     * @see java.util.logging.Logger#setLevel(java.util.logging.Level)
+     */
     static public java.util.logging.Level asJULLevel(Level lbLevel) {
         if (lbLevel == null)
             throw new IllegalArgumentException("Unexpected level [null]");
 
         switch (lbLevel.levelInt) {
-        case Level.ALL_INT:
-            return java.util.logging.Level.ALL;
+        case Level.ALL_INT: // pass through
         case Level.TRACE_INT:
-            return java.util.logging.Level.FINEST;
+            return java.util.logging.Level.ALL;
         case Level.DEBUG_INT:
-            return java.util.logging.Level.FINE;
+            return MinSlf4jLevel.MIN_DEBUG;
         case Level.INFO_INT:
-            return java.util.logging.Level.INFO;
+            return MinSlf4jLevel.MIN_INFO;
         case Level.WARN_INT:
-            return java.util.logging.Level.WARNING;
+            return MinSlf4jLevel.MIN_WARN;
         case Level.ERROR_INT:
-            return java.util.logging.Level.SEVERE;
+            return MinSlf4jLevel.MIN_ERROR;
         case Level.OFF_INT:
             return java.util.logging.Level.OFF;
         default:

--- a/logback-classic/src/main/java/ch/qos/logback/classic/jul/MinSlf4jLevel.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/jul/MinSlf4jLevel.java
@@ -1,0 +1,32 @@
+package ch.qos.logback.classic.jul;
+
+class MinSlf4jLevel extends java.util.logging.Level {
+    private MinSlf4jLevel(String name, int value) {
+        super(name, value);
+    }
+
+    /**
+     * A JUL Level with the smallest intValue that jul-to-slf4j
+     * converts to a SLF4J DEBUG.
+     */
+    public static MinSlf4jLevel MIN_DEBUG = new MinSlf4jLevel(
+        "MIN_DEBUG", java.util.logging.Level.FINEST.intValue() + 1);
+    /**
+     * A JUL Level with the smallest intValue that jul-to-slf4j
+     * converts to a SLF4J INFO.
+     */
+    public static MinSlf4jLevel MIN_INFO = new MinSlf4jLevel(
+        "MIN_INFO", java.util.logging.Level.FINE.intValue() + 1);
+    /**
+     * A JUL Level with the smallest intValue that jul-to-slf4j
+     * converts to a SLF4J WARN.
+     */
+    public static MinSlf4jLevel MIN_WARN = new MinSlf4jLevel(
+        "MIN_INFO", java.util.logging.Level.INFO.intValue() + 1);
+    /**
+     * A JUL Level with the smallest intValue that jul-to-slf4j
+     * converts to a SLF4J ERROR.
+     */
+    public static MinSlf4jLevel MIN_ERROR = new MinSlf4jLevel(
+        "MIN_INFO", java.util.logging.Level.WARNING.intValue() + 1);
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/jul/LevelChangePropagatorTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/jul/LevelChangePropagatorTest.java
@@ -16,14 +16,20 @@ package ch.qos.logback.classic.jul;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import ch.qos.logback.core.testUtil.RandomUtil;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LevelChangePropagatorTest {
     int rand = RandomUtil.getPositiveInt();
@@ -93,5 +99,160 @@ public class LevelChangePropagatorTest {
 
         assertEquals(parent.getEffectiveLevel(), child.getEffectiveLevel());
         assertEquals(Level.DEBUG, child.getEffectiveLevel());
+    }
+
+    // test that a message logged at a given JUL level
+    // will still be loggable when the SLF4J logger is set to that level
+    // to satisfy the Basic Selection Rule
+    // https://logback.qos.ch/manual/architecture.html#basic_selection
+    private void testLoggableAtJulLevel(ListAppender<ILoggingEvent> listAppender, java.util.logging.Level level) {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Logger logger = loggerContext.getLogger("LevelChangePropagatorTest.testLoggableAtJulLevel");
+        java.util.logging.Logger julLogger = JULHelper.asJULLogger(logger);
+        logger.setLevel(Level.ALL);
+        assertEquals(0, listAppender.list.size());
+        julLogger.log(level, "hi");
+        assertEquals(
+            "logger at ALL -> jul " + julLogger.getLevel() + " should pass message at " + level,
+            1, listAppender.list.size()
+        );
+        ILoggingEvent msg = listAppender.list.get(0);
+        listAppender.list.clear();
+        Level observedLevel = msg.getLevel();
+        logger.setLevel(observedLevel);
+        assertTrue(
+            "logger at " + observedLevel + " -> jul " + julLogger.getLevel() + " should pass message at " + level,
+            julLogger.isLoggable(level)
+        );
+        julLogger.log(level, "hi");
+        assertEquals(
+            "logger at " + observedLevel + " -> jul " + julLogger.getLevel() + " should pass message at " + level,
+            1, listAppender.list.size()
+        );
+        listAppender.list.clear();
+    }
+    @Test
+    public void intermediateValues() {
+        // we have to use the global LoggerContext and jul LogManager
+        // since LogManager does not support being constructed by user code
+        SLF4JBridgeHandler.install();
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        LevelChangePropagator levelChangePropagator = new LevelChangePropagator();
+        levelChangePropagator.setContext(loggerContext);
+        loggerContext.addListener(levelChangePropagator);
+
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<ILoggingEvent>();
+        Logger root = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.addAppender(listAppender);
+
+        java.util.logging.Level SLIGHTLY_DEBUG = new java.util.logging.Level(
+            "SLIGHTLY_DEBUG",
+            java.util.logging.Level.FINEST.intValue() + 1) {
+        };
+        java.util.logging.Level SLIGHTLY_INFO = new java.util.logging.Level(
+            "SLIGHTLY_INFO",
+            java.util.logging.Level.FINE.intValue() + 1) {
+        };
+        java.util.logging.Level SLIGHTLY_WARN = new java.util.logging.Level(
+            "SLIGHTLY_WARN",
+            java.util.logging.Level.INFO.intValue() + 1) {
+        };
+        java.util.logging.Level SLIGHTLY_ERROR = new java.util.logging.Level(
+            "SLIGHTLY_ERROR",
+            java.util.logging.Level.WARNING.intValue() + 1) {
+        };
+        listAppender.start();
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.SEVERE);
+        testLoggableAtJulLevel(listAppender, SLIGHTLY_ERROR);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.WARNING);
+        testLoggableAtJulLevel(listAppender, SLIGHTLY_WARN);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.INFO);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.CONFIG);
+        testLoggableAtJulLevel(listAppender, SLIGHTLY_INFO);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.FINE);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.FINER);
+        testLoggableAtJulLevel(listAppender, SLIGHTLY_DEBUG);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.FINEST);
+        testLoggableAtJulLevel(listAppender, java.util.logging.Level.ALL);
+
+        // test that all messages (including an message at ALL level)
+        // are isLoggable for a logger at TRACE
+        Logger logger = loggerContext.getLogger("LevelChangePropagatorTest.isLoggable");
+        java.util.logging.Logger julLogger = JULHelper.asJULLogger(logger);
+        logger.setLevel(Level.TRACE);
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.SEVERE));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_ERROR));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.WARNING));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_WARN));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.INFO));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.CONFIG));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_INFO));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.FINE));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.FINER));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_DEBUG));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.FINEST));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.ALL));
+
+        // test that FINER and custom debug-like messages
+        // are isLoggable for a logger at DEBUG
+        logger.setLevel(Level.DEBUG);
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.SEVERE));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_ERROR));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.WARNING));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_WARN));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.INFO));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.CONFIG));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_INFO));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.FINE));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.FINER));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_DEBUG));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINEST));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.ALL));
+
+        // test that CONFIG and custom info-like messages
+        // are isLoggable for a logger at INFO
+        logger.setLevel(Level.INFO);
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.SEVERE));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_ERROR));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.WARNING));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_WARN));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.INFO));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.CONFIG));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_INFO));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINE));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINER));
+        assertFalse(julLogger.isLoggable(SLIGHTLY_DEBUG));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINEST));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.ALL));
+
+        // test that custom warn-like messages are isLoggable for a logger at WARN
+        logger.setLevel(Level.WARN);
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.SEVERE));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_ERROR));
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.WARNING));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_WARN));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.INFO));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.CONFIG));
+        assertFalse(julLogger.isLoggable(SLIGHTLY_INFO));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINE));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINER));
+        assertFalse(julLogger.isLoggable(SLIGHTLY_DEBUG));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINEST));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.ALL));
+
+        // test that custom error-like messages are isLoggable for a logger at ERROR
+        logger.setLevel(Level.ERROR);
+        assertTrue(julLogger.isLoggable(java.util.logging.Level.SEVERE));
+        assertTrue(julLogger.isLoggable(SLIGHTLY_ERROR));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.WARNING));
+        assertFalse(julLogger.isLoggable(SLIGHTLY_WARN));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.INFO));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.CONFIG));
+        assertFalse(julLogger.isLoggable(SLIGHTLY_INFO));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINE));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINER));
+        assertFalse(julLogger.isLoggable(SLIGHTLY_DEBUG));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.FINEST));
+        assertFalse(julLogger.isLoggable(java.util.logging.Level.ALL));
     }
 }


### PR DESCRIPTION
Fix [LOGBACK-1612](https://jira.qos.ch/browse/LOGBACK-1612): propagate minimum JUL level, not maximum

Call setLevel with the minimum JUL level for any SLF4J level, not the maximum, so that intermediate JUL levels will will not be filtered out.