### PR TITLE
update byte count for FileAppender in prudent mode

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -280,6 +280,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
                 fileChannel.position(size);
             }
             writeByteArrayToOutputStreamWithPossibleFlush(byteArray);
+            updateByteCount(byteArray);
         } catch (IOException e) {
             // Mainly to catch FileLockInterruptionExceptions (see LOGBACK-875)
             resilientFOS.postIOFailure(e);


### PR DESCRIPTION
as that method is overridden but not called in RollingFileAppender otherwise which causes issues in size based rolling policies as the lengthCounter is always 0