### PR TITLE
Fail loudly when LayoutWrappingEncoder has no layout (#1046)

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/encoder/LayoutWrappingEncoder.java
@@ -111,6 +111,9 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
     }
 
     public byte[] encode(E event) {
+        if (layout == null) {
+            return null;
+        }
         String txt = layout.doLayout(event);
         return convertToBytes(txt);
     }
@@ -120,6 +123,10 @@ public class LayoutWrappingEncoder<E> extends EncoderBase<E> {
     }
 
     public void start() {
+        if (layout == null) {
+            addError("No layout set for the encoder. This encoder will produce no output. "
+                    + "Please set a layout, or check for an ignored <if>/<then>/<else> block in your configuration.");
+        }
         if (immediateFlush != null) {
             if (parent instanceof OutputStreamAppender) {
                 addWarn("Setting the \"immediateFlush\" property of the enclosing appender to " + immediateFlush);

--- a/logback-core/src/test/java/ch/qos/logback/core/encoder/LayoutWrappingEncoderTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/encoder/LayoutWrappingEncoderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.encoder;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.LayoutBase;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.status.testUtil.StatusChecker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class LayoutWrappingEncoderTest {
+
+    Context context = new ContextBase();
+    StatusChecker statusChecker = new StatusChecker(context);
+    LayoutWrappingEncoder<Object> encoder = new LayoutWrappingEncoder<Object>();
+
+    static class EchoLayout extends LayoutBase<Object> {
+        public String doLayout(Object event) {
+            return String.valueOf(event);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        encoder.setContext(context);
+    }
+
+    // https://github.com/qos-ch/logback/issues/1046
+    // A wrapping encoder left without a layout (e.g. when an <if>/<then>/<else>
+    // block is silently ignored) used to start "successfully" and then throw a
+    // NullPointerException on every logging event, causing silent log loss.
+    @Test
+    public void nullLayoutReportsErrorOnStartAndDoesNotThrowOnEncode() {
+        encoder.start();
+        statusChecker.assertContainsMatch(Status.ERROR, "No layout set for the encoder");
+
+        byte[] result = assertDoesNotThrow(() -> encoder.encode(new Object()));
+        assertNull(result);
+    }
+
+    @Test
+    public void encodesWhenLayoutIsSet() {
+        encoder.setLayout(new EchoLayout());
+        encoder.start();
+        statusChecker.assertIsErrorFree();
+
+        byte[] result = encoder.encode("hello");
+        assertEquals("hello", new String(result));
+    }
+}


### PR DESCRIPTION
Fixes #1046

## Root cause
A `LayoutWrappingEncoder` whose `layout` ends up `null` — which happens when an `<if>/<then>/<else>` block is silently ignored (see the reports in #1046) — used to `start()` "successfully" (`started = true`) and then throw

```
NullPointerException: Cannot invoke "ch.qos.logback.core.Layout.doLayout(Object)" because "this.layout" is null
```

from `encode()` on **every** logging event. The event is dropped, so the appender runs while logging nothing and the only signal is a status warning. As several users noted on the issue, silent log loss is about the worst failure mode for a logging framework.

Notably `headerBytes()` and `footerBytes()` in the same class already guard `if (layout == null) return null;` — `encode()` was the one path that did not, so the class was internally inconsistent.

## Change
- `encode()` returns `null` when `layout == null`, consistent with `headerBytes()`/`footerBytes()` (and `OutputStreamAppender.writeBytes` already treats a `null`/empty byte array as a no-op, so no event spam and no NPE).
- `start()` emits an `ERROR` status when `layout == null`, so the misconfiguration surfaces loudly at startup rather than as silent log loss at runtime.

## Test
Added `LayoutWrappingEncoderTest` in `logback-core`:
- `nullLayoutReportsErrorOnStartAndDoesNotThrowOnEncode` — asserts an `ERROR` status is recorded at `start()` and that `encode()` returns `null` without throwing (fails before this change: NPE + no error status).
- `encodesWhenLayoutIsSet` — confirms the normal path is unaffected (error-free, correct output).

Verification done: (1) searched open/closed PRs for `LayoutWrappingEncoder` and issue #1046 — no in-flight PR (my other open PRs #1050/#1051 are unrelated); (2) no self-claim in the thread; (3) code-focused (`.java` only); (4) grepped master — `start()` still sets `started = true` unconditionally and `encode()` dereferenced `layout` directly; (6) no triage gate (not a spring-projects repo). Built and ran the new test with `mvn -pl logback-core test` on JDK 21 (release target 17): 2 passed, 0 failed.