### PR TITLE
fixes #803 PatternLayoutBase custom converter classloading in OSGi

### DIFF
--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -60,6 +60,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter-params.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>

--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/parser/Parser.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/parser/Parser.java
@@ -13,9 +13,11 @@
  */
 package ch.qos.logback.core.pattern.parser;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.Converter;
@@ -81,7 +83,21 @@ public class Parser<E> extends ContextAwareBase {
      * @return
      */
     public Converter<E> compile(final Node top, Map<String, String> converterMap) {
-        Compiler<E> compiler = new Compiler<E>(top, converterMap);
+        return compile(top, converterMap, Collections.emptyMap());
+    }
+
+    /**
+     * When the parsing step is done, the Node list can be transformed into a
+     * converter chain.
+     *
+     * @param top
+     * @param converterMap
+     * @param converterSupplierMap
+     * @return
+     */
+    public Converter<E> compile(final Node top, Map<String, String> converterMap,
+            Map<String, Supplier<Converter<E>>> converterSupplierMap) {
+        Compiler<E> compiler = new Compiler<E>(top, converterMap, converterSupplierMap);
         compiler.setContext(context);
         // compiler.setStatusManager(statusManager);
         return compiler.compile();


### PR DESCRIPTION
This is the proposed changes to resolve issue #803

This is an alternate way to declare the PatternLayoutBase defaultConverterMap and instanceConverterMap values in a way that works with the OSGi classloading restrictions.

These changes should preserve backward compatibility with code that defines the converter map using the original technique

I also updated the tests in an attempt to confirm it works as expected.

Please review and merge if you agree with the proposed changes.