### PR TITLE
Add missing word "find" into one log line

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/tomcat/LogbackValve.java
@@ -194,7 +194,7 @@ public class LogbackValve extends ValveBase
             addInfo("Found configuration file [" + candidatePath + "] using property \"" + propertyKey + "\"");
             return candidateFile;
         } else {
-            addInfo("Could NOT configuration file [" + candidatePath + "] using property \"" + propertyKey + "\"");
+            addInfo("Could NOT find configuration file [" + candidatePath + "] using property \"" + propertyKey + "\"");
             return null;
         }
     }

--- a/logback-access/src/test/java/ch/qos/logback/access/tomcat/LogbackValveTest.java
+++ b/logback-access/src/test/java/ch/qos/logback/access/tomcat/LogbackValveTest.java
@@ -55,6 +55,18 @@ public class LogbackValveTest {
     }
 
     @Test
+    public void nonExistingConfigFileUnderCatalinaBaseShouldResultInWarning() throws LifecycleException {
+        final String path = AccessTestConstants.JORAN_INPUT_PREFIX + "tomcat/";
+        final String fileName = "logback-test2-config.xml";
+        final String fullPath = path + fileName;
+        System.setProperty(LogbackValve.CATALINA_BASE_KEY, path);
+        setupValve(fileName);
+        valve.start();
+        checker.assertContainsMatch("Could NOT find configuration file");
+        checker.assertIsErrorFree();
+    }
+
+    @Test
     public void fileUnderCatalinaHomeShouldBeFound() throws LifecycleException {
         System.setProperty(LogbackValve.CATALINA_HOME_KEY, AccessTestConstants.JORAN_INPUT_PREFIX + "tomcat/");
         final String fileName = "logback-access.xml";


### PR DESCRIPTION
There was the word "find" missing from one log line, so I added it. I also created a unit test that covers it, for it was not covered at all before.