### PR TITLE
Warn when condition is nested inside if

### DIFF
--- a/logback-core-blackbox/src/test/blackboxInput/joran/conditional/conditionInsideIf.xml
+++ b/logback-core-blackbox/src/test/blackboxInput/joran/conditional/conditionInsideIf.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<x>
+  <stack name="BEGIN"/>
+  <if>
+    <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
+      <expression>propertyEquals("ki1", "val1")</expression>
+    </condition>
+    <then>
+      <stack name="a"/>
+    </then>
+  </if>
+  <stack name="END"/>
+</x>

--- a/logback-core-blackbox/src/test/java/ch/qos/logback/core/blackbox/joran/conditional/IfThenElseTest.java
+++ b/logback-core-blackbox/src/test/java/ch/qos/logback/core/blackbox/joran/conditional/IfThenElseTest.java
@@ -189,6 +189,15 @@ public class IfThenElseTest {
         simpleConfigurator.doConfigure(CONDITIONAL_DIR_PREFIX + "if0_NoJoran.xml");
         verifyConfig(new String[] { "BEGIN", "b", "END" });
     }
+
+    @Test
+    public void conditionNestedWithinIfProducesWarning() throws JoranException {
+        simpleConfigurator.doConfigure(CONDITIONAL_DIR_PREFIX + "conditionInsideIf.xml");
+        assertTrue(checker.containsMatch(Status.WARN,
+                "The <condition> element must be placed before the <if> element, not inside it."));
+        verifyConfig(new String[] { "BEGIN", "END" });
+    }
+
     // ----------------------------------------------------------------------------------------------------
 
     @Test

--- a/logback-core/src/main/java/ch/qos/logback/core/model/processor/conditional/IfModelHandler.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/model/processor/conditional/IfModelHandler.java
@@ -19,6 +19,7 @@ import ch.qos.logback.core.Context;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.joran.conditional.Condition;
 import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.conditional.ByPropertiesConditionModel;
 import ch.qos.logback.core.model.conditional.IfModel;
 import ch.qos.logback.core.model.conditional.IfModel.BranchState;
 import ch.qos.logback.core.model.processor.ModelHandlerBase;
@@ -63,6 +64,10 @@ public class IfModelHandler extends ModelHandlerBase {
     public void handle(ModelInterpretationContext mic, Model model) throws ModelHandlerException {
         
         ifModel = (IfModel) model;
+        if (ifModel.getSubModels().stream().anyMatch(ByPropertiesConditionModel.class::isInstance)) {
+            addWarn("The <condition> element must be placed before the <if> element, not inside it.");
+        }
+
         mic.pushModel(ifModel);
         Object micTopObject = mic.peekObject();
         String conditionStr = ifModel.getCondition();


### PR DESCRIPTION
A `<condition>` nested inside `<if>` now produces a clear placement warning instead of only the misleading Janino message. The black-box regression confirms the branch remains skipped and the warning identifies the configuration error. Tests: `IfThenElseTest` (19 tests, 2 skipped) and the `logback-core-blackbox` suite (29 tests, 3 skipped) passed. Release note: <p>Warn when a <code>&lt;condition&gt;</code> element is nested inside <code>&lt;if&gt;</code> instead of placed before it. See <a href=https://github.com/qos-ch/logback/issues/1024>#1024</a>.</p> Closes #1024.