### PR TITLE
Fix typo in Throwable class name

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/HardenedObjectInputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/HardenedObjectInputStream.java
@@ -53,7 +53,7 @@ public class HardenedObjectInputStream extends ObjectInputStream {
             "java.lang.Number",
             "java.lang.Short",
             "java.lang.String",
-            "java,lang.Throwable",
+            "java.lang.Throwable",
             "java.util.ArrayList",
             "java.util.Collections$EmptyMap",
             "java.util.Collections$UnmodifiableMap",


### PR DESCRIPTION
Hi, I noticed a typo in the `JAVA_CLASSES` whitelist array.

In the current implementation, `Throwable` is written with a comma instead of a period, which prevents `java.lang.Throwable` from being correctly recognized or filtered.

* **Before**: `"java,lang.Throwable"`
* **After**: `"java.lang.Throwable"`

Thank you!
