### PR TITLE
let appender class be interpolated

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/AppenderAction.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/AppenderAction.java
@@ -20,7 +20,7 @@ public class AppenderAction extends BaseModelAction {
     protected Model buildCurrentModel(SaxEventInterpretationContext interpretationContext, String name,
             Attributes attributes) {
         AppenderModel appenderModel = new AppenderModel();
-        appenderModel.setClassName(attributes.getValue(CLASS_ATTRIBUTE));
+        appenderModel.setClassName(interpretationContext.subst(attributes.getValue(CLASS_ATTRIBUTE)));
         appenderModel.setName(attributes.getValue(NAME_ATTRIBUTE));
         return appenderModel;
     }


### PR DESCRIPTION
Nearly everything else is allowed to be substituted, including layout class, level but not the appender class, which is not convenient in container apps. 
Say, depending on the env variable, the logs should be sent into different receivers, preserving the same complex layout. 
While it can be achieved using conditional constructors, it wouldn't be convenient due to the absence of "layout-red" or "encoder-ref" functionality. 