### PR TITLE
Ensure proper version ranges of re-imported OSGi packages

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -145,6 +145,7 @@
                 Bnd's analysis of java code.
             -->
             <Import-Package>
+              ch.qos.logback.access*;version="${range;[==,+);${maven_version;${project.version}}}",
               ch.qos.logback.core.rolling,
               ch.qos.logback.core.rolling.helper,
               org.apache.catalina.*;version="${tomcat.version}";resolution:=optional,

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -320,6 +320,7 @@
                  config files). They won't be found by Bnd's analysis
                  of java code. -->
             <Import-Package>
+              ch.qos.logback.classic*;version="${range;[==,+);${maven_version;${project.version}}}",
               sun.reflect;resolution:=optional,
               javax.*;resolution:=optional,
               org.xml.*;resolution:=optional,

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -140,8 +140,9 @@
         </executions>
         <configuration>
           <instructions>
-            <Export-Package>ch.qos.logback.core.*</Export-Package>
+            <Export-Package>ch.qos.logback.core*</Export-Package>
             <Import-Package>
+              ch.qos.logback.core*;version="${range;[==,+);${maven_version;${project.version}}}",
               javax.*;resolution:=optional,
               org.xml.*;resolution:=optional,
               org.fusesource.jansi;resolution:=optional,


### PR DESCRIPTION
Back port of https://github.com/qos-ch/logback/pull/647 to the 1.3 branch.

If you prefer the `version_cleanup` macro over `maven_version`, just let me know and I'll adapt this PR accordingly (see https://github.com/qos-ch/logback/pull/647#issuecomment-1501071781).