### PR TITLE
[LOGBACK-1409] FileFilterUtil.filesInFolderMatchingStemRegex resuses compiled pattern

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileFilterUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/FileFilterUtil.java
@@ -79,11 +79,9 @@ public class FileFilterUtil {
         if (!file.exists() || !file.isDirectory()) {
             return new File[0];
         }
-        return file.listFiles(new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                return name.matches(stemRegex);
-            }
-        });
+
+        Pattern regex = Pattern.compile(stemRegex);
+        return file.listFiles((dir, name) -> regex.matcher(name).matches());
     }
 
     static public int findHighestCounter(File[] matchingFileArray, final String stemRegex) {


### PR DESCRIPTION
Fixes [LOGBACK-1409](https://jira.qos.ch/browse/LOGBACK-1409)

While reviewing some JFR from a service using logback, I noticed some significant allocations and processing being done by `ch.qos.logback.core.rolling.helper.FileFilterUtil$3.accept(File, String)` where it was recompiling a regex for each listed file as part of the FileFilter.

![image](https://user-images.githubusercontent.com/54594/182257502-3b884e44-ed7f-4a5b-bf80-f172bd02b103.png)

This PR compiles the pattern once and reuses it for each file.