### PR TITLE
Use `DefaultJoranConfigurator` instead of copy/pasting `configureByResource`

### DIFF
--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
@@ -155,28 +155,28 @@ public class ContextInitializerTest {
         assertTrue(sll.size() == 1, sll.size() + " should be 1");
     }
 
-        @Test
-        public void shouldConfigureFromXmlFile() throws MalformedURLException, JoranException {
-            assertNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
+    @Test
+    public void shouldConfigureFromXmlFile() throws MalformedURLException, JoranException {
+        assertNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
 
-            URL configurationFileUrl = Loader.getResource("BOO_logback-test.xml",
-                    Thread.currentThread().getContextClassLoader());
-            configureByResource(configurationFileUrl);
+        URL configurationFileUrl = Loader.getResource("BOO_logback-test.xml",
+                Thread.currentThread().getContextClassLoader());
+        configureByResource(configurationFileUrl);
 
-            assertNotNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
-        }
+        assertNotNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
+    }
 
-    //    @Test
-    //    public void shouldConfigureFromGroovyScript() throws MalformedURLException, JoranException {
-    //        LoggerContext loggerContext = new LoggerContext();
-    //        ContextInitializer initializer = new ContextInitializer(loggerContext);
-    //        assertNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
-    //
-    //        URL configurationFileUrl = Loader.getResource("test.groovy", Thread.currentThread().getContextClassLoader());
-    //        initializer.configureByResource(configurationFileUrl);
-    //
-    //        assertNotNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
-    //    }
+//    @Test
+//    public void shouldConfigureFromGroovyScript() throws MalformedURLException, JoranException {
+//        LoggerContext loggerContext = new LoggerContext();
+//        ContextInitializer initializer = new ContextInitializer(loggerContext);
+//        assertNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
+//
+//        URL configurationFileUrl = Loader.getResource("test.groovy", Thread.currentThread().getContextClassLoader());
+//        initializer.configureByResource(configurationFileUrl);
+//
+//        assertNotNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
+//    }
 
     private  void configureByResource(URL url) throws JoranException {
         if (url == null) {

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
@@ -15,7 +15,6 @@ import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.ClassicTestConstants;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
@@ -161,7 +160,9 @@ public class ContextInitializerTest {
 
         URL configurationFileUrl = Loader.getResource("BOO_logback-test.xml",
                 Thread.currentThread().getContextClassLoader());
-        configureByResource(configurationFileUrl);
+        DefaultJoranConfigurator joranConfigurator = new DefaultJoranConfigurator();
+        joranConfigurator.setContext(loggerContext);
+        joranConfigurator.configureByResource(configurationFileUrl);
 
         assertNotNull(loggerContext.getObject(CoreConstants.SAFE_JORAN_CONFIGURATION));
     }
@@ -178,25 +179,13 @@ public class ContextInitializerTest {
 //        assertNotNull(loggerContext.getObject(CoreConstants.CONFIGURATION_WATCH_LIST));
 //    }
 
-    private  void configureByResource(URL url) throws JoranException {
-        if (url == null) {
-            throw new IllegalArgumentException("URL argument cannot be null");
-        }
-        final String urlString = url.toString();
-        if (urlString.endsWith("xml")) {
-            JoranConfigurator configurator = new JoranConfigurator();
-            configurator.setContext(loggerContext);
-            configurator.doConfigure(url);
-        } else {
-            throw new LogbackException("Unexpected filename extension of file [" + url + "]. Should be .xml");
-        }
-    }
-
     @Test
     public void shouldThrowExceptionIfUnexpectedConfigurationFileExtension() throws JoranException {
         URL configurationFileUrl = Loader.getResource("README.txt", Thread.currentThread().getContextClassLoader());
         try {
-            this.configureByResource(configurationFileUrl);
+            DefaultJoranConfigurator joranConfigurator = new DefaultJoranConfigurator();
+            joranConfigurator.setContext(loggerContext);
+            joranConfigurator.configureByResource(configurationFileUrl);
             fail("Should throw LogbackException");
         } catch (LogbackException expectedException) {
             // pass


### PR DESCRIPTION
In 4b06e062488e4cb87f22be6ae96e4d7d6350ed6b `ContextInitializer#configureByResource` got removed and to fix the tests that method was just copy/pasted.
However `DefaultJoranConfigurator`  contains a identical method, so why not just use that one instead of introducing duplicated code?
https://github.com/qos-ch/logback/blob/d8a4bdaf021b1d644551150d60ed53df4fde7c1d/logback-classic/src/main/java/ch/qos/logback/classic/util/DefaultJoranConfigurator.java#L60-L73

(The diff of this PR is a bit messed up because formatting was messed up in 4b06e062488e4cb87f22be6ae96e4d7d6350ed6b, so just look at the second commit of this PR)