### PR TITLE
Custom selector class via JNDI and post-create logger customization

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
@@ -28,6 +28,9 @@ public class ClassicConstants {
             + "comp/env/logback/configuration-resource";
     public static final String JNDI_CONTEXT_NAME = JNDI_JAVA_NAMESPACE + "comp/env/logback/context-name";
 
+    /** JNDI name of custom contextSelector classname, if used */
+    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = "java:comp/env/logback/contextSelector";
+    
     /**
      * The maximum number of package separators (dots) that abbreviation algorithms
      * can handle. Class or logger names with more separators will have their first

--- a/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
@@ -154,6 +154,7 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
                 childLogger = logger.getChildByName(childName);
                 if (childLogger == null) {
                     childLogger = logger.createChildByName(childName);
+                    customizeNewLogger(childLogger);
                     loggerCache.put(childName, childLogger);
                     incSize();
                 }
@@ -165,6 +166,15 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
         }
     }
 
+    /**
+     * Allows subclasses to perform post-create modifications on newly-created {@link Logger} instances.
+     * By default, this method does nothing
+     *  
+     * @param childLogger
+     */
+    protected void customizeNewLogger(final Logger childLogger) {
+    }
+    
     private void incSize() {
         size++;
     }

--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/ContextSelectorStaticBinder.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/ContextSelectorStaticBinder.java
@@ -74,7 +74,7 @@ public class ContextSelectorStaticBinder {
         if (contextSelectorStr == null) {
             try {
                 Context ctx = JNDIUtil.getInitialContext();
-                contextSelectorStr = (String) JNDIUtil.lookup(ctx, ClassicConstants.JNDI_LOGBACK_CONTEXT_SELECTOR);
+                contextSelectorStr = JNDIUtil.lookupString(ctx, ClassicConstants.JNDI_LOGBACK_CONTEXT_SELECTOR);
             } catch (NamingException ne) {
                 // We can't log here
             }


### PR DESCRIPTION
* allows specifying a custom selector class name via JNDI
* allows specifying a custom selector class name system environment (useful in conjunction with JEE context environment vars)
* allows optional post-create customization of new loggers
* if a custom selector throws an Exception, fall back to default selector
