### PR TITLE
fix writing the header for RollingFileAppender

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/OutputStreamAppender.java
@@ -174,6 +174,8 @@ public class OutputStreamAppender<E> extends UnsynchronizedAppenderBase<E> {
             closeOutputStream();
             this.outputStream = outputStream;
 
+            // after opening we have to output the header
+            encoderInit();
         } finally {
             streamWriteLock.unlock();
         }


### PR DESCRIPTION
this fixes issue #857

`encoderInit` will write the header once the `OutputStreamAppender` is started. Since the outputStream is set before starting, the other `encoderInit` inside the `start`-method is still needed.