### PR TITLE
Correct reference to wrong class in manual

### DIFF
--- a/logback-site/src/site/pages/manual/appenders.html
+++ b/logback-site/src/site/pages/manual/appenders.html
@@ -1332,7 +1332,7 @@ public interface RollingPolicy extends LifeCycle {
     based log file archiving.</p>
     
   <p class="example">Example: Sample configuration for
-  <code>SizeAndTimeBasedFNATP</code> 
+  <code>SizeAndTimeBasedRollingPolicy</code> 
   (logback-examples/src/main/resources/chapters/appenders/conf/logback-sizeAndTime.xml)</p>
 
   


### PR DESCRIPTION
Example shows SizeAndTimeBasedRollingPolicy, but description says the example is about SizeAndTimeBasedFNATP