### PR TITLE
Update out-of-date reference website

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/encoder/JsonEncoder.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/encoder/JsonEncoder.java
@@ -37,7 +37,7 @@ import static ch.qos.logback.core.model.ModelConstants.NULL_STR;
 /**
  *
  *
- * http://ndjson.org/ https://datatracker.ietf.org/doc/html/rfc8259
+ * https://jsonlines.org/ https://datatracker.ietf.org/doc/html/rfc8259
  */
 public class JsonEncoder extends EncoderBase<ILoggingEvent> {
     static final boolean DO_NOT_ADD_QUOTE_KEY = false;


### PR DESCRIPTION
The ndjson domain has expired and now shows Korean gambling advertisements.

ndjson is roughly the same as jsonlines (the difference being that ndjson allows empty lines, something that logback does not need)