### PR TITLE
fix a test failure by increasing waiting time

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/FileAppenderResilienceTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/FileAppenderResilienceTest.java
@@ -90,7 +90,7 @@ public class FileAppenderResilienceTest implements RecoveryListener {
 
         double delayCoefficient = 2.0;
         for (int i = 0; i < 5; i++) {
-            Thread.sleep((int) (RecoveryCoordinator.BACKOFF_COEFFICIENT_MIN * delayCoefficient));
+            Thread.sleep((int) (RecoveryCoordinator.BACKOFF_COEFFICIENT_MIN * delayCoefficient)+200);
             closeLogFileOnPurpose();
         }
         runner.setDone(true);


### PR DESCRIPTION
**What is the purpose of this PR**
-  This PR fixes the flaky failure mentioned https://jira.qos.ch/browse/LOGBACK-1720

**Why the test fails**
The test is failed because one thread (threadId-1) executes the assertion given at Line 104. In this assertion, this thread is checking the value of a global variable _recoveryCounter_. This variable value is supposed to be set by another thread (threadId-24). However, due to some noise or different thread interleaving, that thread cannot set the value of _recoveryCounter_. As a result, the test failure occurs.

**Fix**
We simply increase some waiting time (for the thread Id-1) before this assertion check.
