### PR TITLE
Include license in JARs

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -144,6 +144,13 @@
       <resource>
         <directory>src/main/resources</directory>
       </resource>
+      <resource>
+        <directory>${project.basedir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+        </includes>
+      </resource>
     </resources>
 
     <plugins>

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -70,6 +70,16 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE.txt</include>
+                </includes>
+            </resource>
+        </resources>
+
         <plugins>
 
             <plugin>


### PR DESCRIPTION
The EPL and LGPL require that the license file be provided to users when the libraries (or their source code) is redistributed. Most open source projects include these files in the JAR files, to make this requirement easy for users to fulfill. This was done previously for the SLF4J JARs (https://github.com/qos-ch/slf4j/pull/335), but has not yet been done for the Logback JARs. This PR adds these license files to the Logback JARs.