### PR TITLE
Ignore blank logback.configurationFile system property

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/DefaultJoranConfigurator.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/DefaultJoranConfigurator.java
@@ -100,7 +100,7 @@ public class DefaultJoranConfigurator extends ContextAwareBase implements Config
 
     private URL findConfigFileURLFromSystemProperties(ClassLoader classLoader, boolean updateStatus) {
         String logbackConfigFile = OptionHelper.getSystemProperty(ClassicConstants.CONFIG_FILE_PROPERTY);
-        if (logbackConfigFile != null) {
+        if (!OptionHelper.isNullOrEmptyOrAllSpaces(logbackConfigFile)) {
             URL result = null;
             try {
                 result = new URL(logbackConfigFile);

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/ContextInitializerTest.java
@@ -15,6 +15,7 @@ import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.ClassicTestConstants;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.Configurator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
@@ -91,6 +92,24 @@ public class ContextInitializerTest {
         doAutoConfigFromSystemProperties("autoConfigAsResource.xml");
         // test passing a URL. note the relative path syntax with file:src/test/...
         doAutoConfigFromSystemProperties("file://./" + ClassicTestConstants.INPUT_PREFIX + "autoConfig.xml");
+    }
+
+    @Test
+    public void emptyConfigurationFilePropertyFallsBackToDefaultDiscovery() throws JoranException {
+        doAutoConfigWithBlankConfigurationFileProperty("");
+    }
+
+    @Test
+    public void whitespaceConfigurationFilePropertyFallsBackToDefaultDiscovery() throws JoranException {
+        doAutoConfigWithBlankConfigurationFileProperty("  \t  ");
+    }
+
+    private void doAutoConfigWithBlankConfigurationFileProperty(String propertyValue) throws JoranException {
+        System.setProperty(ClassicConstants.CONFIG_FILE_PROPERTY, propertyValue);
+        DefaultJoranConfigurator configurator = new DefaultJoranConfigurator();
+        configurator.setContext(loggerContext);
+        Configurator.ExecutionStatus status = configurator.configure(loggerContext);
+        assertEquals(Configurator.ExecutionStatus.INVOKE_NEXT_IF_ANY, status);
     }
 
     public void doAutoConfigFromSystemProperties(String val) throws JoranException {


### PR DESCRIPTION
## Summary

- Treat empty or whitespace-only `-Dlogback.configurationFile=` as unset, matching the pattern already used for other system properties (e.g. `logback.statusListenerClass`).
- Allows default config discovery (`logback-test.xml` / `logback.xml`) to proceed instead of failing initialization with `LogbackException`.

Fixes #946

## Root cause

`DefaultJoranConfigurator.findConfigFileURLFromSystemProperties()` checked `logbackConfigFile != null`. When the JVM property is set to `""` (as with `-Dlogback.configurationFile=`), the value is non-null and logback attempts to load it as a config file, which fails.

## Test plan

- [x] `ContextInitializerTest#emptyConfigurationFilePropertyFallsBackToDefaultDiscovery`
- [x] `ContextInitializerTest#whitespaceConfigurationFilePropertyFallsBackToDefaultDiscovery`
- [x] Verified unfixed code throws `LogbackException` on empty property; fixed code returns `INVOKE_NEXT_IF_ANY`

```
JAVA_HOME=/Users/fardanan/Library/Java/JavaVirtualMachines/jdk-21.0.12+8/Contents/Home \
  mvn -pl logback-classic -am test \
  -Dtest=ContextInitializerTest#emptyConfigurationFilePropertyFallsBackToDefaultDiscovery,ContextInitializerTest#whitespaceConfigurationFilePropertyFallsBackToDefaultDiscovery \
  -Dsurefire.failIfNoSpecifiedTests=false
```