### PR TITLE
Detect file collisions in SiftingAppender nested appenders (#1041)

### DIFF
--- a/logback-classic/src/test/input/joran/collision/siftDistinct.xml
+++ b/logback-classic/src/test/input/joran/collision/siftDistinct.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Logback: the reliable, generic, fast and flexible logging framework.
+  ~  Copyright (C) 1999-2025, QOS.ch. All rights reserved.
+  ~
+  ~ This program and the accompanying materials are dual-licensed under
+  ~ either the terms of the Eclipse Public License v1.0 as published by
+  ~ the Eclipse Foundation
+  ~
+  ~     or (per the licensee's choosing)
+  ~
+  ~ under the terms of the GNU Lesser General Public License version 2.1
+  ~ as published by the Free Software Foundation.
+  -->
+
+<!DOCTYPE configuration>
+
+<configuration debug="false">
+
+    <import class="ch.qos.logback.core.FileAppender"/>
+
+    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <discriminator>
+            <Key>userId</Key>
+            <DefaultValue>default</DefaultValue>
+        </discriminator>
+        <sift>
+            <appender name="FILE-${userId}" class="FileAppender">
+                <file>${outputTargetKey}-${userId}.log</file>
+                <encoder>
+                    <pattern>%msg%n</pattern>
+                </encoder>
+            </appender>
+        </sift>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="SIFT"/>
+    </root>
+
+</configuration>

--- a/logback-classic/src/test/input/joran/collision/siftShared.xml
+++ b/logback-classic/src/test/input/joran/collision/siftShared.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Logback: the reliable, generic, fast and flexible logging framework.
+  ~  Copyright (C) 1999-2025, QOS.ch. All rights reserved.
+  ~
+  ~ This program and the accompanying materials are dual-licensed under
+  ~ either the terms of the Eclipse Public License v1.0 as published by
+  ~ the Eclipse Foundation
+  ~
+  ~     or (per the licensee's choosing)
+  ~
+  ~ under the terms of the GNU Lesser General Public License version 2.1
+  ~ as published by the Free Software Foundation.
+  -->
+
+<!DOCTYPE configuration>
+
+<configuration debug="false">
+
+    <import class="ch.qos.logback.core.FileAppender"/>
+
+    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <discriminator>
+            <Key>userId</Key>
+            <DefaultValue>default</DefaultValue>
+        </discriminator>
+        <sift>
+            <appender name="FILE-${userId}" class="FileAppender">
+                <file>${outputTargetKey}</file>
+                <encoder>
+                    <pattern>%msg%n</pattern>
+                </encoder>
+            </appender>
+        </sift>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="SIFT"/>
+    </root>
+
+</configuration>

--- a/logback-classic/src/test/java/ch/qos/logback/classic/joran/FileCollisionAnalyserTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/joran/FileCollisionAnalyserTest.java
@@ -85,6 +85,25 @@ public class FileCollisionAnalyserTest {
         runCollisionTest(configFile, 1, 0, "file", outputTargetVal);
     }
 
+    // see https://github.com/qos-ch/logback/issues/1041
+    @Test
+    public void siftingAppenderSharedFileIsDetected() throws JoranException {
+        String configFile = ClassicTestConstants.JORAN_INPUT_PREFIX + "collision/siftShared.xml";
+        configure(configFile);
+        //statusPrinter2.print(loggerContext);
+        checker.assertContainsMatch(Status.WARN, ".*does not reference the discriminator key \\[userId\\].*");
+    }
+
+    // when the nested appender embeds the discriminator key, each sifted appender resolves
+    // to a distinct file, so no collision warning must be emitted. see #1041
+    @Test
+    public void siftingAppenderDistinctFileIsNotFlagged() throws JoranException {
+        String configFile = ClassicTestConstants.JORAN_INPUT_PREFIX + "collision/siftDistinct.xml";
+        configure(configFile);
+        //statusPrinter2.print(loggerContext);
+        checker.assertMatchCount(".*does not reference the discriminator key.*", 0);
+    }
+
     @Test
     public void testConditionalFileCollision() throws JoranException {
         String configFile = ClassicTestConstants.JORAN_INPUT_PREFIX + "collision/conditionalRepeat.xml";

--- a/logback-core/src/main/java/ch/qos/logback/core/model/processor/FileCollisionAnalyser.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/model/processor/FileCollisionAnalyser.java
@@ -19,9 +19,11 @@ import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.model.AppenderModel;
 import ch.qos.logback.core.model.ImplicitModel;
 import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.SiftModel;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.helper.FileNamePattern;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +53,17 @@ public class FileCollisionAnalyser extends ModelHandlerBase {
         String className = mic.getImport(originalClassName);
 
         String appenderName = appenderModel.getName();
+
+        // A SiftingAppender instantiates its nested appender once per discriminator
+        // value at runtime, so the nested appender escapes the static collision maps
+        // handled below. If its file/fileNamePattern does not reference the
+        // discriminator key, every instance resolves to the same target and their
+        // output silently collides. Detect that at model-analysis time (see #1041).
+        Model siftModel = firstSubModelOfClass(appenderModel, SiftModel.class);
+        if (siftModel != null) {
+            checkSiftingAppenderForCollision(mic, appenderModel, siftModel, appenderName);
+            return;
+        }
 
         if (!fileAppenderOrRollingFileAppender(className)) {
             return;
@@ -123,5 +136,71 @@ public class FileCollisionAnalyser extends ModelHandlerBase {
     private void addErrorForCollision(String optionName, String appenderName, String previousAppenderName, String optionValue) {
         addError(String.format(COLLISION_DETECTED, appenderName));
         addError(String.format(COLLISION_MESSAGE, appenderName, optionName, optionValue, previousAppenderName));
+    }
+
+    static public final String SIFT_COLLISION_MESSAGE = "The nested appender of SiftingAppender [%s] does not reference the discriminator key [%s] in its 'file'/'fileNamePattern'. Every sifted appender will therefore write to the same file [%s] and their output will collide. Consider embedding ${%s} in the file path.";
+
+    /**
+     * Detect the SiftingAppender variant of a file collision: the nested appender is
+     * created once per discriminator value, so unless its file/fileNamePattern embeds a
+     * reference to the discriminator key, all instances resolve to the same target.
+     */
+    private void checkSiftingAppenderForCollision(ModelInterpretationContext mic, AppenderModel appenderModel,
+            Model siftModel, String appenderName) {
+
+        String discriminatorKey = findDiscriminatorKey(appenderModel);
+        if (discriminatorKey == null || discriminatorKey.isEmpty()) {
+            // discriminator key not declared in XML (e.g. a discriminator with a built-in
+            // default key); can't reason about the file pattern, so stay silent.
+            return;
+        }
+
+        Model nestedAppenderModel = firstSubModelOfClass(siftModel, AppenderModel.class);
+        if (nestedAppenderModel == null) {
+            return;
+        }
+
+        List<String> fileValues = new ArrayList<>();
+        collectBodyText(nestedAppenderModel, "file", fileValues);
+        collectBodyText(nestedAppenderModel, "fileNamePattern", fileValues);
+
+        if (fileValues.isEmpty()) {
+            // nested appender writes to no file (e.g. ConsoleAppender); nothing to collide.
+            return;
+        }
+
+        String keyReference = "${" + discriminatorKey;
+        boolean referencesKey = fileValues.stream().anyMatch(v -> v.contains(keyReference));
+        if (!referencesKey) {
+            String resolvedTarget = mic.subst(fileValues.get(0));
+            addWarn(String.format(SIFT_COLLISION_MESSAGE, appenderName, discriminatorKey, resolvedTarget,
+                    discriminatorKey));
+        }
+    }
+
+    private Model firstSubModelOfClass(Model parent, Class<? extends Model> modelClass) {
+        return parent.getSubModels().stream().filter(modelClass::isInstance).findFirst().orElse(null);
+    }
+
+    private String findDiscriminatorKey(AppenderModel appenderModel) {
+        Optional<Model> discriminator = appenderModel.getSubModels().stream()
+                .filter(m -> "discriminator".equalsIgnoreCase(m.getTag())).findFirst();
+        if (!discriminator.isPresent()) {
+            return null;
+        }
+        return discriminator.get().getSubModels().stream().filter(m -> "key".equalsIgnoreCase(m.getTag()))
+                .map(Model::getBodyText).filter(b -> b != null).map(String::trim).findFirst().orElse(null);
+    }
+
+    /**
+     * Collect the raw body text of every {@code <tagName>} element nested (one or two levels
+     * deep) inside the given appender model. Raw text is used on purpose: the discriminator
+     * key is only bound as a substitution property at runtime, so it must be matched textually.
+     */
+    private void collectBodyText(Model appenderModel, String tagName, List<String> out) {
+        Stream<Model> level1 = appenderModel.getSubModels().stream();
+        Stream<Model> level2 = appenderModel.getSubModels().stream().flatMap(child -> child.getSubModels().stream());
+        Stream.concat(level1, level2).filter(m -> tagPredicate(m, tagName)).map(Model::getBodyText)
+                .filter(b -> b != null).forEach(out::add);
     }
 }


### PR DESCRIPTION
Fixes #1041

### Root cause
`FileCollisionAnalyser` runs during the `DEPENDENCY_ANALYSIS` phase and only inspects statically declared `FileAppender`/`RollingFileAppender` models. A `SiftingAppender` instantiates its nested appender once per discriminator value **at runtime**, so the nested appender never passes through the static collision maps. When the nested `file`/`fileNamePattern` does not embed the discriminator key, every sifted instance resolves to the *same* target file and their output silently collides — exactly the case @ceki confirmed and scoped in the issue ("add an analyzer for the case the appender inside SiftingAppender does not make use of the discriminating key").

### Change
When an `AppenderModel` contains a `SiftModel`, the analyser now:
1. resolves the discriminator key from the model tree (`<discriminator><Key>…</Key>`),
2. reads the nested appender's `file`/`fileNamePattern` **raw** body text (raw on purpose — the key is only bound as a substitution property at runtime), and
3. if none of them reference `${<key>}`, emits a warning naming the appender, the discriminator key, and the shared target file.

The check stays silent when the key cannot be determined from the configuration (e.g. a discriminator using a built-in default key) or when the nested appender writes to no file (e.g. a `ConsoleAppender`), to avoid false positives. It is a warning rather than a hard error/skip because the colliding appenders only exist at runtime and cannot be skipped at model-analysis time.

### Change summary
- `FileCollisionAnalyser`: detect the SiftingAppender variant and warn (`SIFT_COLLISION_MESSAGE`).
- New tests + input configs.

### Test evidence
Added to `FileCollisionAnalyserTest`:
- `siftingAppenderSharedFileIsDetected` — nested `<file>` does not reference the discriminator key → warning is emitted (`siftShared.xml`, mirrors the issue's reproduction).
- `siftingAppenderDistinctFileIsNotFlagged` — nested `<file>` embeds `${userId}` → no warning (`siftDistinct.xml`).

Verification done: built `logback-core`, ran `FileCollisionAnalyserTest` (7/7 pass, incl. the 5 pre-existing collision tests) and the full `*Sift*` suite (14 run, 0 failures) — no regressions. JDK 21.

Automated tooling was used to help prepare this change; it has been reviewed and verified by a human.