### PR TITLE
fix missing JDK9 export

### DIFF
--- a/logback-core/src/main/java9/module-info.java
+++ b/logback-core/src/main/java9/module-info.java
@@ -24,6 +24,7 @@ module ch.qos.logback.core {
     exports ch.qos.logback.core.filter;
 
     exports ch.qos.logback.core.model;
+    exports ch.qos.logback.core.model.conditional;
     exports ch.qos.logback.core.model.processor;
 
     exports ch.qos.logback.core.joran;


### PR DESCRIPTION
Adds an export to fix JDK9 module bug:

> Exception in thread "main" java.lang.IllegalAccessError: class ch.qos.logback.classic.joran.JoranConfigurator (in module ch.qos.logback.classic) cannot access class ch.qos.logback.core.model.conditional.IfModel (in module ch.qos.logback.core) because **module ch.qos.logback.core does not export ch.qos.logback.core.model.conditional to module ch.qos.logback.classic**