### PR TITLE
Additional ways to specify contextselector updated2

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
@@ -28,6 +28,9 @@ public class ClassicConstants {
             + "comp/env/logback/configuration-resource";
     public static final String JNDI_CONTEXT_NAME = JNDI_JAVA_NAMESPACE + "comp/env/logback/context-name";
 
+    /** JNDI name of custom contextSelector classname, if used */
+    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = "java:comp/env/logback/contextSelector";
+
     /**
      * The maximum number of package separators (dots) that abbreviation algorithms
      * can handle. Class or logger names with more separators will have their first

--- a/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/ClassicConstants.java
@@ -29,7 +29,7 @@ public class ClassicConstants {
     public static final String JNDI_CONTEXT_NAME = JNDI_JAVA_NAMESPACE + "comp/env/logback/context-name";
 
     /** JNDI name of custom contextSelector classname, if used */
-    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = "java:comp/env/logback/contextSelector";
+    public static final String JNDI_LOGBACK_CONTEXT_SELECTOR = JNDI_JAVA_NAMESPACE + "comp/env/logback/contextSelector";
 
     /**
      * The maximum number of package separators (dots) that abbreviation algorithms


### PR DESCRIPTION
Additional ways to specify contextselector (updated)

* via system environment - especially usefor for JEE contexts
* via JNDI lookup (note this is NOT the same as using the ContextJNDISelector)

Signed-off-by: Richard Sand <rsand@idfconnect.com>