### PR TITLE
Fix error message formatting in PreconditionValidator

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/PreconditionValidator.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/PreconditionValidator.java
@@ -21,6 +21,8 @@ import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.ContextAwareBase;
 import ch.qos.logback.core.util.OptionHelper;
 
+import java.util.Arrays;
+
 public class PreconditionValidator extends ContextAwareBase {
 
     boolean valid = true;
@@ -78,7 +80,7 @@ public class PreconditionValidator extends ContextAwareBase {
             this.valid = true;
         } else {
             this.valid = false;
-            addError("Element [" + tag + "] should have at least one of [" + names + "] as an attribute, near line "
+            addError("Element [" + tag + "] should have at least one of [" + Arrays.toString(names) + "] as an attribute, near line "
                     + Action.getLineNumber(seic));
         }
         return this;


### PR DESCRIPTION
The current error message shows 

```
ch.qos.logback.core.joran.action.IncludeAction - Element [include] should have at least one of [[Ljava.lang.String;@7f811d00] as an attribute, near line 9 
```

which is not useful to users.