### PR TITLE
Add constant to reset text attributes

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/color/ANSIConstants.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/color/ANSIConstants.java
@@ -18,6 +18,7 @@ public class ANSIConstants {
     public final static String ESC_START = "\033[";
     public final static String ESC_END = "m";
     public final static String BOLD = "1;";
+    public final static String RESET = "0;";
 
     public final static String BLACK_FG = "30";
     public final static String RED_FG = "31";

--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/color/ForegroundCompositeConverterBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/color/ForegroundCompositeConverterBase.java
@@ -24,7 +24,7 @@ import static ch.qos.logback.core.pattern.color.ANSIConstants.*;
  */
 abstract public class ForegroundCompositeConverterBase<E> extends CompositeConverter<E> {
 
-    final private static String SET_DEFAULT_COLOR = ESC_START + "0;" + DEFAULT_FG + ESC_END;
+    final private static String SET_DEFAULT_COLOR = ESC_START + RESET + DEFAULT_FG + ESC_END;
 
     @Override
     protected String transform(E event, String in) {


### PR DESCRIPTION
Since the class `ANSIConstants` is missing the constant to reset text attributes (used for instance by `ForegroundCompositeConverterBase`), it could be useful to add it.
