### PR TITLE
LOGBACK-1729: Add OSGi Service Loader Mediator entries to load logback Configurators

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -333,10 +333,17 @@
               *
             </Import-Package>
             <!-- Needed to integrate ServiceLoader mechanism with OSGi -->
-            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
-            <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider</Provide-Capability>
-
-
+            <Require-Capability><![CDATA[
+              osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))",
+              osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))",
+              osgi.serviceloader;filter:="(osgi.serviceloader=ch.qos.logback.classic.spi.Configurator)";osgi.serviceloader="ch.qos.logback.classic.spi.Configurator";cardinality:=multiple
+            ]]></Require-Capability>
+            <Provide-Capability><![CDATA[
+              osgi.service;objectClass:List<String>="jakarta.servlet.ServletContainerInitializer";effective:=active,
+              osgi.service;objectClass:List<String>="org.slf4j.spi.SLF4JServiceProvider";effective:=active,
+              osgi.serviceloader;osgi.serviceloader="jakarta.servlet.ServletContainerInitializer";register:="ch.qos.logback.classic.servlet.LogbackServletContainerInitializer",
+              osgi.serviceloader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="ch.qos.logback.classic.spi.LogbackServiceProvider"
+            ]]></Provide-Capability>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
At the moment logback cannot load Configurator implementations provided by other bundles in an OSGi runtime, because of missing Service Loader Mediator entries. This PR adds them, so the Service Loader Mediator implementation does not have to be configured to workaround the missing metadata.

Additionally add entry to provide the `ServletContainerInitializer` service implementation in OSGi runtimes via SPI.

In general improve the overall quality of the Service Loader Mediator entries.
See
- https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.loader.html
- https://aries.apache.org/documentation/modules/spi-fly.html#specconf

Fixes https://jira.qos.ch/browse/LOGBACK-1729.