### PR TITLE
Use preferred 'version_cleanup' BND macro instead of 'maven_version'

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -145,7 +145,7 @@
                 Bnd's analysis of java code.
             -->
             <Import-Package>
-              ch.qos.logback.access*;version="${range;[==,+);${maven_version;${project.version}}}",
+              ch.qos.logback.access*;version="${range;[==,+);${version_cleanup;${project.version}}}",
               ch.qos.logback.core.rolling,
               ch.qos.logback.core.rolling.helper,
               org.apache.catalina.*;version="${tomcat.version}";resolution:=optional,

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -320,7 +320,7 @@
                  config files). They won't be found by Bnd's analysis
                  of java code. -->
             <Import-Package>
-              ch.qos.logback.classic*;version="${range;[==,+);${maven_version;${project.version}}}",
+              ch.qos.logback.classic*;version="${range;[==,+);${version_cleanup;${project.version}}}",
               sun.reflect;resolution:=optional,
               javax.*;resolution:=optional,
               org.xml.*;resolution:=optional,

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -142,7 +142,7 @@
           <instructions>
             <Export-Package>ch.qos.logback.core*</Export-Package>
             <Import-Package>
-              ch.qos.logback.core*;version="${range;[==,+);${maven_version;${project.version}}}",
+              ch.qos.logback.core*;version="${range;[==,+);${version_cleanup;${project.version}}}",
               javax.*;resolution:=optional,
               org.xml.*;resolution:=optional,
               org.fusesource.jansi;resolution:=optional,


### PR DESCRIPTION
Backport of https://github.com/qos-ch/logback/pull/650 to the 1.3 branch.