### PR TITLE
Allows subclasses to do post-create operations on new Logger instances

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
@@ -154,6 +154,7 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
                 childLogger = logger.getChildByName(childName);
                 if (childLogger == null) {
                     childLogger = logger.createChildByName(childName);
+                    customizeNewLogger(childLogger);
                     loggerCache.put(childName, childLogger);
                     incSize();
                 }
@@ -165,6 +166,15 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
         }
     }
 
+    /**
+     * This method allows subclasses to perform post-create customizations on newly-created {@link Logger} instances.
+     * By default, this method does nothing
+     *  
+     * @param childLogger
+     */
+    protected void customizeNewLogger(final Logger childLogger) {
+    }
+    
     private void incSize() {
         size++;
     }


### PR DESCRIPTION
Allows subclasses to do post-create operations on new Logger instances. This is very useful for subclassing Logger in conjunction with a custom context selector.

Signed-off-by: Richard Sand <rsand@idfconnect.com>
