### PR TITLE
Support HALF_DAY periodicity for AM/PM date patterns

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/PeriodicityType.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/PeriodicityType.java
@@ -21,6 +21,7 @@ public enum PeriodicityType {
     // The followed list consists of valid periodicity types in increasing period lengths
     static PeriodicityType[] VALID_ORDERED_LIST = new PeriodicityType[] { TOP_OF_MILLISECOND,
             PeriodicityType.TOP_OF_SECOND, PeriodicityType.TOP_OF_MINUTE, PeriodicityType.TOP_OF_HOUR,
-            PeriodicityType.TOP_OF_DAY, PeriodicityType.TOP_OF_WEEK, PeriodicityType.TOP_OF_MONTH };
+            PeriodicityType.HALF_DAY, PeriodicityType.TOP_OF_DAY, PeriodicityType.TOP_OF_WEEK,
+            PeriodicityType.TOP_OF_MONTH };
 
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
@@ -105,6 +105,10 @@ public class RollingCalendar extends GregorianCalendar {
             // isolated hh or KK
             return !collision(12 * MILLIS_IN_ONE_HOUR);
 
+        case HALF_DAY:
+            // isolated 'a' (AM/PM) without a date component repeats every day
+            return !collision(MILLIS_IN_ONE_DAY);
+
         case TOP_OF_DAY:
             // EE or uu
             if (collision(7 * MILLIS_IN_ONE_DAY))
@@ -198,6 +202,8 @@ public class RollingCalendar extends GregorianCalendar {
             return diff / MILLIS_IN_ONE_MINUTE;
         case TOP_OF_HOUR:
             return diff / MILLIS_IN_ONE_HOUR;
+        case HALF_DAY:
+            return diff / (12 * MILLIS_IN_ONE_HOUR);
         case TOP_OF_DAY:
             return diff / MILLIS_IN_ONE_DAY;
         case TOP_OF_WEEK:
@@ -249,6 +255,15 @@ public class RollingCalendar extends GregorianCalendar {
             cal.set(Calendar.SECOND, 0);
             cal.set(Calendar.MILLISECOND, 0);
             cal.add(Calendar.HOUR_OF_DAY, numPeriods);
+            break;
+
+        case HALF_DAY:
+            // floor to the start of the current half-day (00:00 or 12:00), then advance
+            cal.set(Calendar.HOUR_OF_DAY, cal.get(Calendar.HOUR_OF_DAY) < 12 ? 0 : 12);
+            cal.set(Calendar.MINUTE, 0);
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            cal.add(Calendar.HOUR_OF_DAY, numPeriods * 12);
             break;
 
         case TOP_OF_DAY:

--- a/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/RollingCalendarTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/RollingCalendarTest.java
@@ -81,6 +81,17 @@ public class RollingCalendarTest {
         }
 
         {
+            // 'a' (AM/PM) without a finer time token means twice-a-day roll-over
+            RollingCalendar rc = new RollingCalendar("yyyy-MM-dd-a");
+            assertEquals(PeriodicityType.HALF_DAY, rc.getPeriodicityType());
+        }
+
+        {
+            RollingCalendar rc = new RollingCalendar("yyyy-MM-dd a");
+            assertEquals(PeriodicityType.HALF_DAY, rc.getPeriodicityType());
+        }
+
+        {
             RollingCalendar rc = new RollingCalendar("yyyy-MM-dd");
             assertEquals(PeriodicityType.TOP_OF_DAY, rc.getPeriodicityType());
         }
@@ -132,6 +143,23 @@ public class RollingCalendarTest {
         }
     }
 
+    @Test
+    public void testVaryingNumberOfHalfDailyPeriods() {
+        RollingCalendar rc = new RollingCalendar("yyyy-MM-dd-a");
+        final long MILLIS_IN_HALF_DAY = 12 * 3600 * 1000;
+
+        for (int p = 20; p > -100; p--) {
+            long now = 1223325293589L; // Mon Oct 06 22:34:53 CEST 2008
+            Instant nowInstant = Instant.ofEpochMilli(now);
+            Instant result = rc.getEndOfNextNthPeriod(nowInstant, p);
+            long offset = rc.getTimeZone().getRawOffset() + rc.getTimeZone().getDSTSavings();
+
+            long origin = now - ((now + offset) % (MILLIS_IN_HALF_DAY));
+            long expected = origin + p * MILLIS_IN_HALF_DAY;
+            assertEquals(expected, result.toEpochMilli(), "p=" + p);
+        }
+    }
+
     // Wed Mar 23 23:07:05 CET 2016
     final long WED_2016_03_23_T_230705_CET = 1458770825333L;
 
@@ -143,6 +171,8 @@ public class RollingCalendarTest {
                 WED_2016_03_23_T_230705_CET + 3 * CoreConstants.MILLIS_IN_ONE_MINUTE, 3);
         checkPeriodBarriersCrossed("yyyy-MM-dd'T'HH", WED_2016_03_23_T_230705_CET,
                 WED_2016_03_23_T_230705_CET + 3 * CoreConstants.MILLIS_IN_ONE_HOUR, 3);
+        checkPeriodBarriersCrossed("yyyy-MM-dd-a", WED_2016_03_23_T_230705_CET,
+                WED_2016_03_23_T_230705_CET + 3 * 12 * CoreConstants.MILLIS_IN_ONE_HOUR, 3);
         checkPeriodBarriersCrossed("yyyy-MM-dd", WED_2016_03_23_T_230705_CET,
                 WED_2016_03_23_T_230705_CET + 3 * CoreConstants.MILLIS_IN_ONE_DAY, 3);
     }
@@ -163,6 +193,10 @@ public class RollingCalendarTest {
 
         checkCollisionFreeness("yyyy-MM-dd KK", false);
         checkCollisionFreeness("yyyy-MM-dd KK a", true);
+
+        // half-daily
+        checkCollisionFreeness("yyyy-MM-dd-a", true);
+        checkCollisionFreeness("a", false);
 
         // daily
         checkCollisionFreeness("yyyy-MM-dd", true);


### PR DESCRIPTION
Fixes #976

## Root cause
The `HALF_DAY` periodicity type and its `RollingCalendar.printPeriodicity()` message ("Roll-over at midday and midnight.") have existed since LBCORE-11 (2008), but `HALF_DAY` was **never** added to `PeriodicityType.VALID_ORDERED_LIST`, and `RollingCalendar` has no `HALF_DAY` branch in its switch statements. So `computePeriodicityType()` can never select it: a `TimeBasedRollingPolicy` whose date pattern carries the AM/PM token but no finer time token (e.g. `%d{yyyy-MM-dd-a}`) falls through to `TOP_OF_DAY` and rolls over only at midnight, logging "Roll-over at midnight." instead of rotating at both 00:00 and 12:00.

## Change
- `PeriodicityType`: insert `HALF_DAY` into `VALID_ORDERED_LIST` between `TOP_OF_HOUR` and `TOP_OF_DAY`. Because detection returns the shortest matching period, this only affects patterns that distinguish 00:00 from 12:00 but nothing finer (i.e. the `a` token) — patterns that already match at `TOP_OF_HOUR` or below are unchanged.
- `RollingCalendar.innerGetEndOfNextNthPeriod`: add the `HALF_DAY` case — floor to the current half-day boundary (00:00 or 12:00) and advance in 12h steps, mirroring the existing `TOP_OF_DAY` flooring.
- `RollingCalendar.periodBarriersCrossed`: add `HALF_DAY` (previously it hit the `default` branch and threw `IllegalStateException`).
- `RollingCalendar.isCollisionFree`: add `HALF_DAY` — an isolated `a` without a date component repeats every 24h, so a 1-day collision check flags it.

## Test evidence
Added regression coverage to `RollingCalendarTest` (all pass; each fails on current `master` before the fix):
- `testPeriodicity`: `yyyy-MM-dd-a` and `yyyy-MM-dd a` now resolve to `HALF_DAY` (previously `TOP_OF_DAY`).
- `testVaryingNumberOfHalfDailyPeriods`: `getEndOfNextNthPeriod` advances in exact 12h boundaries across a range of periods.
- `testBarrierCrossingComputation`: 3 half-day barriers over 36h.
- `testCollisionFreenes`: `yyyy-MM-dd-a` is collision-free; isolated `a` is not.

Verification done: `mvn -pl logback-core -am test -Dtest=RollingCalendarTest` → 10/10 pass. Ran the full `ch.qos.logback.core.rolling.*` suite: all rolling tests pass; the only errors are 3 pre-existing `InaccessibleObjectException`s in `RollingFileAppenderTest` (JPMS reflection into `ch.qos.logback.core.appender`), which are unrelated to this change and reproduce identically on a clean `master` checkout when the test JVM is JDK 25.