### PR TITLE
fix: published POM file contain the wrong scm URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
 
   <scm>
-    <url>https://github.com/ceki/logback</url>
+    <url>https://github.com/qos-ch/logback</url>
     <connection>scm:git@github.com:qos-ch/logback.git</connection>
   </scm>
 


### PR DESCRIPTION
LOGBACK-1633