### PR TITLE
Adds additional methods to specify a custom context selector

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -15,7 +15,6 @@
   <packaging>jar</packaging>
   <name>Logback Classic Module</name>
   <description>logback-classic module</description>
-  <version>1.4.6.IDFC.1</version>
 
   <properties>
     <module-name>ch.qos.logback.classic</module-name>
@@ -25,7 +24,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -109,7 +107,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -15,6 +15,7 @@
   <packaging>jar</packaging>
   <name>Logback Classic Module</name>
   <description>logback-classic module</description>
+  <version>1.4.6.IDFC.1</version>
 
   <properties>
     <module-name>ch.qos.logback.classic</module-name>
@@ -24,6 +25,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -107,6 +109,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
+      <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
@@ -28,6 +28,9 @@ public class ClassicConstants {
             + "comp/env/logback/configuration-resource";
     public static final String JNDI_CONTEXT_NAME = JNDI_JAVA_NAMESPACE + "comp/env/logback/context-name";
 
+    /** JNDI name of custom contextSelector classname, if used */
+    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = "java:comp/env/logback/contextSelector";
+
     /**
      * The maximum number of package separators (dots) that abbreviation algorithms
      * can handle. Class or logger names with more separators will have their first

--- a/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
@@ -29,7 +29,7 @@ public class ClassicConstants {
     public static final String JNDI_CONTEXT_NAME = JNDI_JAVA_NAMESPACE + "comp/env/logback/context-name";
 
     /** JNDI name of custom contextSelector classname, if used */
-    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = "java:comp/env/logback/contextSelector";
+    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = JNDI_JAVA_NAMESPACE + "comp/env/logback/contextSelector";
 
     /**
      * The maximum number of package separators (dots) that abbreviation algorithms


### PR DESCRIPTION
* via system environment - especially usefor for JEE contexts
* via JNDI lookup (note this is NOT the same as using the ContextJNDISelector)

Signed-off-by: Richard Sand <rsand@idfconnect.com>