### PR TITLE
feat: implement a json encoder

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/encoder/JsonEncoder.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/encoder/JsonEncoder.java
@@ -1,0 +1,134 @@
+package ch.qos.logback.classic.encoder;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is a concrete JsonEncoder for {@link ILoggingEvent} that emits fields according to object's configuration.
+ * It is partially imported from <a href="https://github.com/hkupty/penna">penna</a>, but adapted to logback's structure.
+ *
+ * @author Henry John Kupty
+ */
+public class JsonEncoder extends ch.qos.logback.core.encoder.JsonEncoder<ILoggingEvent> {
+
+
+    // Excerpt below imported from
+    // ch.qos.logback.contrib.json.classic.JsonLayout
+    public static final String TIMESTAMP_ATTR_NAME = "timestamp";
+    public static final String LEVEL_ATTR_NAME = "level";
+    public static final String MARKERS_ATTR_NAME = "tags";
+    public static final String THREAD_ATTR_NAME = "thread";
+    public static final String MDC_ATTR_NAME = "mdc";
+    public static final String LOGGER_ATTR_NAME = "logger";
+    public static final String FORMATTED_MESSAGE_ATTR_NAME = "message";
+    public static final String MESSAGE_ATTR_NAME = "raw-message";
+    public static final String EXCEPTION_ATTR_NAME = "exception";
+    public static final String CONTEXT_ATTR_NAME = "context";
+
+    protected boolean includeLevel;
+    protected boolean includeThreadName;
+    protected boolean includeMDC;
+    protected boolean includeLoggerName;
+    protected boolean includeFormattedMessage;
+    protected boolean includeMessage;
+    protected boolean includeException;
+    protected boolean includeContextName;
+
+    private final List<Emitter<ILoggingEvent>> emitters;
+
+
+    public JsonEncoder() {
+        super();
+
+        emitters = new ArrayList<>();
+        this.includeLevel = true;
+        this.includeThreadName = true;
+        this.includeMDC = true;
+        this.includeLoggerName = true;
+        this.includeFormattedMessage = true;
+        this.includeException = true;
+        this.includeContextName = true;
+    }
+
+    public void writeMessage(ILoggingEvent event) {
+        jsonWriter.writeStringValue(MESSAGE_ATTR_NAME, event.getMessage());
+    }
+
+    public void writeFormattedMessage(ILoggingEvent event) {
+        jsonWriter.writeStringValue(FORMATTED_MESSAGE_ATTR_NAME, event.getFormattedMessage());
+    }
+
+    public void writeLogger(ILoggingEvent event) {
+        jsonWriter.writeStringValue(LOGGER_ATTR_NAME, event.getLoggerName());
+    }
+
+    public void writeThreadName(ILoggingEvent event) {
+        jsonWriter.writeStringValue(THREAD_ATTR_NAME, event.getThreadName());
+    }
+
+    public void writeLevel(ILoggingEvent event) {
+        jsonWriter.writeStringValue(LEVEL_ATTR_NAME, event.getLevel().levelStr);
+    }
+
+
+    public void writeMarkers(ILoggingEvent event) {
+        var markers = event.getMarkerList();
+        if (!markers.isEmpty()) {
+            jsonWriter.openArray(MARKERS_ATTR_NAME);
+            for (var marker : markers) {
+                jsonWriter.writeString(marker.getName());
+                jsonWriter.writeSep();
+            }
+            // Close array will overwrite the last "," in the buffer, so we are OK
+            jsonWriter.closeArray();
+            jsonWriter.writeSep();
+        }
+    }
+
+    public void writeMdc(ILoggingEvent event) {
+        var mdc = event.getMDCPropertyMap();
+        if (!mdc.isEmpty()) {
+            jsonWriter.openObject(MDC_ATTR_NAME);
+            for (var entry : mdc.entrySet()) {
+                jsonWriter.writeStringValue(entry.getKey(), entry.getValue());
+            }
+            jsonWriter.closeObject();
+            jsonWriter.writeSep();
+        }
+    }
+
+    private void buildEmitterList() {
+        // This method should be re-entrant and allow for reconfiguring the emitters if something change;
+        emitters.clear();
+
+        // TODO figure out order
+        if (includeLevel) emitters.add(this::writeLevel);
+        if (includeMDC) emitters.add(this::writeMdc);
+        if (includeMessage) emitters.add(this::writeMessage);
+        if (includeFormattedMessage) emitters.add(this::writeFormattedMessage);
+        if (includeThreadName) emitters.add(this::writeThreadName);
+        if (includeLoggerName) emitters.add(this::writeLogger);
+        // TODO add fields missing:
+        // context
+        // exception
+        // custom data
+        // marker
+    }
+
+    @Override
+    public byte[] encode(ILoggingEvent event) {
+        if (emitters.isEmpty()) {
+            buildEmitterList();
+        }
+        jsonWriter.openObject();
+
+        for (var emitter: emitters) {
+            emitter.write(event);
+        }
+
+        jsonWriter.closeObject();
+        return jsonWriter.flush();
+    }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/JsonEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/JsonEncoder.java
@@ -1,0 +1,18 @@
+package ch.qos.logback.core.encoder;
+
+public class JsonEncoder<E> extends EncoderBase<E> {
+    @Override
+    public byte[] headerBytes() {
+        return new byte[0];
+    }
+
+    @Override
+    public byte[] encode(E event) {
+        return new byte[0];
+    }
+
+    @Override
+    public byte[] footerBytes() {
+        return new byte[0];
+    }
+}

--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/JsonEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/JsonEncoder.java
@@ -1,14 +1,28 @@
 package ch.qos.logback.core.encoder;
 
-public class JsonEncoder<E> extends EncoderBase<E> {
-    @Override
-    public byte[] headerBytes() {
-        return new byte[0];
+import ch.qos.logback.core.util.DirectJson;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * This class allows for concrete encoders to write json log messages.
+ *
+ * @param <E>
+ * @author Henry John Kupty
+ */
+public abstract class JsonEncoder<E> extends EncoderBase<E> {
+    @FunctionalInterface
+    protected interface Emitter<E> {
+        void write(E event);
     }
 
+    private static final byte[] LINE_BREAK = System.getProperty("line.separator").getBytes(StandardCharsets.UTF_8);
+
+    protected DirectJson jsonWriter = new DirectJson();
+
     @Override
-    public byte[] encode(E event) {
-        return new byte[0];
+    public byte[] headerBytes() {
+        return LINE_BREAK;
     }
 
     @Override

--- a/logback-core/src/main/java/ch/qos/logback/core/util/DirectJson.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/DirectJson.java
@@ -1,0 +1,265 @@
+package ch.qos.logback.core.util;
+
+import java.io.Closeable;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * This is a utility class for writing json logs.
+ * It is imported from (and in collaboration with) penna.
+ *
+ * @author Henry John Kupty
+ * @see <a href="https://github.com/hkupty/penna">penna</a>
+ */
+public final class DirectJson implements Closeable {
+    private static final int INITIAL_BUFFER_SIZE = 32 * 1024;
+    private static final byte[] LINE_BREAK = System.getProperty("line.separator").getBytes(StandardCharsets.UTF_8);
+    private static final byte QUOTE = '"';
+    private static final byte ENTRY_SEP = ':';
+    private static final byte KV_SEP = ',';
+    private static final byte DOT = '.';
+    private static final byte OPEN_OBJ = '{';
+    private static final byte CLOSE_OBJ = '}';
+    private static final byte OPEN_ARR = '[';
+    private static final byte CLOSE_ARR = ']';
+
+    private static final byte[] NEWLINE = new byte[] {
+            '\\',
+            'n',
+    };
+    private static final byte[] ESCAPE = new byte[] {
+            '\\',
+            '\\',
+    };
+    private static final byte[] LINEBREAK = new byte[] {
+            '\\',
+            'r',
+    };
+    private static final byte[] TAB = new byte[] {
+            '\\',
+            't',
+    };
+    private static final byte[] TRUE = new byte[] {
+            't',
+            'r',
+            'u',
+            'e'
+    };
+    private static final byte[] FALSE = new byte[] {
+            'f',
+            'a',
+            'l',
+            's',
+            'e'
+    };
+    private static final byte[] NULL = new byte[] {
+            'n',
+            'u',
+            'l',
+            'l'
+    };
+
+    private final FileOutputStream backingOs;
+    private final FileChannel channel;
+    // This is not private only for the sake of testing
+    ByteBuffer buffer = ByteBuffer.allocateDirect(INITIAL_BUFFER_SIZE);
+
+    public DirectJson(FileChannel channel) {
+        this.backingOs = null;
+        this.channel = channel;
+    }
+    @SuppressWarnings("PMD.AvoidFileStream")
+    public DirectJson() {
+        this.backingOs = new FileOutputStream(FileDescriptor.out);
+        this.channel = backingOs.getChannel();
+    }
+
+    public void openObject() { buffer.put(OPEN_OBJ); }
+    public void openArray() { buffer.put(OPEN_ARR); }
+
+    public void openObject(String str) {
+        writeString(str);
+        writeEntrySep();
+        buffer.put(OPEN_OBJ);
+    }
+
+    public void openArray(String str) {
+        writeString(str);
+        writeEntrySep();
+        buffer.put(OPEN_ARR);
+    }
+
+    public void closeObject() {
+        var target = buffer.position() - 1;
+        if (',' == buffer.get(target)) {
+            buffer.put(target, CLOSE_OBJ);
+        } else {
+            buffer.put(CLOSE_OBJ);
+        }
+    }
+
+    public void closeArray() {
+        var target = buffer.position() - 1;
+        if (',' == buffer.get(target)) {
+            buffer.put(target, CLOSE_ARR);
+        } else {
+            buffer.put(CLOSE_ARR);
+        }
+    }
+
+    public void writeRaw(String str) {
+        for(int i = 0; i < str.length(); i++ ){
+            var chr = str.codePointAt(i);
+            switch (chr) {
+                case '\\':
+                    buffer.put(ESCAPE);
+                    break;
+                case '\n':
+                    buffer.put(NEWLINE);
+                    break;
+                case '\r':
+                    buffer.put(LINEBREAK);
+                    break;
+                case '\t':
+                    buffer.put(TAB);
+                    break;
+                default:
+                    if (chr >= 0x80 && chr <= 0x10FFFF) {
+                        buffer.put(String.valueOf(str.charAt(i)).getBytes());
+                    } else if (chr > 0x1F) buffer.put((byte) chr);
+            }
+
+        }
+    }
+
+    public void writeRaw(char chr) { buffer.put((byte) chr); }
+    public void writeRaw(byte[] chr) { buffer.put(chr); }
+
+    public void writeQuote() { buffer.put(QUOTE); }
+    public void writeString(String str) {
+        checkSpace(str.length() + 3);
+        buffer.put(QUOTE);
+        writeRaw(str);
+        buffer.put(QUOTE);
+        buffer.put(KV_SEP);
+    }
+    public void writeSep() { buffer.put(KV_SEP); }
+
+    public void writeNumberRaw(final long data) {
+        final int pos = buffer.position();
+        final int sz = (int) Math.log10(data) + 1;
+        long dataPointer = data;
+
+        for (int i = sz - 1; i >= 0; i--) {
+            byte chr = (byte) (dataPointer % 10);
+            dataPointer = dataPointer / 10;
+            chr += 48;
+            buffer.put(pos + i, chr);
+        }
+
+        buffer.position(pos + sz);
+    }
+
+    public void writeNumber(final long data) {
+        final int pos = buffer.position();
+        final int sz = data == 0 ? 1 : (int) Math.log10(data) + 1;
+        long dataPointer = data;
+
+        for (int i = sz - 1; i >= 0; i--) {
+            byte chr = (byte) (dataPointer % 10);
+            dataPointer = dataPointer / 10;
+            chr += 48;
+            buffer.put(pos + i, chr);
+        }
+
+        buffer.position(pos + sz);
+        buffer.put(KV_SEP);
+    }
+
+    public void writeNumber(final double data) {
+        int pos = buffer.position();
+        long whole = (long) data;
+        final int sz = (int) Math.log10(whole) + 1;
+
+        for (int i = sz - 1; i >= 0; i--) {
+            byte chr = (byte) (whole % 10);
+            whole = whole / 10;
+            chr += 48;
+            buffer.put(pos + i, chr);
+        }
+        buffer.position(pos + sz);
+        buffer.put(DOT);
+        pos = buffer.position();
+        BigDecimal fractional = BigDecimal.valueOf(data).remainder(BigDecimal.ONE);
+        int decs = 0;
+        while (!fractional.equals(BigDecimal.ZERO)) {
+            fractional = fractional.movePointRight(1);
+            byte chr = (byte) (fractional.intValue() + 48);
+            fractional = fractional.remainder(BigDecimal.ONE);
+            decs += 1;
+            buffer.put(chr);
+        }
+
+        buffer.position(pos + decs);
+        buffer.put(KV_SEP);
+    }
+
+    public void writeEntrySep() { buffer.put(buffer.position() - 1, ENTRY_SEP); }
+
+    public void writeStringValue(String key, String value) {
+        writeString(key);
+        writeEntrySep();
+        writeString(value);
+    }
+
+    public void writeNumberValue(String key, long value) {
+        writeString(key);
+        writeEntrySep();
+        writeNumber(value);
+    }
+
+    public void writeNumberValue(String key, double value) {
+        writeString(key);
+        writeEntrySep();
+        writeNumber(value);
+    }
+
+    public void writeBoolean(boolean value) {
+        buffer.put(value ? TRUE : FALSE);
+        buffer.put(KV_SEP);
+    }
+
+    public void writeNull() {
+        buffer.put(NULL);
+        buffer.put(KV_SEP);
+    }
+
+    public void checkSpace(int size) {
+        // buffer at ~80% of the capacity
+        if (buffer.position() + size >= buffer.capacity()) {
+            var newSize = (buffer.capacity() + size) * 2;
+            ByteBuffer newBuffer = ByteBuffer.allocateDirect(newSize);
+            buffer.flip();
+            newBuffer.put(buffer);
+            buffer = newBuffer;
+        }
+    }
+
+    public void flush() throws IOException {
+        buffer.put(LINE_BREAK);
+        buffer.flip();
+        channel.write(buffer);
+        buffer.clear();
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+        if (this.backingOs != null) backingOs.close();
+    }
+}


### PR DESCRIPTION
This is an initial implementation of a json encoder for logback.

To be noted:
- This is still work-in-progress and will be updated still, but I decided to open it earlier to enable for async discussion;
- Based on [penna's `DirectJson` implementation](https://github.com/hkupty/penna), but adapted to logback's jvm targer version and usage;