### PR TITLE
StatusPrinter timestamp format changed to include date

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/StatusPrinter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/StatusPrinter.java
@@ -28,7 +28,7 @@ public class StatusPrinter {
 
     private static PrintStream ps = System.out;
 
-    static CachingDateFormatter cachingDateFormat = new CachingDateFormatter("HH:mm:ss,SSS");
+    static CachingDateFormatter cachingDateFormat = new CachingDateFormatter("yyyy-MM-dd HH:mm:ss,SSS");
 
     public static void setPrintStream(PrintStream printStream) {
         ps = printStream;


### PR DESCRIPTION
No JIRA issue, hopefully small enough to be accepted without one.
Added date information to timestamp format pattern in StatusPrinter for easier navigation in multi-day status log files.