### PR TITLE
Add ScopedMDC

### DIFF
--- a/logback-scoped-mdc/pom.xml
+++ b/logback-scoped-mdc/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-parent</artifactId>
+        <version>1.5.33-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>logback-scoped-mdc</artifactId>
+    <packaging>jar</packaging>
+    <name>Logback Scoped MDC Module</name>
+    <description>ScopedValue-based MDC for virtual threads (Java 25+)</description>
+
+    <properties>
+        <maven.compiler.release>25</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>25</release>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <release>25</release>
+                            <compilerArgs>
+                                <arg>--enable-preview</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/logback-scoped-mdc/src/main/java/ch/qos/logback/classic/scoped/ScopedMDC.java
+++ b/logback-scoped-mdc/src/main/java/ch/qos/logback/classic/scoped/ScopedMDC.java
@@ -1,0 +1,142 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.scoped;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.lang.ScopedValue.CallableOp;
+
+/**
+ * A {@link ScopedValue}-based diagnostic context for use with virtual threads
+ * and structured concurrency. Unlike the traditional MDC which uses
+ * {@link ThreadLocal}, scoped values are automatically inherited by child
+ * threads created via {@link java.util.concurrent.StructuredTaskScope#fork}.
+ *
+ * <p>Usage example:</p>
+ * <pre>
+ * ScopedMDC.put("requestId", "abc-123")
+ *          .put("userId", "user-42")
+ *          .run(() -&gt; {
+ *              logger.info("Processing request");
+ *          });
+ * </pre>
+ *
+ * @since 1.5.33
+ */
+public final class ScopedMDC {
+
+    private static final ScopedValue<Map<String, String>> SCOPED_MDC = ScopedValue.newInstance();
+
+    private ScopedMDC() {
+    }
+
+    /**
+     * Returns the value associated with the given key in the current scoped
+     * context, or {@code null} if no value is bound for that key.
+     *
+     * @param key the key to look up
+     * @return the value, or {@code null}
+     */
+    public static String get(String key) {
+        return getPropertyMap().get(key);
+    }
+
+    /**
+     * Returns an unmodifiable view of the current scoped context map.
+     * Returns an empty map if no scoped context is bound.
+     *
+     * @return the current scoped context map, never {@code null}
+     */
+    public static Map<String, String> getPropertyMap() {
+        return SCOPED_MDC.orElse(Collections.emptyMap());
+    }
+
+    /**
+     * Creates a new {@link Binding} that will include the given key-value pair
+     * merged with any values from the current scope.
+     *
+     * @param key   the key
+     * @param value the value
+     * @return a {@link Binding} to execute code within the new scope
+     */
+    public static Binding put(String key, String value) {
+        Map<String, String> merged = new HashMap<>(getPropertyMap());
+        merged.put(key, value);
+        return new Binding(merged);
+    }
+
+    /**
+     * Creates a new {@link Binding} that will include all entries from the
+     * given map merged with any values from the current scope.
+     *
+     * @param entries the entries to add
+     * @return a {@link Binding} to execute code within the new scope
+     */
+    public static Binding putAll(Map<String, String> entries) {
+        Map<String, String> merged = new HashMap<>(getPropertyMap());
+        merged.putAll(entries);
+        return new Binding(merged);
+    }
+
+    /**
+     * A binding that can be used to execute code within a scoped MDC context.
+     * Additional entries can be chained via {@link #put(String, String)} before
+     * calling {@link #run(Runnable)} or {@link #call(CallableOp)}.
+     */
+    public static final class Binding {
+
+        private final Map<String, String> map;
+
+        Binding(Map<String, String> map) {
+            this.map = Collections.unmodifiableMap(new HashMap<>(map));
+        }
+
+        /**
+         * Adds an additional key-value pair to this binding.
+         *
+         * @param key   the key
+         * @param value the value
+         * @return a new {@link Binding} with the additional entry
+         */
+        public Binding put(String key, String value) {
+            Map<String, String> merged = new HashMap<>(map);
+            merged.put(key, value);
+            return new Binding(merged);
+        }
+
+        /**
+         * Executes the given operation within this scoped MDC context.
+         *
+         * @param op the operation to run
+         */
+        public void run(Runnable op) {
+            ScopedValue.where(SCOPED_MDC, map).run(op);
+        }
+
+        /**
+         * Executes the given operation within this scoped MDC context and
+         * returns its result.
+         *
+         * @param op  the operation to call
+         * @param <R> the result type
+         * @param <X> the exception type
+         * @return the result of the operation
+         * @throws X if the operation throws
+         */
+        public <R, X extends Throwable> R call(CallableOp<R, X> op) throws X {
+            return ScopedValue.where(SCOPED_MDC, map).call(op);
+        }
+    }
+}

--- a/logback-scoped-mdc/src/main/java/ch/qos/logback/classic/scoped/ScopedMDCConverter.java
+++ b/logback-scoped-mdc/src/main/java/ch/qos/logback/classic/scoped/ScopedMDCConverter.java
@@ -1,0 +1,103 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.scoped;
+
+import ch.qos.logback.classic.pattern.ClassicConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+import java.util.Map;
+
+import static ch.qos.logback.core.util.OptionHelper.extractDefaultReplacement;
+
+/**
+ * A pattern converter that reads values from {@link ScopedMDC}.
+ *
+ * <p>Register in logback.xml:</p>
+ * <pre>
+ * &lt;conversionRule conversionWord="scopedContext"
+ *     converterClass="ch.qos.logback.classic.scoped.ScopedMDCConverter" /&gt;
+ * &lt;conversionRule conversionWord="Y"
+ *     converterClass="ch.qos.logback.classic.scoped.ScopedMDCConverter" /&gt;
+ * </pre>
+ *
+ * <p>Then use {@code %scopedContext} or {@code %Y} in patterns.
+ * Use {@code %scopedContext{key}} for a specific key, or
+ * {@code %scopedContext{key:-default}} for a key with a default value.</p>
+ *
+ * <p><b>Note:</b> This converter reads from the thread-current {@link ScopedValue}
+ * binding at format time. It works correctly with synchronous appenders. With
+ * asynchronous appenders, the scoped values will not be available on the
+ * formatting thread.</p>
+ *
+ * @since 1.5.33
+ */
+public class ScopedMDCConverter extends ClassicConverter {
+
+    private String key;
+    private String defaultValue = "";
+
+    @Override
+    public void start() {
+        String[] keyInfo = extractDefaultReplacement(getFirstOption());
+        key = keyInfo[0];
+        if (keyInfo[1] != null) {
+            defaultValue = keyInfo[1];
+        }
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        key = null;
+        super.stop();
+    }
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        Map<String, String> scopedMap = ScopedMDC.getPropertyMap();
+
+        if (scopedMap.isEmpty()) {
+            return defaultValue;
+        }
+
+        if (key == null) {
+            return outputForAllKeys(scopedMap);
+        } else {
+            String value = scopedMap.get(key);
+            if (value != null) {
+                return value;
+            } else {
+                return defaultValue;
+            }
+        }
+    }
+
+    private String outputForAllKeys(Map<String, String> scopedMap) {
+        StringBuilder buf = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : scopedMap.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                buf.append(", ");
+            }
+            buf.append(entry.getKey()).append('=').append(entry.getValue());
+        }
+        return buf.toString();
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/logback-scoped-mdc/src/test/java/ch/qos/logback/classic/scoped/ScopedMDCConverterTest.java
+++ b/logback-scoped-mdc/src/test/java/ch/qos/logback/classic/scoped/ScopedMDCConverterTest.java
@@ -1,0 +1,144 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.scoped;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.classic.util.LogbackMDCAdapter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ScopedMDCConverterTest {
+
+    LoggerContext loggerContext;
+    ScopedMDCConverter converter;
+
+    @BeforeEach
+    public void setUp() {
+        loggerContext = new LoggerContext();
+        loggerContext.setMDCAdapter(new LogbackMDCAdapter());
+        converter = new ScopedMDCConverter();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        converter.stop();
+        converter = null;
+        loggerContext = null;
+    }
+
+    @Test
+    public void convertWithNoScopedContext() {
+        converter.start();
+        ILoggingEvent event = createLoggingEvent();
+        assertEquals("", converter.convert(event));
+    }
+
+    @Test
+    public void convertWithSingleEntry() {
+        converter.start();
+        ScopedMDC.put("key1", "value1").run(() -> {
+            ILoggingEvent event = createLoggingEvent();
+            String result = converter.convert(event);
+            assertEquals("key1=value1", result);
+        });
+    }
+
+    @Test
+    public void convertWithMultipleEntries() {
+        converter.start();
+        ScopedMDC.put("key1", "value1").put("key2", "value2").run(() -> {
+            ILoggingEvent event = createLoggingEvent();
+            String result = converter.convert(event);
+            // Order is not guaranteed, so check both possible orderings
+            boolean isConform = result.matches("key[12]=value[12], key[12]=value[12]");
+            assertTrue(isConform, result + " is not conform");
+        });
+    }
+
+    @Test
+    public void convertWithSpecificKey() {
+        setConverterOptions("key1");
+        converter.start();
+        ScopedMDC.put("key1", "value1").put("key2", "value2").run(() -> {
+            ILoggingEvent event = createLoggingEvent();
+            assertEquals("value1", converter.convert(event));
+        });
+    }
+
+    @Test
+    public void convertWithMissingKeyReturnsEmpty() {
+        setConverterOptions("missing");
+        converter.start();
+        ScopedMDC.put("key1", "value1").run(() -> {
+            ILoggingEvent event = createLoggingEvent();
+            assertEquals("", converter.convert(event));
+        });
+    }
+
+    @Test
+    public void convertWithDefaultValue() {
+        setConverterOptions("missing:-N/A");
+        converter.start();
+        ScopedMDC.put("key1", "value1").run(() -> {
+            ILoggingEvent event = createLoggingEvent();
+            assertEquals("N/A", converter.convert(event));
+        });
+    }
+
+    @Test
+    public void convertWithKeyPresentIgnoresDefault() {
+        setConverterOptions("key1:-fallback");
+        converter.start();
+        ScopedMDC.put("key1", "value1").run(() -> {
+            ILoggingEvent event = createLoggingEvent();
+            assertEquals("value1", converter.convert(event));
+        });
+    }
+
+    @Test
+    public void convertWhenUnboundWithDefaultValue() {
+        setConverterOptions("key1:-fallback");
+        converter.start();
+        ILoggingEvent event = createLoggingEvent();
+        assertEquals("fallback", converter.convert(event));
+    }
+
+    private ILoggingEvent createLoggingEvent() {
+        return new LoggingEvent(
+                this.getClass().getName(),
+                loggerContext.getLogger(Logger.ROOT_LOGGER_NAME),
+                Level.DEBUG,
+                "test message",
+                null,
+                null
+        );
+    }
+
+    private void setConverterOptions(String option) {
+        List<String> options = new ArrayList<>();
+        options.add(option);
+        converter.setOptionList(options);
+    }
+}

--- a/logback-scoped-mdc/src/test/java/ch/qos/logback/classic/scoped/ScopedMDCTest.java
+++ b/logback-scoped-mdc/src/test/java/ch/qos/logback/classic/scoped/ScopedMDCTest.java
@@ -1,0 +1,160 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.scoped;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.StructuredTaskScope;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ScopedMDCTest {
+
+    @Test
+    public void unboundReturnsNullAndEmptyMap() {
+        assertNull(ScopedMDC.get("any"));
+        assertTrue(ScopedMDC.getPropertyMap().isEmpty());
+    }
+
+    @Test
+    public void putAndGetWithinScope() {
+        ScopedMDC.put("key1", "value1").run(() -> {
+            assertEquals("value1", ScopedMDC.get("key1"));
+            assertNull(ScopedMDC.get("missing"));
+        });
+    }
+
+    @Test
+    public void getPropertyMapReturnsAllEntries() {
+        ScopedMDC.put("a", "1").put("b", "2").run(() -> {
+            Map<String, String> map = ScopedMDC.getPropertyMap();
+            assertEquals(2, map.size());
+            assertEquals("1", map.get("a"));
+            assertEquals("2", map.get("b"));
+        });
+    }
+
+    @Test
+    public void nestedScopeInheritsParentValues() {
+        ScopedMDC.put("parent", "pval").run(() -> {
+            ScopedMDC.put("child", "cval").run(() -> {
+                assertEquals("pval", ScopedMDC.get("parent"));
+                assertEquals("cval", ScopedMDC.get("child"));
+            });
+        });
+    }
+
+    @Test
+    public void nestedScopeCanOverrideParentValue() {
+        ScopedMDC.put("key", "original").run(() -> {
+            assertEquals("original", ScopedMDC.get("key"));
+
+            ScopedMDC.put("key", "overridden").run(() -> {
+                assertEquals("overridden", ScopedMDC.get("key"));
+            });
+
+            assertEquals("original", ScopedMDC.get("key"));
+        });
+    }
+
+    @Test
+    public void parentScopeUnaffectedAfterNestedScopeExits() {
+        ScopedMDC.put("parent", "pval").run(() -> {
+            ScopedMDC.put("child", "cval").run(() -> {
+                // child scope active
+            });
+            assertNull(ScopedMDC.get("child"));
+            assertEquals("pval", ScopedMDC.get("parent"));
+        });
+    }
+
+    @Test
+    public void putChainingOnBinding() {
+        ScopedMDC.put("a", "1")
+                 .put("b", "2")
+                 .put("c", "3")
+                 .run(() -> {
+                     assertEquals("1", ScopedMDC.get("a"));
+                     assertEquals("2", ScopedMDC.get("b"));
+                     assertEquals("3", ScopedMDC.get("c"));
+                 });
+    }
+
+    @Test
+    public void putAllMergesWithCurrentScope() {
+        ScopedMDC.put("existing", "val").run(() -> {
+            ScopedMDC.putAll(Map.of("new1", "v1", "new2", "v2")).run(() -> {
+                assertEquals("val", ScopedMDC.get("existing"));
+                assertEquals("v1", ScopedMDC.get("new1"));
+                assertEquals("v2", ScopedMDC.get("new2"));
+            });
+        });
+    }
+
+    @Test
+    public void callReturnsValue() throws Exception {
+        String result = ScopedMDC.put("key", "value").call(() -> {
+            assertEquals("value", ScopedMDC.get("key"));
+            return "result";
+        });
+        assertEquals("result", result);
+    }
+
+    @Test
+    public void callPropagatesException() {
+        assertThrows(IllegalStateException.class, () ->
+            ScopedMDC.put("key", "value").call(() -> {
+                throw new IllegalStateException("test");
+            })
+        );
+    }
+
+    @Test
+    public void scopedValuesNotVisibleOutsideScope() {
+        ScopedMDC.put("key", "value").run(() -> {
+            assertEquals("value", ScopedMDC.get("key"));
+        });
+        assertNull(ScopedMDC.get("key"));
+        assertTrue(ScopedMDC.getPropertyMap().isEmpty());
+    }
+
+    @Test
+    public void propertyMapIsUnmodifiable() {
+        ScopedMDC.put("key", "value").run(() -> {
+            Map<String, String> map = ScopedMDC.getPropertyMap();
+            assertThrows(UnsupportedOperationException.class, () -> map.put("new", "val"));
+        });
+    }
+
+    @Test
+    public void childThreadInheritsScopedValuesViaStructuredTaskScope() throws Exception {
+        AtomicReference<String> captured = new AtomicReference<>();
+
+        ScopedMDC.put("requestId", "abc-123").run(() -> {
+            try (var scope = StructuredTaskScope.open()) {
+                scope.fork(() -> {
+                    captured.set(ScopedMDC.get("requestId"));
+                    return null;
+                });
+                scope.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        assertEquals("abc-123", captured.get());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <module>logback-classic-blackbox</module>
     <module>logback-access</module>
     <module>logback-examples</module>
+    <module>logback-scoped-mdc</module>
   </modules>
 
   <properties>
@@ -190,6 +191,11 @@
             <artifactId>logback-classic-misc</artifactId>
             <version>${project.version}</version>
         </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-scoped-mdc</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
@@ -473,7 +479,7 @@
          <extensions>true</extensions>
          <configuration>
            <publishingServerId>central</publishingServerId>
-           <excludeArtifacts>logback-core-blackbox,logback-classic-misc,logback-classic-blackbox,logback-examples</excludeArtifacts>
+           <excludeArtifacts>logback-core-blackbox,logback-classic-misc,logback-classic-blackbox,logback-examples,logback-scoped-mdc</excludeArtifacts>
          </configuration>
        </plugin>
 


### PR DESCRIPTION
Related to the issue: https://github.com/qos-ch/logback/issues/917

Example usage:
```java
 ScopedMDC.put("requestId", "abc-123")
          .put("userId", "user-42")
          .run(() -> {
              logger.info("Processing request");
          });
```

Alternative considered:
```java
var scopedRequestId = ScopedValue.newInstance<String>();

ScopedMDC.register("requestId", scopedRequestId);

ScopedValue.where(scopedRequestId, "abc-123").run(() -> {
    logger.info("Processing request");
});
```

In the end I decided to go with the first approach since it's more contained. The only limitation is that it requires `String` values.