### PR TITLE
Prevent `NullPointerException` in `PatternLayoutBase#caterForLegacyConverterMaps`

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/pattern/PatternLayoutBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/pattern/PatternLayoutBase.java
@@ -105,10 +105,11 @@ abstract public class PatternLayoutBase<E> extends LayoutBase<E> {
      * @param effectiveMap
      */
     private void caterForLegacyConverterMaps(Map<String, Supplier<DynamicConverter>> effectiveMap) {
-        Map<String, String> mapFromContext = (Map<String, String>) this.context
+        if (getContext() != null) {
+            Map<String, String> mapFromContext = (Map<String, String>) getContext()
                         .getObject(CoreConstants.PATTERN_RULE_REGISTRY);
-
-        migrateFromStringMapToSupplierMap(mapFromContext, effectiveMap);
+            migrateFromStringMapToSupplierMap(mapFromContext, effectiveMap);
+        }
 
         Map<String, String> defaultConverterMap = getDefaultConverterMap();
         migrateFromStringMapToSupplierMap(defaultConverterMap, effectiveMap);


### PR DESCRIPTION
This PR addresses https://github.com/qos-ch/logback/issues/929 by adding a null check in `PatternLayoutBase#caterForLegacyConverterMaps`.