### PR TITLE
Ridiculously minor - Fix misleading Jetty version comment

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/jetty/RequestLogImpl.java
@@ -55,13 +55,11 @@ import org.eclipse.jetty.util.component.LifeCycle;
  * </p>
  * <h2>Supported Jetty Versions</h2>
  * <p>
- * This {@code RequestLogImpl} only supports Jetty 7.0.0 through Jetty 10.
- * If you are using Jetty 11 with the new Jakarta Servlets (namespace {@code jakarta.servlet})
- * then you will need a more modern version of {@code logback-access}.
- * </p>
- * <h2>Configuring for Jetty 9.4.x through to Jetty 10.0.x</h2>
+ * This {@code RequestLogImpl} only supports Jetty 11+ with the new Jakarta Servlets
+ * (namespace {@code jakarta.servlet}).  For Jetty 9.4.x through to Jetty 10.0.x you will
+ * need to use Logback &lt; 1.4.
  * <p>
- * Jetty 9.4.x and Jetty 10.x use a modern {@code org.eclipse.jetty.server.Server.setRequestLog(RequestLog)}
+ * Jetty 11+ uses a modern {@code org.eclipse.jetty.server.Server.setRequestLog(RequestLog)}
  * interface that is based on a Server level RequestLog behavior.  This means all requests are logged,
  * even bad requests, and context-less requests.
  * </p>


### PR DESCRIPTION
The docs said it supported jetty10, which it does not - that appears to have change with Logback 1.4

This confused the heck out of me for a bit, so I thought I'd fix it - the actual class loading happens in IAccessEvent, so it's not immediately obvious the comment is wrong until you start pulling at the threads.