### PR TITLE
Remove logback-access from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
     <module>logback-core-blackbox</module>
     <module>logback-classic</module>
     <module>logback-classic-blackbox</module>
-    <module>logback-access</module>
     <module>logback-examples</module>
   </modules>
 


### PR DESCRIPTION
The module has been removed in a past release, the presence of the submodule definition made the repo not build