### PR TITLE
Fix LOGBACK-1728: Incorrect OSGi execution-environment requirements

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -127,7 +127,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -148,13 +147,10 @@
             <Import-Package>
               ch.qos.logback.core.rolling,
               ch.qos.logback.core.rolling.helper,
-              javax.servlet.*;version="4.0.0",
               org.apache.catalina.*;version="${tomcat.version}";resolution:=optional,
               org.eclipse.jetty.*;version="${jetty.version}";resolution:=optional,
               *
             </Import-Package>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6
-            </Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
       </plugin>

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -303,7 +303,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -315,8 +314,6 @@
         </executions>
         <configuration>
           <instructions>
-            <_noee>true</_noee> <!-- Jigsaw -->
-            <_failok>true</_failok> <!-- Jigsaw -->
             <Export-Package>ch.qos.logback.classic*, org.slf4j.impl;version=${slf4j.version}</Export-Package>
             <!-- LB-CLASSIC It is necessary to specify the rolling
                  file packages as classes are created via IOC (xml
@@ -326,16 +323,11 @@
               sun.reflect;resolution:=optional,
               javax.*;resolution:=optional,
               org.xml.*;resolution:=optional,
-              org.slf4j,
-              org.slf4j.spi,
-              org.slf4j.event,
               ch.qos.logback.core.rolling,
               ch.qos.logback.core.rolling.helper,
-              ch.qos.logback.core.util,
               ch.qos.logback.core.read,
               *
             </Import-Package>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
             <!-- Needed to integrate ServiceLoader mechanism with OSGi -->
             <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider</Provide-Capability>

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -128,7 +128,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
 
         <executions>
           <execution>
@@ -141,8 +140,6 @@
         </executions>
         <configuration>
           <instructions>
-            <_noee>true</_noee> <!-- Jigsaw -->
-            <_failok>true</_failok> <!-- Jigsaw -->
             <Export-Package>ch.qos.logback.core.*</Export-Package>
             <Import-Package>
               javax.*;resolution:=optional,
@@ -152,8 +149,6 @@
               org.codehaus.commons.compiler;resolution:=optional,
               *
             </Import-Package>
-            <Bundle-RequiredExecutionEnvironment>JavaSE-1.6
-            </Bundle-RequiredExecutionEnvironment>
           </instructions>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
-    <maven-bundle-plugin.version>5.1.6</maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <ant.version>1.10.12</ant.version>
     <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>


### PR DESCRIPTION
Back port of https://github.com/qos-ch/logback/pull/640/ to the 1.3.x branch.
