### PR TITLE
RFA_FILENAME_PATTERN_COLLISION_MAP --> ConcurrentHashMap

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ContextBase.java
@@ -104,8 +104,8 @@ public class ContextBase implements Context, LifeCycle {
     }
 
     protected void initCollisionMaps() {
-        putObject(FA_FILENAME_COLLISION_MAP, new HashMap<String, String>());
-        putObject(RFA_FILENAME_PATTERN_COLLISION_MAP, new HashMap<String, FileNamePattern>());
+        putObject(FA_FILENAME_COLLISION_MAP, new ConcurrentHashMap<String, String>());
+        putObject(RFA_FILENAME_PATTERN_COLLISION_MAP, new ConcurrentHashMap<String, FileNamePattern>());
     }
 
     @Override


### PR DESCRIPTION
https://github.com/qos-ch/logback/issues/959


ERROR in ch.qos.logback.classic.sift.SiftingAppender[FILE] - Appender [FILE] failed to append. java.util.ConcurrentModificationException at java.util.ConcurrentModificationExceptionat
at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.iava:1597)at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1630)at java.base/java.utiL.HashMap$EntryIterator.next(HashMap.iava:1628) at
at
at ch.qos. Logback.core.rolling.RollingFileAppender.innerCheckForFileNamePatternCollisionInPreviousRFA(RollingFileAppender.java:141)at ch.qos.Logback.core.rolling.RollingFileAppender.checkForCollisionsInPreviousRollingFileAppenders(RollingFileAppender.java:127)at ch.qos.Logback.core.rolling.RollingFileAppender.start(RollingFileAppender.java:65)