### PR TITLE
Add plugin sortpom-maven-plugin to build

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +17,7 @@
   <properties>
     <module-name>ch.qos.logback.access</module-name>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -118,10 +116,10 @@
         <executions>
           <execution>
             <id>bundle-test-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <phase>package</phase>
           </execution>
         </executions>
       </plugin>
@@ -129,15 +127,6 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <instructions>
             <Export-Package>ch.qos.logback.access.*</Export-Package>
@@ -146,23 +135,28 @@
                 are created via IOC (xml config files). They won't be found by
                 Bnd's analysis of java code.
             -->
-            <Import-Package>
-              ch.qos.logback.core.rolling,
+            <Import-Package>ch.qos.logback.core.rolling,
               ch.qos.logback.core.rolling.helper,
               jakarta.servlet.*;version="4.0.0",
               org.apache.catalina.*;version="${tomcat.version}";resolution:=optional,
               org.eclipse.jetty.*;version="${jetty.version}";resolution:=optional,
-              *
-            </Import-Package>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6
-            </Bundle-RequiredExecutionEnvironment>
+              *</Import-Package>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
 
-  <profiles>
-  </profiles>
+  <profiles/>
 
 </project>

--- a/logback-classic-blackbox/pom.xml
+++ b/logback-classic-blackbox/pom.xml
@@ -1,127 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-parent</artifactId>
-        <version>1.4.5-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-parent</artifactId>
+    <version>1.4.5-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>logback-classic-blackbox</artifactId>
-    <packaging>jar</packaging>
-    <name>Logback Classic Blackbox Testing</name>
-    <description>Logback Classic Blackbox Testing Module</description>
+  <artifactId>logback-classic-blackbox</artifactId>
+  <packaging>jar</packaging>
+  <name>Logback Classic Blackbox Testing</name>
+  <description>Logback Classic Blackbox Testing Module</description>
 
-    <dependencies>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
 
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
 
-        <dependency>
-            <groupId>jakarta.mail</groupId>
-            <artifactId>jakarta.mail-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
+    <dependency>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <scope>compile</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
-        <dependency>
-            <groupId>org.dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <scope>compile</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
-            <scope>test</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-mail</artifactId>
+      <scope>test</scope>
+    </dependency>
 
-        <dependency>
-            <groupId>com.icegreen</groupId>
-            <artifactId>greenmail</artifactId>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.mail</groupId>
-                    <artifactId>jakarta.mail</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>com.icegreen</groupId>
+      <artifactId>greenmail</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.mail</groupId>
+          <artifactId>jakarta.mail</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-test</id>
-                        <configuration>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <configuration>
 
-                            <argLine>
-                            </argLine>
-                            <parallel>classes</parallel>
-                            <threadCount>8</threadCount>
-                            <!--<useUnlimitedThreads>false</useUnlimitedThreads>-->
-                            <forkCount>1C</forkCount>
-                            <reuseForks>true</reuseForks>
-                            <reportFormat>plain</reportFormat>
-                            <trimStackTrace>false</trimStackTrace>
-                            <!-- See https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
-                            <!--<childDelegation>true</childDelegation>-->
-                            <useModulePath>true</useModulePath>
+              <argLine/>
+              <parallel>classes</parallel>
+              <threadCount>8</threadCount>
+              <!--<useUnlimitedThreads>false</useUnlimitedThreads>-->
+              <forkCount>1C</forkCount>
+              <reuseForks>true</reuseForks>
+              <reportFormat>plain</reportFormat>
+              <trimStackTrace>false</trimStackTrace>
+              <!-- See https://issues.apache.org/jira/browse/SUREFIRE-1265 -->
+              <!--<childDelegation>true</childDelegation>-->
+              <useModulePath>true</useModulePath>
 
-                            <excludes>
-                                <!--- temporary -->
+              <excludes>
+                <!--- temporary -->
 
-                                <exclude>**/ConditionalTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
+                <exclude>**/ConditionalTest.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
 
-                    <execution>
-                        <id>singleJVM</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <forkCount>4</forkCount>
-                            <reuseForks>false</reuseForks>
-                            <includes>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+          <execution>
+            <id>singleJVM</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <forkCount>4</forkCount>
+              <reuseForks>false</reuseForks>
+              <includes/>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
 
-        </plugins>
-    </build>
+    </plugins>
+  </build>
 </project>

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -29,25 +27,25 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-<!--     <dependency>
+    <!--dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-ext</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>
-    </dependency> -->
+    </dependency -->
 
-<!--     <dependency>
+    <!--dependency>
       <groupId>ch.qos.cal10n.plugins</groupId>
       <artifactId>maven-cal10n-plugin</artifactId>
       <version>${cal10n.version}</version>
       <scope>test</scope>
-    </dependency> -->
+    </dependency -->
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <type>test-jar</type>
       <version>${slf4j.version}</version>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,25 +138,22 @@
 
     <plugins>
 
-       <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestEntries>
-            </manifestEntries>
-            <manifestFile>
-              ${project.build.outputDirectory}/META-INF/MANIFEST.MF
-            </manifestFile>
+            <manifestEntries/>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>
           <execution>
             <id>bundle-test-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <phase>package</phase>
           </execution>
         </executions>
       </plugin>
@@ -184,7 +179,6 @@
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit-jupiter-api.version}</version>
           </dependency>
-
 
           <dependency>
             <groupId>org.junit.vintage</groupId>
@@ -220,8 +214,11 @@
             </goals>
           </execution>
            -->
-	  <execution>
+          <execution>
             <id>ant-integration-test</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
             <phase>package</phase>
             <configuration>
               <target>
@@ -229,9 +226,6 @@
                 <ant antfile="${basedir}/integration.xml"/>
               </target>
             </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>
@@ -257,12 +251,10 @@
             <id>default-test</id>
             <configuration>
               <!-- x-show-module-resolution -->
-              <argLine>
-                --add-modules jakarta.mail
+              <argLine>--add-modules jakarta.mail
                 --add-modules jakarta.servlet
                 --add-opens ch.qos.logback.core/ch.qos.logback.core.testUtil=java.naming
-                --add-opens ch.qos.logback.classic/ch.qos.logback.classic.testUtil=ch.qos.logback.core
-              </argLine>
+                --add-opens ch.qos.logback.classic/ch.qos.logback.classic.testUtil=ch.qos.logback.core</argLine>
               <parallel>classes</parallel>
               <threadCount>8</threadCount>
               <!--<useUnlimitedThreads>false</useUnlimitedThreads>-->
@@ -307,19 +299,12 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <instructions>
-            <_noee>true</_noee> <!-- Jigsaw -->
-            <_failok>true</_failok> <!-- Jigsaw -->
+            <!-- Jigsaw -->
+            <_noee>true</_noee>
+            <!-- Jigsaw -->
+            <_failok>true</_failok>
             <Export-Package>ch.qos.logback.classic*, org.slf4j.impl;version=${slf4j.version}</Export-Package>
             <!-- LB-CLASSIC It is necessary to specify the rolling
                  file packages as classes are created via IOC (xml
@@ -343,15 +328,19 @@
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider</Provide-Capability>
 
-
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-      </plugins>
-    </pluginManagement>
   </build>
 
 </project>

--- a/logback-core-blackbox/pom.xml
+++ b/logback-core-blackbox/pom.xml
@@ -1,65 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-parent</artifactId>
-        <version>1.4.5-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-parent</artifactId>
+    <version>1.4.5-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>logback-core-blackbox</artifactId>
-    <packaging>jar</packaging>
-    <name>Logback Core Blackbox Testing</name>
-    <description>Logback Core Blackbox Testing Module</description>
+  <artifactId>logback-core-blackbox</artifactId>
+  <packaging>jar</packaging>
+  <name>Logback Core Blackbox Testing</name>
+  <description>Logback Core Blackbox Testing Module</description>
 
-    <dependencies>
+  <dependencies>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
-        <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <scope>compile</scope>
-        </dependency>
+  </dependencies>
 
-    </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <configuration>
+              <reuseForks>true</reuseForks>
+              <reportFormat>plain</reportFormat>
+              <trimStackTrace>false</trimStackTrace>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-test</id>
-                        <configuration>
-                            <reuseForks>true</reuseForks>
-                            <reportFormat>plain</reportFormat>
-                            <trimStackTrace>false</trimStackTrace>
+            </configuration>
+          </execution>
 
-                        </configuration>
-                    </execution>
+        </executions>
+      </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
 
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-        </plugins>
-    </build>
+    </plugins>
+  </build>
 </project>

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -23,7 +21,7 @@
   <dependencies>
 
     <dependency>
-       <groupId>org.codehaus.janino</groupId>
+      <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
       <scope>compile</scope>
       <optional>true</optional>
@@ -60,7 +58,6 @@
       <optional>true</optional>
     </dependency>
 
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -80,10 +77,8 @@
           <!--<argLine>XXadd-opens ch.qos.logback.core/ch.qos.logback.core.testUtil=java.naming</argLine>-->
           <!--<argLine>add-opens ch.qos.logback.core/ch.qos.logback.core.testUtil=java.naming
                        add-reads ch.qos.logback.core=ALL-UNNAMED</argLine>-->
-          <argLine>
-            --add-opens ch.qos.logback.core/ch.qos.logback.core.testUtil=java.naming
-            --add-reads ch.qos.logback.core=ALL-UNNAMED
-          </argLine>
+          <argLine>--add-opens ch.qos.logback.core/ch.qos.logback.core.testUtil=java.naming
+            --add-reads ch.qos.logback.core=ALL-UNNAMED</argLine>
           <parallel>classes</parallel>
           <threadCount>8</threadCount>
           <!--<useUnlimitedThreads>false</useUnlimitedThreads>-->
@@ -98,7 +93,6 @@
             <exclude>**/PackageTest.java</exclude>
             <!-- ConsoleAppenderTest redirects System.out which is not well tolerated by Maven -->
             <exclude>**/ConsoleAppenderTest.java</exclude>
-
 
           </excludes>
         </configuration>
@@ -116,10 +110,10 @@
         <executions>
           <execution>
             <id>bundle-test-jar</id>
-            <phase>package</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <phase>package</phase>
           </execution>
         </executions>
       </plugin>
@@ -128,33 +122,32 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
-
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <instructions>
-            <_noee>true</_noee> <!-- Jigsaw -->
-            <_failok>true</_failok> <!-- Jigsaw -->
+            <_noee>true</_noee>
+            <!-- Jigsaw -->
+            <_failok>true</_failok>
+            <!-- Jigsaw -->
             <Export-Package>ch.qos.logback.core.*</Export-Package>
-            <Import-Package>
-              jakarta.*;resolution:=optional,
+            <Import-Package>jakarta.*;resolution:=optional,
               org.xml.*;resolution:=optional,
               org.fusesource.jansi;resolution:=optional,
               org.codehaus.janino;resolution:=optional,
               org.codehaus.commons.compiler;resolution:=optional,
-              *
-            </Import-Package>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6
-            </Bundle-RequiredExecutionEnvironment>
+              *</Import-Package>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
+
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/logback-examples/pom.xml
+++ b/logback-examples/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -44,7 +42,7 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>compile</scope>
       <optional>true</optional>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
@@ -55,8 +53,8 @@
   <build>
     <resources>
       <resource>
-        <directory>src/main/resources</directory>
         <filtering>true</filtering>
+        <directory>src/main/resources</directory>
       </resource>
     </resources>
     <plugins>
@@ -66,10 +64,10 @@
         <executions>
           <execution>
             <id>copy</id>
-            <phase>package</phase>
             <goals>
               <goal>copy</goal>
             </goals>
+            <phase>package</phase>
             <configuration>
               <artifactItems>
                 <artifactItem>
@@ -92,7 +90,7 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-       
-   </plugins>
+
+    </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,12 +12,12 @@
   <description>logback project pom.xml file</description>
 
   <url>http://logback.qos.ch</url>
+  <inceptionYear>2005</inceptionYear>
 
   <organization>
     <name>QOS.ch</name>
     <url>http://www.qos.ch</url>
   </organization>
-  <inceptionYear>2005</inceptionYear>
 
   <licenses>
     <license>
@@ -33,23 +31,46 @@
     </license>
   </licenses>
 
-  <scm>
-    <url>https://github.com/qos-ch/logback</url>
-    <connection>scm:git@github.com:qos-ch/logback.git</connection>
-  </scm>
+  <developers>
+    <developer>
+      <id>ceki</id>
+      <name>Ceki Gulcu</name>
+      <email>ceki@qos.ch</email>
+    </developer>
+
+    <developer>
+      <id>hixi</id>
+      <name>Joern Huxhorn</name>
+      <email>huxi@undisclosed.org</email>
+    </developer>
+  </developers>
 
   <modules>
     <module>logback-core</module>
     <module>logback-core-blackbox</module>
     <module>logback-classic</module>
-    <module>logback-classic-blackbox</module>    
+    <module>logback-classic-blackbox</module>
     <module>logback-access</module>
     <module>logback-examples</module>
   </modules>
 
+  <scm>
+    <connection>scm:git@github.com:qos-ch/logback.git</connection>
+    <url>https://github.com/qos-ch/logback</url>
+  </scm>
+
+  <distributionManagement>
+
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+
+  </distributionManagement>
+
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
-    <project.build.outputTimestamp>2022-10-07T20:47:29Z</project.build.outputTimestamp>    
+    <project.build.outputTimestamp>2022-10-07T20:47:29Z</project.build.outputTimestamp>
     <jdk.version>11</jdk.version>
     <maven.compiler.release>${jdk.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -69,7 +90,7 @@
     <janino.version>3.1.8</janino.version>
     <!-- slf4j.version property is used below, in
          logback-classic/pom.xml, /logback-examples/src/main/resources/setClasspath.cmd, download.html
-    -->    
+    -->
     <slf4j.version>2.0.1</slf4j.version>
     <cal10n.version>0.8.1</cal10n.version>
     <consolePlugin.version>1.1.0</consolePlugin.version>
@@ -97,52 +118,8 @@
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <ant.version>1.10.12</ant.version>
     <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
+    <sortpom.maven.plugin.version>3.0.1</sortpom.maven.plugin.version>
   </properties>
-
-  <developers>
-    <developer>
-      <id>ceki</id>
-      <name>Ceki Gulcu</name>
-      <email>ceki@qos.ch</email>
-    </developer>
-
-    <developer>
-      <id>hixi</id>
-      <name>Joern Huxhorn</name>
-      <email>huxi@undisclosed.org</email>
-    </developer>
-  </developers>
-
-  <dependencies>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit-jupiter-api.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit-jupiter-api.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-  </dependencies>
 
   <dependencyManagement>
 
@@ -259,15 +236,38 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit-jupiter-api.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter-api.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-ssh</artifactId>
-        <version>2.10</version>
-      </extension>
-    </extensions>
 
     <pluginManagement>
       <plugins>
@@ -355,19 +355,34 @@
           <version>${maven-bundle-plugin.version}</version>
         </plugin>
 
-
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
-        	<groupId>org.eclipse.m2e</groupId>
-        	<artifactId>lifecycle-mapping</artifactId>
-        	<version>1.0.0</version>
-        	<configuration>
-        		<lifecycleMappingMetadata>
-        			<pluginExecutions>
-           			</pluginExecutions>
-        		</lifecycleMappingMetadata>
-        	</configuration>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions/>
+            </lifecycleMappingMetadata>
+          </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>com.github.ekryd.sortpom</groupId>
+          <artifactId>sortpom-maven-plugin</artifactId>
+          <version>${sortpom.maven.plugin.version}</version>
+          <configuration>
+            <createBackupFile>false</createBackupFile>
+            <expandEmptyElements>false</expandEmptyElements>
+            <keepBlankLines>true</keepBlankLines>
+            <lineSeparator>\n</lineSeparator>
+            <nrOfIndentSpace>2</nrOfIndentSpace>
+            <sortModules>false</sortModules>
+            <sortDependencies>none</sortDependencies>
+            <sortProperties>false</sortProperties>
+          </configuration>
+        </plugin>
+
       </plugins>
 
     </pluginManagement>
@@ -381,7 +396,7 @@
           <release>${jdk.version}</release>
         </configuration>
       </plugin>
- 
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
@@ -403,17 +418,29 @@
         <version>1.16.0</version>
       </plugin>
       -->
+
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh</artifactId>
+        <version>2.10</version>
+      </extension>
+    </extensions>
   </build>
-
-  <distributionManagement>
-
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-
-  </distributionManagement>
 
   <reporting>
     <plugins>
@@ -440,13 +467,12 @@
           <linkJavadoc>true</linkJavadoc>
         </configuration>
       </plugin>
-      
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        
-        <configuration>                                
+
+        <configuration>
           <aggregate>true</aggregate>
           <linkJavadoc>true</linkJavadoc>
           <linksource>true</linksource>
@@ -455,40 +481,33 @@
             <sourceFileExclude>**/module-info.java</sourceFileExclude>
           </sourceFileExcludes>
           <links>
-            <link>
-              http://docs.oracle.com/javase/7/docs/api/
-            </link>
+            <link>http://docs.oracle.com/javase/7/docs/api/</link>
           </links>
-          
+
           <groups>
             <group>
               <title>Logback Core</title>
-              <packages>ch.qos.logback.core:ch.qos.logback.core.*
-              </packages>
+              <packages>ch.qos.logback.core:ch.qos.logback.core.*</packages>
             </group>
             <group>
               <title>Logback Classic</title>
-              <packages>
-                ch.qos.logback:ch.qos.logback.classic:ch.qos.logback.classic.*
-              </packages>
+              <packages>ch.qos.logback:ch.qos.logback.classic:ch.qos.logback.classic.*</packages>
             </group>
             <group>
               <title>Logback Access</title>
-              <packages>ch.qos.logback.access:ch.qos.logback.access.*
-              </packages>
+              <packages>ch.qos.logback.access:ch.qos.logback.access.*</packages>
             </group>
             <group>
               <title>Examples</title>
               <packages>chapter*:joran*</packages>
             </group>
-          </groups>                  
+          </groups>
         </configuration>
       </plugin>
-      
-            
+
     </plugins>
   </reporting>
-  
+
   <profiles>
     <profile>
       <id>testSkip</id>
@@ -535,20 +554,20 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>${maven-javadoc-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>            
-            </executions>
             <configuration>
               <doclint>none</doclint>
               <sourceFileExcludes>
                 <sourceFileExclude>**/module-info.java</sourceFileExclude>
               </sourceFileExcludes>
             </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
@@ -565,10 +584,10 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
-                <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
`sortpom` automatically formats and structures the project's POMs.
This ensures harmonized, more readable POM layouts.
I've configured it to as closely as possible resemble the existing layouts.