### PR TITLE
update byte count for FileAppender in prudent mode

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -280,6 +280,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
                 fileChannel.position(size);
             }
             writeByteArrayToOutputStreamWithPossibleFlush(byteArray);
+            updateByteCount(byteArray);
         } catch (IOException e) {
             // Mainly to catch FileLockInterruptionExceptions (see LOGBACK-875)
             resilientFOS.postIOFailure(e);


### PR DESCRIPTION
As this method is overridden in RollingFileAppender but was not getting called, without this the size based rolling policies don't work as lengthCounter is never updated