### PR TITLE
Reducing flakiness by increasing waiting time

### DIFF
--- a/logback-core/src/test/java/ch/qos/logback/core/FileAppenderResilienceTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/FileAppenderResilienceTest.java
@@ -90,7 +90,7 @@ public class FileAppenderResilienceTest implements RecoveryListener {
 
         double delayCoefficient = 2.0;
         for (int i = 0; i < 5; i++) {
-            Thread.sleep((int) (RecoveryCoordinator.BACKOFF_COEFFICIENT_MIN * delayCoefficient));
+            Thread.sleep((int) (RecoveryCoordinator.BACKOFF_COEFFICIENT_MIN * delayCoefficient) + 200);
             closeLogFileOnPurpose();
         }
         runner.setDone(true);


### PR DESCRIPTION
**What is the purpose of this PR** 
-  This PR fixes the flaky failure mentioned in https://jira.qos.ch/browse/LOGBACK-1720 

**Why the test fails**
When the main test thread executes the assertion given at Line 104, it is checking the value of a global variable _recoveryCounter_. This variable value is supposed to be set by another thread. However, due to some noise, sometimes that thread cannot set the value of _recoveryCounter_ before the other thread checks the value. As a result, the flaky test failure occurs.

**Fix**
We increase the existing waiting time in the test before the assertion check.
