### PR TITLE
Ensure proper version ranges of re-imported OSGi packages

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -146,6 +146,7 @@
                 Bnd's analysis of java code.
             -->
             <Import-Package>
+              ch.qos.logback.access*;version="${range;[==,+);${maven_version;${project.version}}}",
               ch.qos.logback.core.rolling,
               ch.qos.logback.core.rolling.helper,
               org.apache.catalina.*;version="${tomcat.version}";resolution:=optional,

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -324,6 +324,7 @@
                  config files). They won't be found by Bnd's analysis
                  of java code. -->
             <Import-Package>
+              ch.qos.logback.classic*;version="${range;[==,+);${maven_version;${project.version}}}",
               sun.reflect;resolution:=optional,
               jakarta.*;resolution:=optional,
               org.xml.*;resolution:=optional,

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -139,8 +139,9 @@
         </executions>
         <configuration>
           <instructions>
-            <Export-Package>ch.qos.logback.core.*</Export-Package>
+            <Export-Package>ch.qos.logback.core*</Export-Package>
             <Import-Package>
+              ch.qos.logback.core*;version="${range;[==,+);${maven_version;${project.version}}}",
               jakarta.*;resolution:=optional,
               org.xml.*;resolution:=optional,
               org.fusesource.jansi;resolution:=optional,


### PR DESCRIPTION
As mentioned in https://github.com/qos-ch/logback/pull/642#issuecomment-1481528172 when building logback locally the Imported Packages, which are also exported by a logback bundle have no version range at all. But in general they should have one.

Looking into the jars of previous releases at Maven-Central even those 're-imported' packages have a suitable version range, but I cannot really tell why they are absent in a local build. AFAICT nothing changed in this regard in the meantime and this happens is even the case if I build the logback 1.4.6 release commit locally. So I'm puzzled why this is fine in the released artifacts but isn't for my local builds.

Nevertheless this PR ensures that the imported packages, which are also exported by a logback bundle have a suitable version range.