### PR TITLE
use defaultCharset instead of failing on invalid file.encoding

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ConfigurationWatchList.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/spi/ConfigurationWatchList.java
@@ -16,8 +16,10 @@ package ch.qos.logback.core.joran.spi;
 import ch.qos.logback.core.spi.ContextAwareBase;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,11 +92,16 @@ public class ConfigurationWatchList extends ContextAwareBase {
         // SENTINEL);
     }
 
-    @SuppressWarnings("deprecation")
     File convertToFile(URL url) {
         String protocol = url.getProtocol();
         if ("file".equals(protocol)) {
-            return new File(URLDecoder.decode(url.getFile()));
+            try  {
+                return new File(URLDecoder.decode(url.getFile(), Charset.defaultCharset().name()));
+            } catch (UnsupportedEncodingException e) {
+                // This can't (?) happen, and if it did, we would not see this message
+                addInfo("Invalid defaultCharset encoding");
+                return null;
+            }
         } else {
             addInfo("URL [" + url + "] is not of type file");
             return null;


### PR DESCRIPTION
Possible fix for #777 

If not supporting Java 8 the try/catch is unnessecary as one can use `URLDecoder.decode(String, Charset)`.
This change would be in line with the recent [JDK change](https://bugs.openjdk.org/browse/JDK-8317246) to always use the default charset for decode.

