### PR TITLE
LOGBACK-1730: Remove export of obsolete/removed package 'org.slf4j.impl' in OSGi

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -314,7 +314,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Export-Package>ch.qos.logback.classic*, org.slf4j.impl;version=${slf4j.version}</Export-Package>
+            <Export-Package>ch.qos.logback.classic*</Export-Package>
             <!-- LB-CLASSIC It is necessary to specify the rolling
                  file packages as classes are created via IOC (xml
                  config files). They won't be found by Bnd's analysis


### PR DESCRIPTION
Backport of https://github.com/qos-ch/logback/pull/642 to the 1.3.x branch.
