### PR TITLE
backport of fix LOGBACK-1162

### DIFF
--- a/logback-classic/src/test/input/joran/issues/logback_1162.xml
+++ b/logback-classic/src/test/input/joran/issues/logback_1162.xml
@@ -1,0 +1,19 @@
+<configuration debug="TRUE">
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${output_dir}/info.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${output_dir}/info.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%date %level [%thread] %logger{40} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="FILE" />
+    </root>
+    
+    <shutdownHook/>
+</configuration>

--- a/logback-classic/src/test/java/ch/qos/logback/classic/issue/logback_1162/Main.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/issue/logback_1162/Main.java
@@ -1,0 +1,29 @@
+package ch.qos.logback.classic.issue.logback_1162;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.ClassicTestConstants;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.util.concurrent.TimeUnit;
+
+public class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+    public static void main(String[] args) throws InterruptedException, JoranException {
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        lc.reset();
+        lc.putProperty("output_dir", ClassicTestConstants.OUTPUT_DIR_PREFIX+"logback_issue_1162/");
+        
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(lc);
+        configurator.doConfigure(ClassicTestConstants.JORAN_INPUT_PREFIX+ "issues/logback_1162.xml");
+
+        
+        logger.info("Hello, world!");
+
+        TimeUnit.SECONDS.sleep(0);
+    }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/issue/logback_1162/reproduce-bug.sh
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/issue/logback_1162/reproduce-bug.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+DD="dd"
+TOUCH="touch"
+
+TARGET_DIR=/home/ceki/logback/logback-classic/target/test-output/logback_issue_1162/
+
+rm -rf $TARGET_DIR && \
+  mkdir -p $TARGET_DIR  && \
+  $DD if=/dev/urandom of=$TARGET_DIR/info.log bs=1M count=50 && \
+  $TOUCH -d "24 hours ago" $TARGET_DIR/info.log 
+#./gradlew run && \
+#du -hs logs/*

--- a/logback-classic/src/test/java/ch/qos/logback/classic/joran/JoranConfiguratorTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/joran/JoranConfiguratorTest.java
@@ -440,4 +440,13 @@ public class JoranConfiguratorTest {
         configure(configFileAsStr);
         checker.assertIsWarningOrErrorFree();
     }
+    
+    @Test
+    public void shutdownHookTest() throws JoranException {
+        String configFileAsStr = ClassicTestConstants.JORAN_INPUT_PREFIX + "issues/logback_1162.xml";
+        loggerContext.putProperty("output_dir", ClassicTestConstants.OUTPUT_DIR_PREFIX+"logback_issue_1162/");
+        configure(configFileAsStr);
+        assertNotNull(loggerContext.getObject(CoreConstants.SHUTDOWN_HOOK_THREAD));
+    }
+
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
@@ -166,8 +166,8 @@ public class ContextBase implements Context, LifeCycle {
     }
 
     /**
-     * Clear the internal objectMap and all properties. Removes registered
-     * shutdown hook
+     * Clear the internal objectMap and all properties. Removes any registered
+     * shutdown hook.
      */
     public void reset() {
 

--- a/logback-core/src/main/java/ch/qos/logback/core/hook/DefaultShutdownHook.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/hook/DefaultShutdownHook.java
@@ -16,12 +16,12 @@ package ch.qos.logback.core.hook;
 import ch.qos.logback.core.util.Duration;
 
 /**
- * ShutdownHook implementation that stops the Logback context after a specified
+ * ShutdownHook implementation that <b>stops</b> the Logback context after a specified
  * delay.  The default delay is 0 ms (zero).
  *
  * @author Mike Reinhold
  */
-public class DelayingShutdownHook extends ShutdownHookBase {
+public class DefaultShutdownHook extends ShutdownHookBase {
     /**
      * The default is no delay before shutdown.
      */
@@ -32,7 +32,7 @@ public class DelayingShutdownHook extends ShutdownHookBase {
      */
     private Duration delay = DEFAULT_DELAY;
 
-    public DelayingShutdownHook() {
+    public DefaultShutdownHook() {
     }
 
     public Duration getDelay() {
@@ -49,10 +49,12 @@ public class DelayingShutdownHook extends ShutdownHookBase {
     }
 
     public void run() {
-        addInfo("Sleeping for "+delay);
-        try {
-            Thread.sleep(delay.getMilliseconds());
-        } catch (InterruptedException e) {
+        if (delay.getMilliseconds() > 0) {
+            addInfo("Sleeping for " + delay);
+            try {
+                Thread.sleep(delay.getMilliseconds());
+            } catch (InterruptedException e) {
+            }
         }
         super.stop();
     }

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/ShutdownHookAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/ShutdownHookAction.java
@@ -16,6 +16,7 @@ package ch.qos.logback.core.joran.action;
 import org.xml.sax.Attributes;
 
 import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.hook.DefaultShutdownHook;
 import ch.qos.logback.core.hook.ShutdownHookBase;
 import ch.qos.logback.core.joran.spi.ActionException;
 import ch.qos.logback.core.joran.spi.InterpretationContext;
@@ -44,9 +45,8 @@ public class ShutdownHookAction extends Action {
 
         String className = attributes.getValue(CLASS_ATTRIBUTE);
         if (OptionHelper.isEmpty(className)) {
-            addError("Missing class name for shutdown hook. Near [" + name + "] line " + getLineNumber(ic));
-            inError = true;
-            return;
+            className = DefaultShutdownHook.class.getName();
+            addInfo("Assuming className [" + className + "]");
         }
 
         try {
@@ -80,7 +80,7 @@ public class ShutdownHookAction extends Action {
             ic.popObject();
 
             Thread hookThread = new Thread(hook, "Logback shutdown hook [" + context.getName() + "]");
-
+            addInfo("Registeting shuthown hook with JVM runtime.");
             context.putObject(CoreConstants.SHUTDOWN_HOOK_THREAD, hookThread);
             Runtime.getRuntime().addShutdownHook(hookThread);
         }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
@@ -118,6 +118,7 @@ public class Compressor extends ContextAwareBase {
             if (!file2zip.delete()) {
                 addStatus(new WarnStatus("Could not delete [" + nameOfFile2zip + "].", this));
             }
+            addInfo("Done ZIP compressing [" + file2zip + "] as [" + zippedFile + "]");
         } catch (Exception e) {
             addStatus(new ErrorStatus("Error occurred while compressing [" + nameOfFile2zip + "] into [" + nameOfZippedFile + "].", this, e));
         } finally {
@@ -136,7 +137,9 @@ public class Compressor extends ContextAwareBase {
                 }
             }
         }
-
+        if (!file2zip.delete()) {
+            addStatus(new WarnStatus("Could not delete [" + nameOfFile2zip + "].", this));
+        }
     }
 
     // http://jira.qos.ch/browse/LBCORE-98
@@ -206,6 +209,7 @@ public class Compressor extends ContextAwareBase {
             if (!file2gz.delete()) {
                 addStatus(new WarnStatus("Could not delete [" + nameOfFile2gz + "].", this));
             }
+            addInfo("Done ZIP compressing [" + file2gz + "] as [" + gzedFile + "]");
         } catch (Exception e) {
             addStatus(new ErrorStatus("Error occurred while compressing [" + nameOfFile2gz + "] into [" + nameOfgzedFile + "].", this, e));
         } finally {
@@ -223,6 +227,9 @@ public class Compressor extends ContextAwareBase {
                     // ignore
                 }
             }
+        }
+        if (!file2gz.delete()) {
+            addStatus(new WarnStatus("Could not delete [" + nameOfFile2gz + "].", this));
         }
     }
 

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/JVMExitBeforeCompressionISDoneTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/JVMExitBeforeCompressionISDoneTest.java
@@ -3,7 +3,6 @@ package ch.qos.logback.core.rolling;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.util.Date;
 
 import org.junit.After;
@@ -13,7 +12,7 @@ import org.junit.Test;
 
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.encoder.EchoEncoder;
-import ch.qos.logback.core.hook.DelayingShutdownHook;
+import ch.qos.logback.core.hook.DefaultShutdownHook;
 import ch.qos.logback.core.status.OnConsoleStatusListener;
 import ch.qos.logback.core.testUtil.RandomUtil;
 import ch.qos.logback.core.util.StatusListenerConfigHelper;
@@ -23,7 +22,7 @@ public class JVMExitBeforeCompressionISDoneTest extends ScaffoldingForRollingTes
 
     RollingFileAppender<Object> rfa = new RollingFileAppender<Object>();
     TimeBasedRollingPolicy<Object> tbrp = new TimeBasedRollingPolicy<Object>();
-    DelayingShutdownHook delayingShutdownHook = new DelayingShutdownHook();
+    DefaultShutdownHook defaultShutdownHook = new DefaultShutdownHook();
     
     static final long FRI_2016_05_13_T_170415_GMT = 1463159055630L;
                                                     
@@ -34,7 +33,7 @@ public class JVMExitBeforeCompressionISDoneTest extends ScaffoldingForRollingTes
     public void setUp() {
         super.setUp();
         StatusListenerConfigHelper.addOnConsoleListenerInstance(context, new OnConsoleStatusListener());
-        delayingShutdownHook.setContext(context);
+        defaultShutdownHook.setContext(context);
         initRFA(rfa);
     }
 
@@ -62,7 +61,7 @@ public class JVMExitBeforeCompressionISDoneTest extends ScaffoldingForRollingTes
     @Ignore
     @Test
     public void test1() {
-        Thread shutdownThread = new Thread(delayingShutdownHook);
+        Thread shutdownThread = new Thread(defaultShutdownHook);
         Runtime.getRuntime().addShutdownHook(shutdownThread);
         
         String patternPrefix = "test1";

--- a/logback-site/src/site/pages/manual/configuration.html
+++ b/logback-site/src/site/pages/manual/configuration.html
@@ -785,8 +785,8 @@ public class MyApp3 {
    <p>In order to release the resources used by logback-classic, it is
    always a good idea to stop the logback context. Stopping the
    context will close all appenders attached to loggers defined by the
-   context and stop any active threads.
-   </p>
+   context and stop any active threads in an orderly way. Please also
+   read the section on "shutdown hooks" just below.</p>
 
 <pre class="prettyprint lang-java source">
 import org.sflf4j.LoggerFactory;
@@ -816,19 +816,29 @@ import ch.qos.logback.classic.LoggerContext;
 
    <pre class="prettyprint source">&lt;configuration debug="true">
    &lt;!-- in the absence of the class attribute, assume 
-   ch.qos.logback.core.hook.DelayingShutdownHook --&gt;
+   ch.qos.logback.core.hook.DefaultShutdownHook --&gt;
    <b>&lt;shutdownHook/></b>
   .... 
 &lt;/configuration></pre>
-   
-   <p>The default shutdown hook, namely <a
-   href="../apidocs/ch/qos/logback/core/hook/DelayingShutdownHook.html">DelayingShutdownHook</a>,
-   can delay shutdown by a user specified duration. Note that you may
-   install a shutdown hook of your own making by setting the <span
-   class="attr">class</span> attribute to correspond to your shutdown
-   hook's class name.</p>
 
-    <h4 class="doAnchor" name="webShutdownHook">Stopping logback-classic 
+   <p>Note that you may install a shutdown hook of your own making by
+       setting the <span class="attr">class</span> attribute to correspond
+       to your shutdown hook's class name.</p>
+
+   <p>The default shutdown hook, namely <a
+   href="../apidocs/ch/qos/logback/core/hook/DefaultShutdownHook.html">DefaultShutdownHook</a>,
+   will <b>stop</b> the logback context after a specified delay (0 by
+   default). Stopping the context will allow up to 30 seconds for any
+   log file compression tasks running in the background to finish. In
+   standalone Java applications, adding a
+   <code>&lt;shutdownHook/></code> directive to your configuration
+   file is an easy way to ensure that any ongoing compression tasks
+   are allowed to finish before JVM exit. In applications within a Web
+   server, <a href="#webShutdownHook">webShutdownHook</a> will be
+   installed automatically making <code>&lt;shutdownHook/></code>
+   directive quite redundant and unnecessary. </p>
+
+   <h4 class="doAnchor" name="webShutdownHook">WebShutdownHook or stopping logback-classic
    in web-applications</h4>
   
    <p><span class="label">since 1.1.10</span> Logback-classic will


### PR DESCRIPTION
For fixing the LOGBACK-1162 bug that occurs when using Spring Boot 2, need to backport it to logback-1.2.x version, as Spring Boot 2 can't be upgraded to logback-1.3.x due to its upgrade policy. See https://github.com/spring-projects/spring-boot/pull/33648 for details.


(adapting commit 4d705d9045b4df494b358984d326efb2ee9d6bd0)