### PR TITLE
Add implementation version in MANIFEST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,13 @@
           <version>${maven-jar-plugin.version}</version>
           <configuration>
             <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
+            <archive>
+            <index>true</index>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              </manifest>
+            </archive>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -285,8 +285,11 @@
           <configuration>
             <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
             <archive>
-            <index>true</index>
+              <index>true</index>
               <manifest>
+                <!-- Add version information into the MANIFEST so it is accessible by
+                     calling Package#getImplementationVersion()
+                 -->
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
               </manifest>


### PR DESCRIPTION
Configure the jar plugin to include the default implementation and specification entries in the MANIFEST file such that Package#getImplementationVersion() and Package#getSpecificationVersion() return meaningful values.

closes [#1597](https://jira.qos.ch/browse/LOGBACK-1597)
