### PR TITLE
Add flatten-maven-plugin for consumer pom preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ logback-classic/jdbc:hsqldb:mem:test.log
 logback-classic/jdbc:hsqldb:mem:test.properties
 logback-classic/jdbc:hsqldb:mem:test.script
 cobertura.ser
+.flattened-pom.xml
 # ignore files with pound characters
 \#*\#

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
     <ant.version>1.10.12</ant.version>
     <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <jetty.version>12.0.13</jetty.version>
@@ -431,6 +432,30 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${flatten-maven-plugin.version}</version>
+        <configuration>
+          <flattenMode>oss</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
     </plugins>
   </build>


### PR DESCRIPTION
This PR introduces the **flatten-maven-plugin** to the project for preparing the consumer POM. The plugin is configured to flatten the POM file during the `process-resources` phase and clean up during the `clean` phase. This helps in simplifying and creating a consistent POM structure for consumer projects.

#### Changes made:
1. **Added the Flatten Maven Plugin** to the `pom.xml`:
   - Added the plugin version `1.6.0`.
   - Configured the plugin to flatten the POM during the `process-resources` phase with `flattenMode` set to `oss` which retains popular tags in pom.
   - Set up the plugin's `clean` goal to be executed during the `clean` phase.
2. **Updated `.gitignore`**:
   - Added an entry to ignore the generated `.flattened-pom.xml` file to avoid committing generated artifacts.

#### Motivation:
The goal is to prepare the consumer POM by flattening its structure, removing unnecessary information, and simplifying it for downstream usage, especially in the context of distributing and using the POM as a dependency in other projects. With the addition of this plugin during the build process (and the deployment process), the dependencies with version property are resolved and hardcoded. Also, the child-parent module versioning is hardcoded to prevent any kind of ambiguity for the users.

#### Testing:
- Ensure that the build successfully flattens the POM file during the `process-resources` phase and the same is used when invoking `mvn install` locally.
- Verify that `.flattened-pom.xml` is not tracked in version control.

#### Additional Information:
No new features or bug fixes were introduced, only a configuration to simplify the POM file for easier consumption in other projects.