### PR TITLE
XMLLayout multithreading fix

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/log4j/XMLLayout.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/log4j/XMLLayout.java
@@ -24,9 +24,8 @@ import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.LayoutBase;
 import ch.qos.logback.core.helpers.Transform;
 
-// Code is based on revision 309623 of org.apache.log4j.xml.XMLLayout dated "Wed
-// Jul 31 09:25:14 2002 UTC" as authored by Ceki Gulcu.
-// See also http://tinyurl.com/dch9mr
+// Code is based on revision 594563f2c1887908955ca6581ae8fb66161396c0 of org.apache.logging.log4j.core.layout.XMLLayout
+// https://github.com/apache/logging-log4j2/blob/594563f2c1887908955ca6581ae8fb66161396c0/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/XMLLayout.java
 
 /**
  * 
@@ -38,9 +37,7 @@ import ch.qos.logback.core.helpers.Transform;
 public class XMLLayout extends LayoutBase<ILoggingEvent> {
 
     private final int DEFAULT_SIZE = 256;
-    private final int UPPER_LIMIT = 2048;
 
-    private StringBuilder buf = new StringBuilder(DEFAULT_SIZE);
     private boolean locationInfo = false;
     private boolean properties = false;
 
@@ -96,13 +93,7 @@ public class XMLLayout extends LayoutBase<ILoggingEvent> {
      */
     public String doLayout(ILoggingEvent event) {
 
-        // Reset working buffer. If the buffer is too large, then we need a new
-        // one in order to avoid the penalty of creating a large array.
-        if (buf.capacity() > UPPER_LIMIT) {
-            buf = new StringBuilder(DEFAULT_SIZE);
-        } else {
-            buf.setLength(0);
-        }
+        StringBuilder buf = new StringBuilder(DEFAULT_SIZE);
 
         // We yield to the \r\n heresy.
 


### PR DESCRIPTION
The XMLLayout has a multithreading bug which was [fixed upstream](https://github.com/apache/logging-log4j2/commit/430a090bf5364f3efa0aa27bee961a2f9f1fe4df#diff-0e590167bc6a61c8caa4f9442f050e70ce690c4446ec98815fcb295ac6237684) already in 2011. This PR backports this patch.

It can result in log output like this:

```
<log4j:event logger="org.apache.nifi.web.security.NiFiAuthenticationFilter"
             timestamp="1760394366906" level="" level="INFOINFO" thread="NiFi Web Server-26">
  <log4j:message>NiFi Web Server-29">
  <log4j:message>NiFi Web Server-22">
  <log4j:message>Authentication Started 10.145.115.175 [&lt;User.Name@example.com&gt;&lt;CN=generated certificate for pod&gt;] GET https://nifi-node-default-0.nifi-node-default-headless.nifi.svc.cluster.local:8443/nifi-api/flow/controller/bulletins</log4j:message>

</log4j:event>

Authentication Started 10.145.115.175 [&lt;User.Name@example.com&gt;&lt;CN=generated certificate for pod&gt;] GET https://nifi-node-default-0.nifi-node-default-headless.nifi.svc.cluster.local:8443/nifi-api/flow/status</log4j:message>

</log4j:event>

<log4j:event logger="org.apache.nifi.web.security.NiFiAuthenticationFilter"
             timestamp="1760394366906" level="" level="INFOINFO" thread="NiFi Web Server-26">
  <log4j:message>NiFi Web Server-29">
  <log4j:message>NiFi Web Server-22">
  <log4j:message>Authentication Started 10.145.115.175 [&lt;User.Name@example.com&gt;&lt;CN=generated certificate for pod&gt;] GET https://nifi-node-default-0.nifi-node-default-headless.nifi.svc.cluster.local:8443/nifi-api/flow/controller/bulletins</log4j:message>

</log4j:event>
```

See for example the `level="INFOINFO"` snippet and the "free standing" text "between" the events 

This has been reported twice to us in the past:

* https://github.com/stackabletech/nifi-operator/issues/856
* https://github.com/stackabletech/issues/issues/491

And it has been reported to Logback as well as [LOGBACK-427](https://jira.qos.ch/browse/LOGBACK-427).


  ## Unrelated / Context

> [!NOTE]
> I'm only adding this here because I found it during my research and maybe it helps someone else at some point. It is unrelated to this PR.

While digging into the bug and backporting this fix I saw that there are lots of other changes upstream already. At some point they moved to an implementation based on Jackson but even before then were a lot of changes. Most notably (based on [revision 594563f2c1887908955ca6581ae8fb66161396c0](https://github.com/apache/logging-log4j2/blob/594563f2c1887908955ca6581ae8fb66161396c0/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/XMLLayout.java), the last commit before the Jackson refactor):

 - **CDATA escaping**: Messages and throwables use `Transform.appendEscapingCDATA()` to prevent CDATA injection attacks where `]]>` sequences in log messages could break XML structure
  - **Improved throwable formatting**: Better handling of nested exceptions (causes) with proper stack trace output using `Throwables.toStringList()` (see also [LOGBACK-328](https://jira.qos.ch/browse/LOGBACK-328))
  - **Complete mode**: Support for outputting well-formed XML documents with XML declaration and root element
  - **Compact mode**: Configurable formatting - either pretty-printed with indentation/newlines or compact with no whitespace
  - **Namespace configuration**: Configurable namespace prefix (default "log4j"), with support for default namespace in complete mode
  - **Marker support**: Output of Log4j markers using `event.getMarker()`/`getParents()`
  - **CamelCase element names**: Changed from lowercase (`<event>`, `<message>`) to CamelCase (`<Event>`, `<Message>`) for consistency
  - **Enhanced content type**: Returns `"text/xml; charset=<charset>"` instead of just `"text/xml"`
  - **Empty logger name handling**: Displays "root" for empty logger names

Some of those are breaking changes which is why I didn't want to clutter this PR. If any of them are of interest let me know.

Also of note: XMLLayout has been removed without replacement in log4j 3.x (not released yet).