### PR TITLE
Do not close console stream on ConsoleAppender.stop

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/ConsoleAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/ConsoleAppender.java
@@ -13,6 +13,7 @@
  */
 package ch.qos.logback.core;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
@@ -22,6 +23,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import ch.qos.logback.core.joran.spi.ConsoleTarget;
+import ch.qos.logback.core.status.ErrorStatus;
 import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.status.WarnStatus;
 import ch.qos.logback.core.util.Loader;
@@ -239,6 +241,28 @@ public class ConsoleAppender<E> extends OutputStreamAppender<E> {
      */
     public void setWithJansi(boolean withJansi) {
         this.withJansi = withJansi;
+    }
+
+    /**
+     * Flush encoder footer and the underlying stream, but do not close it.
+     * <p>
+     * {@link ConsoleAppender} does not own {@code System.out}/{@code System.err}, nor the
+     * process-wide Jansi {@code AnsiPrintStream} returned when {@code withJansi} is enabled.
+     * Closing that stream (Jansi 2 sits on {@link java.io.FileDescriptor#out}) shuts down the
+     * JVM's stdout file descriptor permanently — see LOGBACK-1759 / issue #1063. This mirrors
+     * {@code java.util.logging.ConsoleHandler#close()}, which flushes without closing the console.
+     */
+    @Override
+    protected void closeOutputStream() {
+        if (getOutputStream() != null) {
+            try {
+                // write encoder footer before detaching from the stream
+                encoderClose();
+                getOutputStream().flush();
+            } catch (IOException e) {
+                addStatus(new ErrorStatus("Could not flush output stream for ConsoleAppender.", this, e));
+            }
+        }
     }
 
 }

--- a/logback-core/src/test/java/ch/qos/logback/core/ConsoleAppenderCloseTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/ConsoleAppenderCloseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v2.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core;
+
+import ch.qos.logback.core.encoder.EchoEncoder;
+import ch.qos.logback.core.encoder.NopEncoder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * ConsoleAppender must not close its underlying stream on stop. The console
+ * (and the process-wide Jansi AnsiPrintStream when {@code withJansi=true}) is
+ * not owned by the appender; closing it can shut down the JVM's stdout file
+ * descriptor (see LOGBACK-1759 / issue #1063).
+ *
+ * <p>Unlike {@code ConsoleAppenderTest}, this class does not redirect
+ * {@code System.out}, so it is safe to run under Maven Surefire.
+ */
+public class ConsoleAppenderCloseTest {
+
+    @Test
+    public void stopFlushesButDoesNotCloseUnderlyingStream() {
+        Context context = new ContextBase();
+        ConsoleAppender<Object> ca = new ConsoleAppender<>();
+        ca.setContext(context);
+        ca.setEncoder(new NopEncoder<>());
+        ca.start();
+
+        TrackingOutputStream tracking = new TrackingOutputStream();
+        // Replace ConsoleTarget stream with a tracking stream so we can observe close/flush.
+        ca.setOutputStream(tracking);
+        ca.doAppend(new Object());
+        ca.stop();
+
+        Assertions.assertFalse(tracking.closed.get(), "ConsoleAppender must not close a stream it does not own");
+        Assertions.assertTrue(tracking.flushCount.get() > 0, "ConsoleAppender should flush on stop");
+    }
+
+    @Test
+    public void stopDoesNotCloseStreamInstalledForJansiContract() {
+        // Models the Jansi-2 path: appender holds a stream whose close() is destructive
+        // (AnsiPrintStream closes FileDescriptor.out). We use a tracking stand-in so the
+        // JVM stdout FD is never at risk during the unit test.
+        Context context = new ContextBase();
+        ConsoleAppender<Object> ca = new ConsoleAppender<>();
+        ca.setContext(context);
+        ca.setEncoder(new EchoEncoder<>());
+        ca.start();
+
+        TrackingOutputStream destructiveConsoleStream = new TrackingOutputStream();
+        ca.setOutputStream(destructiveConsoleStream);
+        ca.doAppend("x");
+        ca.stop();
+
+        Assertions.assertFalse(destructiveConsoleStream.closed.get());
+        Assertions.assertTrue(destructiveConsoleStream.flushCount.get() > 0);
+    }
+
+    private static final class TrackingOutputStream extends OutputStream {
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+        private final AtomicInteger flushCount = new AtomicInteger();
+        private final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+        @Override
+        public void write(int b) {
+            buf.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            buf.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            flushCount.incrementAndGet();
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`ConsoleAppender.stop()` inherited `OutputStreamAppender.closeOutputStream()`, which calls `close()` on the appender's stream. That is safe for the default `ConsoleTarget` streams (their `close()` is a no-op), but with `<withJansi>true</withJansi>` Jansi 2 returns a process-wide `AnsiPrintStream` sitting on `FileDescriptor.out`. Closing it permanently shuts down the JVM's stdout FD, so later `System.out` writes and even reconfiguration are lost.

## Fix
Override `closeOutputStream()` in `ConsoleAppender` to write the encoder footer and **flush** only — same contract as `java.util.logging.ConsoleHandler.close()`.

Fixes #1063 (LOGBACK-1759).

## Test plan
- [x] `mvn -pl logback-core test -Dtest=ConsoleAppenderCloseTest` (2/2) — RED before fix (stream closed), GREEN after
- [x] `mvn -pl logback-core,logback-core-blackbox -am test -Dtest=ConsoleAppenderCloseTest,OutputStreamAppenderTest,JlineJansiConsoleAppenderTest,FuseSourceJansiConsoleAppenderTest` (all GREEN)