### PR TITLE
LOGBACK-1227 Avoid excessive filter list clone in TurboFilterList

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/TurboFilterList.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/TurboFilterList.java
@@ -52,16 +52,13 @@ final public class TurboFilterList extends CopyOnWriteArrayList<TurboFilter> {
             }
         }
 
-        Object[] tfa = toArray();
-        final int len = tfa.length;
-        for (int i = 0; i < len; i++) {
-            // for (TurboFilter tf : this) {
-            final TurboFilter tf = (TurboFilter) tfa[i];
+        for(TurboFilter tf : this) {
             final FilterReply r = tf.decide(marker, logger, level, format, params, t);
             if (r == FilterReply.DENY || r == FilterReply.ACCEPT) {
                 return r;
             }
         }
+
         return FilterReply.NEUTRAL;
     }
 


### PR DESCRIPTION
Current implementation clones a list via ```toArray```, which results in excessive allocation in a high-load scenarios.
CoW list iterator is guaranteed to operate on a last known list snapshot already, so there is no need to clone it.