### PR TITLE
LOGBACK-1730: Remove obsolete Export of package 'org.slf4j.impl' in OSGi

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -318,7 +318,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Export-Package>ch.qos.logback.classic*, org.slf4j.impl;version=${slf4j.version}</Export-Package>
+            <Export-Package>ch.qos.logback.classic*</Export-Package>
             <!-- LB-CLASSIC It is necessary to specify the rolling
                  file packages as classes are created via IOC (xml
                  config files). They won't be found by Bnd's analysis


### PR DESCRIPTION
Since SLF4J 2 the connection between SLFJ4 and its providers is established via the Service Loader mechanism, which is enabled in OSGi runtimes using a Service Loader Mediator.

The package 'org.slf4j.impl' no longer exists in this bundle and
therefore can not and need no longer be exported.