### PR TITLE
ViewStatusMessagesServlet requires method POST for button 'Clear'

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/status/ViewStatusMessagesServletBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/status/ViewStatusMessagesServletBase.java
@@ -62,7 +62,7 @@ abstract public class ViewStatusMessagesServletBase extends HttpServlet {
         output.append("<input type=\"submit\" name=\"" + SUBMIT + "\" value=\"" + CLEAR + "\">");
         output.append("</form>\r\n");
 
-        if (CLEAR.equalsIgnoreCase(req.getParameter(SUBMIT))) {
+        if ("POST".equals(req.getMethod()) && CLEAR.equalsIgnoreCase(req.getParameter(SUBMIT))) {
             sm.clear();
             sm.add(new InfoStatus("Cleared all status messages", this));
         }


### PR DESCRIPTION
The button 'Clear' has a side-effect and should not work with GET, as GET is considered a Safe Method not taking an action other than retrieval.

https://www.rfc-editor.org/rfc/rfc2616#section-9.1.1

I'd like to restrict users from doing any changes by restricting them to method GET. With that said one might consider this change as a security fix.