### PR TITLE
LOGBACK-1019: SyslogOutputStream.close() never closes its DatagramSocket

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/net/SyslogOutputStream.java
@@ -72,6 +72,9 @@ public class SyslogOutputStream extends OutputStream {
     }
 
     public void close() {
+        if (ds != null) {
+            ds.close();
+        }
         address = null;
         ds = null;
     }

--- a/logback-core/src/test/java/ch/qos/logback/core/net/SyslogOutputStreamTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/net/SyslogOutputStreamTest.java
@@ -1,0 +1,61 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.net.DatagramSocket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class SyslogOutputStreamTest {
+
+    /**
+     * close() must release the underlying DatagramSocket instead of merely
+     * dropping the reference. Relying on finalization leaks one UDP socket
+     * file descriptor per appender stop (e.g. on every configuration reload)
+     * and per ResilientSyslogOutputStream recovery cycle.
+     */
+    @Test
+    public void closeReleasesUnderlyingDatagramSocket() throws Exception {
+        SyslogOutputStream sos = new SyslogOutputStream("localhost", SyslogConstants.SYSLOG_PORT);
+        DatagramSocket ds = extractDatagramSocket(sos);
+        assertFalse(ds.isClosed());
+
+        sos.close();
+
+        assertTrue(ds.isClosed(), "close() should close the underlying DatagramSocket");
+    }
+
+    @Test
+    public void writeAndFlushAfterCloseAreHarmless() throws Exception {
+        SyslogOutputStream sos = new SyslogOutputStream("localhost", SyslogConstants.SYSLOG_PORT);
+        sos.close();
+
+        assertDoesNotThrow(() -> {
+            sos.write("hello".getBytes());
+            sos.flush();
+            sos.close(); // close must be idempotent
+        });
+    }
+
+    private DatagramSocket extractDatagramSocket(SyslogOutputStream sos) throws Exception {
+        Field dsField = SyslogOutputStream.class.getDeclaredField("ds");
+        dsField.setAccessible(true);
+        return (DatagramSocket) dsField.get(sos);
+    }
+}


### PR DESCRIPTION
`SyslogOutputStream.close()` nulls the DatagramSocket reference but never calls close() on it, so the FD leaks until GC finalization. one socket per appender stop (e.g. config reload with scan="true") and per ResilientSyslogOutputStream recovery cycle, eventually leading to `SocketException: maximum number of DatagramSockets reached` (see comments on #230).
Same fix as #230 / #349, which have been open for years — but this one includes a regression test (fails on master, passes with the fix).
