### PR TITLE
Allow subclasses to use AsyncAppenderBase's put(ILoggingEvent) method

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java
@@ -170,7 +170,7 @@ public class AsyncAppenderBase<E> extends UnsynchronizedAppenderBase<E> implemen
         return (blockingQueue.remainingCapacity() < discardingThreshold);
     }
 
-    private void put(E eventObject) {
+    protected void put(E eventObject) {
         if (neverBlock) {
             blockingQueue.offer(eventObject);
         } else {


### PR DESCRIPTION
Hi, 

I've implemented a [library](https://github.com/entur/cloud-logging/tree/main) with [a 'on-demand' logging feature](https://github.com/entur/cloud-logging/blob/main/guides/web.md#optional-on-demand-logging) which wraps around Logback in order to reduce logging costs for REST-/gRPC-applications running in the cloud. 

It essentially caches log-events in a per-request scope - deciding whether to write the log-events based on various criteria like return HTTP status code, request duration, debug flag and such.

In the heart of this is a subclass of `AsyncAppender`: [LoggingScopeAsyncAppender](https://github.com/entur/cloud-logging/blob/main/appender/src/main/java/no/entur/logging/cloud/appender/scope/LoggingScopeAsyncAppender.java#L15).

While collecting the log-events is easy, writing them depends on using the `put(ILoggingEvent)` method. This method currently has private access in `AsyncAppenderBase`. 

To work around this I've cloned the `AsyncAppenderBase` and `AsyncAppender` classes. This PR changes `put` access to `protected` so that this no longer is necessary. While these classes change very little, I am a bit worried that something might break in the future. 