### PR TITLE
Do not use javax.naming namespace in the catch block, so that Logback can be used without requiring the javax.naming module

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/model/processor/InsertFromJNDIModelHandler.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/model/processor/InsertFromJNDIModelHandler.java
@@ -1,7 +1,5 @@
 package ch.qos.logback.core.model.processor;
 
-import javax.naming.NamingException;
-
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.joran.action.ActionUtil;
 import ch.qos.logback.core.joran.action.ActionUtil.Scope;
@@ -72,7 +70,7 @@ public class InsertFromJNDIModelHandler extends ModelHandlerBase {
                 addInfo("Setting variable [" + asKey + "] to [" + envEntryValue + "] in [" + scope + "] scope");
                 PropertyModelHandlerHelper.setProperty(capc, asKey, envEntryValue, scope);
             }
-        } catch (NamingException e) {
+        } catch (Exception e) {
             addError("Failed to lookup JNDI env-entry [" + envEntryName + "]");
         }
 


### PR DESCRIPTION
Fixes: https://github.com/qos-ch/logback/issues/1003 and https://jira.qos.ch/browse/LOGBACK-1515.

The `InsertFromJNDIModelHandler` is usually created when using Logback, but only used when JNDI is used in the logging configuration. Catching the `javax.naming.NamingException` will automatically resolve the class when the `InsertFromJNDIModelHandler` class is used, throwing an exception when it is not present.

By catching the generic Exception, unless JNDI or SMTP are used, the `javax.naming` module is not required now.

The code is now similar as the `SMPTAppenderBase`, where we catch any generic `Exception` (usually the `NamingException`):

https://github.com/qos-ch/logback/blob/420d67c965b0ef76a084ac37cc45c95d16ffece3/logback-core/src/main/java/ch/qos/logback/core/net/SMTPAppenderBase.java#L141-L151