### PR TITLE
add error message

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -304,6 +304,9 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
                 } catch (InterruptedException e1) {
                     // exit if interrupted
                     break;
+                } catch (Exception e) {
+                    addError("This is an unknown error exit. ");
+                    break;
                 }
             }
 


### PR DESCRIPTION
If the worker thread exits due to other errors and is not aware of them, and logs are added to help the user troubleshoot the issue