### PR TITLE
Performance fix for Copy array every time

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/spi/TurboFilterList.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/spi/TurboFilterList.java
@@ -52,7 +52,7 @@ final public class TurboFilterList extends CopyOnWriteArrayList<TurboFilter> {
             }
         }
 
-        Object[] tfa = toArray();
+        Object[] tfa = getArray();
         final int len = tfa.length;
         for (int i = 0; i < len; i++) {
             // for (TurboFilter tf : this) {


### PR DESCRIPTION
toArray() method copies the array every call of getTurboFilterChainDecision if size() > 1