### PR TITLE
Compressor.gzCompress() log msg fix

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
@@ -176,7 +176,7 @@ public class Compressor extends ContextAwareBase {
                 gzos.write(inbuf, 0, n);
             }
 
-            addInfo("Done ZIP compressing [" + file2gz + "] as [" + gzedFile + "]");
+            addInfo("Done GZ compressing [" + file2gz + "] as [" + gzedFile + "]");
         } catch (Exception e) {
             addStatus(new ErrorStatus(
                     "Error occurred while compressing [" + nameOfFile2gz + "] into [" + nameOfgzedFile + "].", this,


### PR DESCRIPTION
Fixed 'done' message for GZ compression - was copied from ZIP method ('Done ZIP' => 'Done GZ').
No JIRA issue, I hope this is small enough to be accepted without one :)