### PR TITLE
Fix data race on LoggerContext.size (#1038)

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java
@@ -34,6 +34,7 @@ import org.slf4j.spi.MDCAdapter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static ch.qos.logback.core.CoreConstants.EVALUATOR_MAP;
 
@@ -54,7 +55,10 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
     public static final boolean DEFAULT_PACKAGING_DATA = false;
 
     final Logger root;
-    private int size;
+    // loggers are created under per-parent monitors in getLogger(String), so
+    // concurrent creations run under different locks; the shared logger count
+    // must therefore be updated atomically to avoid a data race (see #1038).
+    private final AtomicInteger size = new AtomicInteger();
     private int noAppenderWarning = 0;
     final private List<LoggerContextListener> loggerContextListenerList = new ArrayList<LoggerContextListener>();
 
@@ -81,7 +85,7 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
         this.root.setLevel(Level.DEBUG);
         loggerCache.put(Logger.ROOT_LOGGER_NAME, root);
         initEvaluatorMap();
-        size = 1;
+        size.set(1);
         this.frameworkPackages = new ArrayList<String>();
         // In 1.5.7, the stop() method assumes that at some point the context has been started
         // since earlier versions of logback did not mandate calling the start method
@@ -169,11 +173,11 @@ public class LoggerContext extends ContextBase implements ILoggerFactory, LifeCy
     }
 
     private void incSize() {
-        size++;
+        size.incrementAndGet();
     }
 
     int size() {
-        return size;
+        return size.get();
     }
 
     /**

--- a/logback-classic/src/test/java/ch/qos/logback/classic/LoggerContextTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/LoggerContextTest.java
@@ -19,6 +19,14 @@ import ch.qos.logback.core.status.StatusManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class LoggerContextTest {
@@ -250,6 +258,50 @@ public class LoggerContextTest {
             lc.putProperty("a" + i, "val");
             Thread.yield();
         }
+    }
+
+    // https://github.com/qos-ch/logback/issues/1038
+    // getLogger() creates loggers under the per-parent monitor, so concurrent
+    // creations below distinct parents run under different locks. The internal
+    // logger count must be maintained atomically; otherwise incSize()'s size++
+    // races and increments are lost, leaving size() below the real count.
+    @Test
+    public void concurrentGetLoggerKeepsSizeConsistent() throws InterruptedException {
+        final int threadCount = 16;
+        final int loggersPerThread = 500;
+        // each thread works under its own parent ("t<idx>") so its child
+        // creations hold a distinct monitor, maximising contention on size.
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        final CyclicBarrier start = new CyclicBarrier(threadCount);
+        List<Future<?>> futures = new ArrayList<Future<?>>();
+        for (int t = 0; t < threadCount; t++) {
+            final int idx = t;
+            futures.add(pool.submit(new Runnable() {
+                public void run() {
+                    try {
+                        start.await();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    for (int j = 0; j < loggersPerThread; j++) {
+                        lc.getLogger("t" + idx + ".c" + j);
+                    }
+                }
+            }));
+        }
+        for (Future<?> f : futures) {
+            try {
+                f.get();
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e.getCause());
+            }
+        }
+        pool.shutdown();
+
+        // root + one "t<idx>" parent per thread + all children
+        int expected = 1 + threadCount + threadCount * loggersPerThread;
+        assertEquals(expected, lc.getLoggerList().size());
+        assertEquals(expected, lc.size());
     }
 
 }


### PR DESCRIPTION
Fixes #1038

### Root cause
`LoggerContext.getLogger(String)` creates each new logger under the monitor of its **parent** node (`synchronized (logger)`). Concurrent callers creating loggers below *different* parents therefore hold *different* locks, yet they all update the same counter via `incSize()`, which performed an unsynchronized `size++`. That read-modify-write races, so increments are lost under contention and `size()` reports fewer loggers than actually exist. This is exactly the ThreadSanitizer data race reported in the issue.

### Change
Make the counter an `AtomicInteger` and use `incrementAndGet()` / `get()`, so the count is maintained atomically regardless of which parent monitor a thread happens to hold. No locking is added to the hot path.

### Test evidence
Added `LoggerContextTest#concurrentGetLoggerKeepsSizeConsistent`: 16 threads each create 500 loggers under their own distinct parent (so their `incSize()` calls hold distinct monitors, maximising contention), then the test asserts `size()` matches the real logger count.

- Before the fix the test fails, e.g. `expected: <8017> but was: <7970>` (lost increments).
- After the fix it passes; the full `LoggerContextTest` (17 tests) is green.

Verification done: built and ran `mvn -pl logback-classic -am -Dtest=LoggerContextTest test` on the branch (all pass), and confirmed the new test fails on unpatched `master`.
