### PR TITLE
Add serverAppender parameter to SimpleSocketServer and SocketNode constructors

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/SimpleSocketServer.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/SimpleSocketServer.java
@@ -60,6 +60,9 @@ public class SimpleSocketServer extends Thread {
     // used for testing purposes
     private CountDownLatch latch;
 
+    // Set this appender as the sole appender for the remoteLogger
+    private String serverAppender;
+
     public static void main(String argv[]) throws Exception {
         doMain(SimpleSocketServer.class, argv);
     }
@@ -80,9 +83,14 @@ public class SimpleSocketServer extends Thread {
         sss.start();
     }
 
-    public SimpleSocketServer(LoggerContext lc, int port) {
+    public SimpleSocketServer(LoggerContext lc, int port, String serverAppender) {
         this.lc = lc;
         this.port = port;
+        this.serverAppender = serverAppender;
+    }
+
+    public SimpleSocketServer(LoggerContext lc, int port) {
+        this(lc, port, null);
     }
 
     public void run() {


### PR DESCRIPTION
When using SocketAppender, I needed to aggregate all received logs into a single appender on the server side. Therefore, I added the serverAppender parameter to the constructor of SimpleSocketServer.

This change remains backward compatible with existing usage. The submitted modifications have been tested in my own project.