### PR TITLE
Add SequenceNumberConverter to convert logging event sequence number

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/PatternLayout.java
@@ -153,6 +153,10 @@ public class PatternLayout extends PatternLayoutBase<ILoggingEvent> {
         DEFAULT_CONVERTER_MAP.put("lsn", LocalSequenceNumberConverter.class.getName());
         CONVERTER_CLASS_TO_KEY_MAP.put(LocalSequenceNumberConverter.class.getName(), "lsn");
 
+        DEFAULT_CONVERTER_MAP.put("sn", SequenceNumberConverter.class.getName());
+        DEFAULT_CONVERTER_MAP.put("sequenceNumber", SequenceNumberConverter.class.getName());
+        CONVERTER_CLASS_TO_KEY_MAP.put(SequenceNumberConverter.class.getName(), "sequenceNumber");
+
         DEFAULT_CONVERTER_MAP.put("prefix", PrefixCompositeConverter.class.getName());
 
     }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/pattern/SequenceNumberConverter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/pattern/SequenceNumberConverter.java
@@ -1,0 +1,39 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.pattern;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * Return the event's sequence number.
+ * 
+ * @author Bertrand Renuart
+ */
+public class SequenceNumberConverter extends ClassicConverter {
+
+	@Override
+	public void start() {
+		if (getContext() == null || getContext().getSequenceNumberGenerator() == null) {
+			addWarn("No <sequenceNumberGenerator> defined in Logback configuration - event sequence numbers will not be incremented.");
+		}
+		super.start();
+	}
+	
+	
+	@Override
+    public String convert(ILoggingEvent event) {
+        return Long.toString(event.getSequenceNumber());
+    }
+
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/pattern/ConverterTest.java
@@ -410,4 +410,15 @@ public class ConverterTest {
         String result = converter.convert(event);
         assertEquals("v", result);
     }
+    
+    @Test
+    public void testSequenceNumber() {
+        SequenceNumberConverter converter = new SequenceNumberConverter();
+        converter.setContext(lc);
+
+        LoggingEvent event = makeLoggingEvent(null);
+
+        event.setSquenceNumber(123);
+        assertEquals("123", converter.convert(event));
+    }
 }


### PR DESCRIPTION
Add a SequenceNumberConverter and register it under the `%sn` and `%sequenceNumber` keywords.
Emit a WARN status when started if no sequence generator is defined in the logger context.

closes #1662
