### PR TITLE
ConsoleAppender: support JLine's org.jline.jansi.AnsiConsole for <withJansi>

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/ConsoleAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ConsoleAppender.java
@@ -48,7 +48,11 @@ public class ConsoleAppender<E> extends OutputStreamAppender<E> {
     protected ConsoleTarget target = ConsoleTarget.SystemOut;
     protected boolean withJansi = false;
 
-    private final static String AnsiConsole_CLASS_NAME = "org.fusesource.jansi.AnsiConsole";
+    // Jansi was migrated from FuseSource (org.fusesource.jansi) to JLine (org.jline.jansi), which
+    // changed the package of AnsiConsole. Probe the JLine coordinates first, then fall back to the
+    // legacy FuseSource ones so that <withJansi> keeps working with both artifacts. See LOGBACK issue 1043.
+    private final static String[] ANSI_CONSOLE_CLASS_NAMES = { "org.jline.jansi.AnsiConsole",
+            "org.fusesource.jansi.AnsiConsole" };
     private final static String JANSI2_OUT_METHOD_NAME = "out";
     private final static String JANSI2_ERR_METHOD_NAME = "err";
     private final static String WRAP_SYSTEM_OUT_METHOD_NAME = "wrapSystemOut";
@@ -114,7 +118,7 @@ public class ConsoleAppender<E> extends OutputStreamAppender<E> {
         try {
             addInfo("Enabling JANSI AnsiPrintStream for the console.");
             ClassLoader classLoader = Loader.getClassLoaderOfObject(context);
-            Class<?> classObj = classLoader.loadClass(AnsiConsole_CLASS_NAME);
+            Class<?> classObj = loadAnsiConsoleClass(classLoader);
 
             Method systemInstallMethod  = classObj.getMethod(SYSTEM_INSTALL_METHOD_NAME);
             if(systemInstallMethod != null) {
@@ -155,6 +159,26 @@ public class ConsoleAppender<E> extends OutputStreamAppender<E> {
             addWarn("Failed to create AnsiPrintStream. Falling back on the default stream.", e);
         }
         return targetStream;
+    }
+
+    /**
+     * Loads the Jansi {@code AnsiConsole} class, probing the candidate class names in
+     * {@link #ANSI_CONSOLE_CLASS_NAMES} order (JLine's {@code org.jline.jansi} first, then the legacy
+     * FuseSource {@code org.fusesource.jansi}). This keeps {@code <withJansi>} working across the Jansi
+     * migration from FuseSource to JLine.
+     *
+     * @throws ClassNotFoundException if none of the candidate classes is available.
+     */
+    Class<?> loadAnsiConsoleClass(ClassLoader classLoader) throws ClassNotFoundException {
+        ClassNotFoundException lastException = null;
+        for (String className : ANSI_CONSOLE_CLASS_NAMES) {
+            try {
+                return classLoader.loadClass(className);
+            } catch (ClassNotFoundException e) {
+                lastException = e;
+            }
+        }
+        throw lastException;
     }
 
     /**

--- a/logback-core/src/test/java/ch/qos/logback/core/ConsoleAppenderJansiClassResolutionTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/ConsoleAppenderJansiClassResolutionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@link ConsoleAppender} probes the JLine Jansi {@code AnsiConsole} class name before
+ * the legacy FuseSource one, so that {@code <withJansi>} keeps working after the Jansi migration from
+ * FuseSource to JLine. See LOGBACK issue 1043.
+ */
+public class ConsoleAppenderJansiClassResolutionTest {
+
+    static final String JLINE = "org.jline.jansi.AnsiConsole";
+    static final String FUSESOURCE = "org.fusesource.jansi.AnsiConsole";
+
+    final ConsoleAppender<Object> ca = new ConsoleAppender<>();
+
+    /**
+     * ClassLoader that resolves only the AnsiConsole class names present in {@code known} (mapping each
+     * to a distinct stand-in class) and reports the others as absent.
+     */
+    private ClassLoader loaderResolving(Map<String, Class<?>> known) {
+        return new ClassLoader(getClass().getClassLoader()) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                Class<?> mapped = known.get(name);
+                if (mapped != null) {
+                    return mapped;
+                }
+                if (JLINE.equals(name) || FUSESOURCE.equals(name)) {
+                    throw new ClassNotFoundException(name);
+                }
+                return super.loadClass(name);
+            }
+        };
+    }
+
+    @Test
+    public void prefersJLineWhenBothArePresent() throws ClassNotFoundException {
+        Map<String, Class<?>> known = new HashMap<>();
+        known.put(JLINE, String.class);
+        known.put(FUSESOURCE, Integer.class);
+        assertEquals(String.class, ca.loadAnsiConsoleClass(loaderResolving(known)));
+    }
+
+    @Test
+    public void fallsBackToFuseSourceWhenJLineIsAbsent() throws ClassNotFoundException {
+        Map<String, Class<?>> known = new HashMap<>();
+        known.put(FUSESOURCE, Integer.class);
+        assertEquals(Integer.class, ca.loadAnsiConsoleClass(loaderResolving(known)));
+    }
+
+    @Test
+    public void throwsWhenNoJansiIsAvailable() {
+        Map<String, Class<?>> none = new HashMap<>();
+        assertThrows(ClassNotFoundException.class, () -> ca.loadAnsiConsoleClass(loaderResolving(none)));
+    }
+}


### PR DESCRIPTION
Fixes #1043

## Root cause
Jansi was migrated from FuseSource (`org.fusesource.jansi`) to JLine (`org.jline.jansi`), which changed the package of `AnsiConsole`. `ConsoleAppender.wrapWithJansi(...)` loaded the FuseSource class name by reflection (`org.fusesource.jansi.AnsiConsole`), so for users who now have only the JLine Jansi artifact on the classpath, `<withJansi>` silently degrades to the plain stream:

```
WARN in ch.qos.logback.core.ConsoleAppender[STDOUT] - Failed to create AnsiPrintStream. Falling back on the default stream.
java.lang.ClassNotFoundException: org.fusesource.jansi.AnsiConsole
```

## Change
- `ConsoleAppender` now probes an ordered list of candidate class names — JLine `org.jline.jansi.AnsiConsole` first, then the legacy FuseSource `org.fusesource.jansi.AnsiConsole` — via a small `loadAnsiConsoleClass(ClassLoader)` helper. JLine repackages the same Jansi 2 API (`out()`/`err()`/`systemInstall()`), so the existing reflective method lookup is unchanged.
- Behavior is unchanged for existing FuseSource users (they hit the fallback candidate).

This matches the approach suggested in the issue thread ("try the new class name and fall back to the old one").

## Tests
- New `ConsoleAppenderJansiClassResolutionTest` (dependency-free, uses a custom `ClassLoader` to simulate each environment): verifies JLine is preferred when both are present, falls back to FuseSource when JLine is absent, and throws `ClassNotFoundException` when neither is available. These fail against the old hard-coded lookup in a JLine-only environment and pass after the change.
- Existing `JansiConsoleAppenderTest` (FuseSource on the classpath) still passes, confirming the legacy path is preserved.

Verification done: built and ran `mvn -pl logback-core test -Dtest=ConsoleAppenderJansiClassResolutionTest` (3 passed) and `mvn -pl logback-core-blackbox test -Dtest=JansiConsoleAppenderTest` (2 passed) on JDK 25 with `--release 17`.

Note: the JPMS `module-info` / OSGi `Import-Package` descriptors still reference `org.fusesource.jansi` only; I kept this PR to the runtime reflective lookup to stay minimal, but happy to add JLine to those optional requirements as a follow-up if desired.