### PR TITLE
backport one commit to 1.2.x version

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/SocketReceiverTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/SocketReceiverTest.java
@@ -32,6 +32,7 @@ import javax.net.SocketFactory;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import ch.qos.logback.classic.Level;
@@ -50,6 +51,7 @@ import ch.qos.logback.core.status.Status;
  *
  * @author Carl Harris
  */
+@Ignore
 public class SocketReceiverTest {
 
     private static final int DELAY = 1000;

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/server/ServerSocketReceiverFunctionalTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/server/ServerSocketReceiverFunctionalTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import ch.qos.logback.classic.Level;
@@ -44,6 +45,7 @@ import ch.qos.logback.core.net.server.ServerSocketUtil;
  * network interface, and validate that it receives messages and delivers
  * them to its appender.
  */
+@Ignore
 public class ServerSocketReceiverFunctionalTest {
 
     private static final int EVENT_COUNT = 10;

--- a/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -31,7 +31,7 @@ public class CoreConstants {
     // This causes tests failures in SocketReceiverTest.testDispatchEventForEnabledLevel and
     // ServerSocketReceiverFunctionalTest.testLogEventFromClient.
     // We thus set a pool size > 0 for tests to pass.
-    public static final int SCHEDULED_EXECUTOR_POOL_SIZE = 8;
+    public static final int SCHEDULED_EXECUTOR_POOL_SIZE = 1;
 
     
     /**

--- a/logback-core/src/test/java/ch/qos/logback/core/net/server/ServerSocketAppenderBaseFunctionalTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/net/server/ServerSocketAppenderBaseFunctionalTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import ch.qos.logback.core.net.mock.MockContext;
@@ -35,6 +36,7 @@ import ch.qos.logback.core.util.ExecutorServiceUtil;
  *
  * @author Carl Harris
  */
+@Ignore
 public class ServerSocketAppenderBaseFunctionalTest {
 
     private static final String TEST_EVENT = "test event";

--- a/logback-site/src/site/pages/news.html
+++ b/logback-site/src/site/pages/news.html
@@ -30,14 +30,53 @@
     the <a href="http://www.qos.ch/mailman/listinfo/announce">QOS.ch
     announce</a> mailing list.</p>
 
-    <!--
+
     <hr width="80%" align="center" />
 
-    
-    <p class="highlight">Version 1.3.x and later require JDK 1.7.</p>
+    <h3>, 2018, Release of version 1.3.0-alpha1</h3>
 
-    <p>Version 1.3.x and later require JDK 1.7.</p>
-    -->
+    <p class="highlight">The 1.3.x series requires Java&nbsp;7 at
+    <b>runtime</b>.</p>
+
+    <p class="highlight">The 1.3.x series is Jigsaw/Java&nbsp;9
+    modularized and requires slf4j-api version 1.8.x.</p>
+
+    <p>The 1.3.x series is Jigsaw/Java&nbsp;9 modularized and requires
+    slf4j-api version 1.8.x.</p>
+   
+    <p>The 1.3.x series requires Java&nbsp;7 at <b>runtime</b>
+
+    <p>Building logback from source requires Java&nbsp;9.</p>
+
+    <p>Given that all currently available versions of Groovy are
+    incompatible with Java 9, at least when built with Maven, we have
+    momentarily <b>dropped support for Groovy configuration</b>, a.k.a
+    Gaffer. </p>
+
+    <p>Logback's internal <code>ThreadPoolExecutor</code> now has an
+    initial pool of 1 thread instead of 8 previously.</p>
+
+
+    <hr width="80%" align="center" />
+
+    <h3>January 18th, 2018, Release of version 1.3.0-alpha0</h3>
+
+
+    <p>Added support for minimum length in %i filename pattern. This
+    fixes <a
+    href="https://jira.qos.ch/browse/LOGBACK-1248">LOGBACK-1248</a>
+    with John Gardiner Myers providing the relevant patch.</p>
+
+    <p>Correct parsing of <code>java.version</code> system property
+    for Java 9 and later. This fixes <a
+    href="https://jira.qos.ch/browse/LOGBACK-1260">LOGBACK-1260</a>
+    with Patrick Reinhart providing the relevant patch.
+    </p>
+
+    <p>ConsoleAppender now works with consoles confused by output
+    strings of zero length, e.g.  Java Web Start. This fixes issue <a
+    href="https://jira.qos.ch/browse/LOGBACK-1282">LOGBACK-1282</a>
+    reported by Clas Forsberg.</p>
     
     <hr width="80%" align="center" />
 


### PR DESCRIPTION
(cherry picked from commit fc7c9a440f560260c450cfe57e5f1a42b643a6a5)