### PR TITLE
fix(sec): upgrade jetty-server to 11.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <cal10n.version>0.8.1</cal10n.version>
     <consolePlugin.version>1.1.0</consolePlugin.version>
     <tomcat.version>10.0.10</tomcat.version>
-    <jetty.version>11.0.6</jetty.version>
+    <jetty.version>11.0.10</jetty.version>
     <compiler-plugin.version>3.10.1</compiler-plugin.version> <!-- 3.6.1, 3.7.0 -->
 
     <jansi.version>1.18</jansi.version>


### PR DESCRIPTION
Upgrade jetty-server 11.0.6 to 11.0.10 for vulnerability fix:
         - [CVE-2022-2191](https://www.oscs1024.com/hd/MPS-2022-19808)
         - [CVE-2022-2191](https://www.oscs1024.com/hd/MPS-2022-19808)