### PR TITLE
Add message

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -304,6 +304,9 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
                 } catch (InterruptedException e1) {
                     // exit if interrupted
                     break;
+                } catch (Exception e) {
+                    addError("This is an unknown error exit. ");
+                    break;
                 }
             }
 

--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -305,7 +305,7 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
                     // exit if interrupted
                     break;
                 } catch (Exception e) {
-                    addError("This is an unknown error exit. ");
+                    addError("This is an unknown error , exit. ");
                     break;
                 }
             }


### PR DESCRIPTION
If the worker thread exits due to other errors and is not aware of them, and logs are added to help the user troubleshoot the issue