### PR TITLE
Flaky Test Fix

### DIFF
--- a/logback-classic-blackbox/src/test/java/ch/qos/logback/classic/blackbox/net/SMTPAppender_GreenTest.java
+++ b/logback-classic-blackbox/src/test/java/ch/qos/logback/classic/blackbox/net/SMTPAppender_GreenTest.java
@@ -151,6 +151,9 @@ public class SMTPAppender_GreenTest {
         int expectedEmailCount = 1;
         // wait for the server to receive the messages
         waitForServerToReceiveEmails(expectedEmailCount);
+        while (!ch.qos.logback.core.net.SMTPAppenderBase.getExecutionStatus()) {
+            Thread.yield();
+        }
         MimeMessage[] mma = greenMailServer.getReceivedMessages();
         assertNotNull(mma);
         assertEquals(expectedEmailCount, mma.length);
@@ -304,6 +307,7 @@ public class SMTPAppender_GreenTest {
 
     @Test
     public void testCustomEvaluator() throws Exception {
+        ch.qos.logback.core.net.SMTPAppenderBase.reset();
         startSMTPServer(NO_SSL);
         configure(BlackboxClassicTestConstants.JORAN_INPUT_PREFIX + "smtp/customEvaluator.xml");
 

--- a/logback-core/src/main/java/ch/qos/logback/core/net/SMTPAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SMTPAppenderBase.java
@@ -70,6 +70,7 @@ public abstract class SMTPAppenderBase<E> extends AppenderBase<E> {
     protected Layout<E> subjectLayout;
     protected Layout<E> layout;
 
+    public static volatile boolean hasExecuted;
     private List<PatternLayoutBase<E>> toPatternLayoutList = new ArrayList<PatternLayoutBase<E>>();
     private String from;
     private String subjectStr = null;
@@ -650,6 +651,14 @@ public abstract class SMTPAppenderBase<E> extends AppenderBase<E> {
         this.sessionViaJNDI = sessionViaJNDI;
     }
 
+    public static boolean getExecutionStatus() {
+        return hasExecuted;
+    }
+
+    public static void reset() {
+        hasExecuted = false;
+    }
+
     /**
      * Set the character set encoding of the outgoing email messages. The default
      * encoding is "UTF-8" which usually works well for most purposes.
@@ -680,6 +689,7 @@ public abstract class SMTPAppenderBase<E> extends AppenderBase<E> {
 
         public void run() {
             sendBuffer(cyclicBuffer, e);
+            hasExecuted = true;
         }
     }
 }


### PR DESCRIPTION
### Why are the changes needed?

I observe the following failure when running this test (ch.qos.logback.classic.blackbox.net.SMTPAppender_GreenTest.testCustomEvaluator)  due to the slow execution of logback-core/src/main/java/ch/qos/logback/core/net/SMTPAppenderBase.java#L682. When SMTPAppenderBase.java#682 is not executed quick enough, the test method (testCustomEvaluator) tries to execute the assertion given at Line#156, but it then fails. While it may be possible to fix this flaky test by increasing the waiting time in the test-code, but I believe such a fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. Hence, I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the code location that needs to be executed before the test should proceed to check assertions (logback-core/src/main/java/ch/qos/logback/core/net/SMTPAppenderBase.java#682). so I introduce one variable in this test class that is only there to provide some synchronization. Basically, until this statement is executed, I force the thread that the test runs to wait before it proceeds to the assertions.
 
### Why are the changes needed?

 ch.qos.logback.classic.blackbox.net.SMTPAppender_GreenTest.testCustomEvaluator  Time elapsed: 6.163 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <1> but was: <0> 
    at org.junit.jupiter.api@5.9.1/org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
    at org.junit.jupiter.api@5.9.1/org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
    at org.junit.jupiter.api@5.9.1/org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
    at org.junit.jupiter.api@5.9.1/org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
    at org.junit.jupiter.api@5.9.1/org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
    at org.junit.jupiter.api@5.9.1/org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:528)
    at logback.classic.blackbox/ch.qos.logback.classic.blackbox.net.SMTPAppender_GreenTest.verifyAndExtractMimeMultipart(SMTPAppender_GreenTest.java:157)
    at logback.classic.blackbox/ch.qos.logback.classic.blackbox.net.SMTPAppender_GreenTest.testCustomEvaluator(SMTPAppender_GreenTest.java:316)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    at org.junit.platform.engine@1.9.1/org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    at org.junit.platform.engine@1.9.1/org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
    at org.junit.platform.engine@1.9.1/org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    at org.junit.platform.engine@1.9.1/org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)

### How was this patch tested?

I run this test more than 1000 times and the test always passes.

